### PR TITLE
Rename module and references to evylang

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2,7 +2,7 @@ name: ci/cd
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
         env:
           TERM: vt100
       - run: ./bin/make firebase-deploy
-        if: ${{ github.event_name == 'pull_request' }} # only run on PR, deploy prod/master in release job
+        if: ${{ github.event_name == 'pull_request' }} # only run on PR, deploy prod/main in release job
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [ci]
-    if: ${{ github.event_name == 'push' }} # only run on push to master
+    if: ${{ github.event_name == 'push' }} # only run on push to main
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,8 @@
 brews:
-  - tap:
-      owner: foxygoat
+  - repository:
+      owner: evylang
       name: homebrew-tap
-      branch: master
+      branch: main
 
     commit_author:
       name: goreleaserbot

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 the foxygoat authors
+   Copyright 2023 the evylang authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ release: nexttag ## Tag and release binaries for different OS on GitHub release
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)
 	[ -z "$(CI)" ] || GITHUB_TOKEN=$$(.github/scripts/app_token) || exit 1; \
-	goreleaser release --rm-dist
+	goreleaser release --clean
 
 nexttag:
 	$(eval NEXTTAG := $(shell $(NEXTTAG_CMD)))

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Evy
 
 [![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://evy.dev/discord)
-[![GitHub Build](https://img.shields.io/github/actions/workflow/status/foxygoat/evy/cicd.yaml?style=flat-square&branch=main&logo=github)](https://github.com/foxygoat/evy/actions/workflows/cicd.yaml?query=branch%3Amain)
+[![GitHub Build](https://img.shields.io/github/actions/workflow/status/evylang/evy/cicd.yaml?style=flat-square&branch=main&logo=github)](https://github.com/evylang/evy/actions/workflows/cicd.yaml?query=branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/evylang.dev/evy.svg)](https://pkg.go.dev/evylang.dev/evy)
 
 Evy is a simple programming language, made to learn coding.
@@ -42,7 +42,7 @@ Here is a "hello world" program in Evy
 
 Here are some resources for learning more about Evy:
 
-- [Learn and Practise](https://github.com/foxygoat/evy/wiki): A guided tour that teaches you programming using Evy.
+- [Learn and Practise](https://github.com/evylang/evy/wiki): A guided tour that teaches you programming using Evy.
 - [Syntax by Example](docs/syntax_by_example.md): A collection of examples that illustrate the Evy syntax.
 - [Built-in Documentation](docs/builtins.md): Details on built-in functions and events in Evy.
 - [Language Specification](docs/spec.md): A formal definition of the Evy syntax and language.
@@ -66,9 +66,9 @@ to your path.
 
 Use [Homebrew] to install `evy`.
 
-    brew install foxygoat/tap/evy
+    brew install evylang/tap/evy
 
-[latest release]: https://github.com/foxygoat/evy/releases/latest
+[latest release]: https://github.com/evylang/evy/releases/latest
 [Homebrew]: https://brew.sh/
 
 ## 💻 Development

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://evy.dev/discord)
 [![GitHub Build](https://img.shields.io/github/actions/workflow/status/foxygoat/evy/cicd.yaml?style=flat-square&branch=main&logo=github)](https://github.com/foxygoat/evy/actions/workflows/cicd.yaml?query=branch%3Amain)
-[![Go Reference](https://pkg.go.dev/badge/foxygo.at/evy.svg)](https://pkg.go.dev/foxygo.at/evy)
+[![Go Reference](https://pkg.go.dev/badge/evylang.dev/evy.svg)](https://pkg.go.dev/evylang.dev/evy)
 
 Evy is a simple programming language, made to learn coding.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Evy
 
 [![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://evy.dev/discord)
-[![GitHub Build](https://img.shields.io/github/actions/workflow/status/foxygoat/evy/cicd.yaml?style=flat-square&branch=master&logo=github)](https://github.com/foxygoat/evy/actions/workflows/cicd.yaml?query=branch%3Amaster)
+[![GitHub Build](https://img.shields.io/github/actions/workflow/status/foxygoat/evy/cicd.yaml?style=flat-square&branch=main&logo=github)](https://github.com/foxygoat/evy/actions/workflows/cicd.yaml?query=branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/foxygo.at/evy.svg)](https://pkg.go.dev/foxygo.at/evy)
 
 Evy is a simple programming language, made to learn coding.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Learn programming with Evy
 - Explore the samples on the [Playground] or the [Gallery].
 - Ask questions or discuss Evy in the [Evy community] on Discord.
 
-[Learn and Practise]: https://github.com/foxygoat/evy/wiki
+[Learn and Practise]: https://github.com/evylang/evy/wiki
 [Playground]: https://evy.dev/play
-[Gallery]: https://github.com/foxygoat/evy/wiki/gallery
+[Gallery]: https://github.com/evylang/evy/wiki/gallery
 [Evy community]: https://evy.dev/discord

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1287,7 +1287,7 @@ of type `[]any`.
 x := [1 2 3]
 print "x" (typeof x)
 y:[]any
-// y = [1 2 3] // TODO PR https://github.com/foxygoat/evy/pull/179
+// y = [1 2 3] // TODO PR https://github.com/evylang/evy/pull/179
 print "y" (typeof y)
 // y = x // parse error
 // x = y // parse error

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -19,7 +19,7 @@
       },
       {
         "source": "/docs",
-        "destination": "https://github.com/foxygoat/evy/blob/main/docs/README.md",
+        "destination": "https://github.com/evylang/evy/blob/main/docs/README.md",
         "type": 301
       },
       {

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -19,7 +19,7 @@
       },
       {
         "source": "/docs",
-        "destination": "https://github.com/foxygoat/evy/blob/master/docs/README.md",
+        "destination": "https://github.com/foxygoat/evy/blob/main/docs/README.md",
         "type": 301
       },
       {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module foxygo.at/evy
+module evylang.dev/evy
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@
 //
 //	Run "evy <command> --help" for more information on a command.
 //
-// [built-in functions]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md
+// [built-in functions]: https://github.com/evylang/evy/blob/main/docs/builtins.md
 // [evy.dev/play]: https://evy.dev/play
 package main
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@
 //
 //	Run "evy <command> --help" for more information on a command.
 //
-// [built-in functions]: https://github.com/foxygoat/evy/blob/master/docs/builtins.md
+// [built-in functions]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md
 // [evy.dev/play]: https://evy.dev/play
 package main
 

--- a/main.go
+++ b/main.go
@@ -39,9 +39,9 @@ import (
 	"runtime"
 	"time"
 
-	"foxygo.at/evy/pkg/evaluator"
-	"foxygo.at/evy/pkg/lexer"
-	"foxygo.at/evy/pkg/parser"
+	"evylang.dev/evy/pkg/evaluator"
+	"evylang.dev/evy/pkg/lexer"
+	"evylang.dev/evy/pkg/parser"
 	"github.com/alecthomas/kong"
 )
 

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"foxygo.at/evy/pkg/parser"
+	"evylang.dev/evy/pkg/parser"
 )
 
 type builtin struct {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"math"
 
-	"foxygo.at/evy/pkg/lexer"
-	"foxygo.at/evy/pkg/parser"
+	"evylang.dev/evy/pkg/lexer"
+	"evylang.dev/evy/pkg/parser"
 )
 
 // The Evaluator can return the following sentinel errors:

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -36,7 +36,7 @@ var (
 // ExitError is returned by [Evaluator.Eval] if Evy's [builtin exit]
 // function is called.
 //
-// [builtin exit]: https://github.com/foxygoat/evy/blob/master/docs/builtins.md#exit
+// [builtin exit]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#exit
 type ExitError int
 
 // Error implements the error interface and returns message containing the exit status.
@@ -47,7 +47,7 @@ func (e ExitError) Error() string {
 // PanicError is returned by [Evaluator.Eval] if Evy's [builtin panic]
 // function is called or a runtime error occurs.
 //
-// [builtin panic]: https://github.com/foxygoat/evy/blob/master/docs/builtins.md#panic
+// [builtin panic]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#panic
 type PanicError string
 
 // Error implements the error interface and returns the panic message.
@@ -247,7 +247,7 @@ func (e *Evaluator) eval(node parser.Node) (value, error) {
 //
 // For more details, see the [built-in documentation] on event handlers.
 //
-// [built-in documentation]: https://github.com/foxygoat/evy/blob/master/docs/builtins.md#event-handlers
+// [built-in documentation]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#event-handlers
 func (e *Evaluator) HandleEvent(ev Event) error {
 	eh := e.eventHandlers[ev.Name]
 	if eh == nil {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -36,7 +36,7 @@ var (
 // ExitError is returned by [Evaluator.Eval] if Evy's [builtin exit]
 // function is called.
 //
-// [builtin exit]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#exit
+// [builtin exit]: https://github.com/evylang/evy/blob/main/docs/builtins.md#exit
 type ExitError int
 
 // Error implements the error interface and returns message containing the exit status.
@@ -47,7 +47,7 @@ func (e ExitError) Error() string {
 // PanicError is returned by [Evaluator.Eval] if Evy's [builtin panic]
 // function is called or a runtime error occurs.
 //
-// [builtin panic]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#panic
+// [builtin panic]: https://github.com/evylang/evy/blob/main/docs/builtins.md#panic
 type PanicError string
 
 // Error implements the error interface and returns the panic message.
@@ -247,7 +247,7 @@ func (e *Evaluator) eval(node parser.Node) (value, error) {
 //
 // For more details, see the [built-in documentation] on event handlers.
 //
-// [built-in documentation]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#event-handlers
+// [built-in documentation]: https://github.com/evylang/evy/blob/main/docs/builtins.md#event-handlers
 func (e *Evaluator) HandleEvent(ev Event) error {
 	eh := e.eventHandlers[ev.Name]
 	if eh == nil {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"foxygo.at/evy/pkg/assert"
+	"evylang.dev/evy/pkg/assert"
 )
 
 type testRT struct {

--- a/pkg/evaluator/runtime.go
+++ b/pkg/evaluator/runtime.go
@@ -15,7 +15,7 @@ import (
 // support. For more details on the built-in functions, see the
 // [built-ins documentation].
 //
-// [built-ins documentation]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md
+// [built-ins documentation]: https://github.com/evylang/evy/blob/main/docs/builtins.md
 type Runtime interface {
 	GraphicsRuntime
 	Print(string)
@@ -29,7 +29,7 @@ type Runtime interface {
 // by the graphics built-ins. For more details see the
 // [graphics built-ins] documentation.
 //
-// [graphics built-ins]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#graphics
+// [graphics built-ins]: https://github.com/evylang/evy/blob/main/docs/builtins.md#graphics
 type GraphicsRuntime interface {
 	Move(x, y float64)
 	Line(x, y float64)

--- a/pkg/evaluator/runtime.go
+++ b/pkg/evaluator/runtime.go
@@ -15,7 +15,7 @@ import (
 // support. For more details on the built-in functions, see the
 // [built-ins documentation].
 //
-// [built-ins documentation]: https://github.com/foxygoat/evy/blob/master/docs/builtins.md
+// [built-ins documentation]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md
 type Runtime interface {
 	GraphicsRuntime
 	Print(string)
@@ -29,7 +29,7 @@ type Runtime interface {
 // by the graphics built-ins. For more details see the
 // [graphics built-ins] documentation.
 //
-// [graphics built-ins]: https://github.com/foxygoat/evy/blob/master/docs/builtins.md#graphics
+// [graphics built-ins]: https://github.com/foxygoat/evy/blob/main/docs/builtins.md#graphics
 type GraphicsRuntime interface {
 	Move(x, y float64)
 	Line(x, y float64)

--- a/pkg/evaluator/scope.go
+++ b/pkg/evaluator/scope.go
@@ -1,6 +1,6 @@
 package evaluator
 
-import "foxygo.at/evy/pkg/parser"
+import "evylang.dev/evy/pkg/parser"
 
 type scope struct {
 	values map[string]value

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"foxygo.at/evy/pkg/parser"
+	"evylang.dev/evy/pkg/parser"
 )
 
 type value interface {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -14,8 +14,8 @@
 // Tree(AST), which is a representation of the Evy code's structure.
 // Finally, the [evaluator] walks the AST and executes the program.
 //
-// [parser]: https://pkg.go.dev/foxygo.at/evy/pkg/parser
-// [evaluator]: https://pkg.go.dev/foxygo.at/evy/pkg/evaluator
+// [parser]: https://pkg.go.dev/evylang.dev/evy/pkg/parser
+// [evaluator]: https://pkg.go.dev/evylang.dev/evy/pkg/evaluator
 package lexer
 
 import (

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"foxygo.at/evy/pkg/assert"
+	"evylang.dev/evy/pkg/assert"
 )
 
 func TestSingleToken(t *testing.T) {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"foxygo.at/evy/pkg/lexer"
+	"evylang.dev/evy/pkg/lexer"
 )
 
 // Node represents a node in the AST.

--- a/pkg/parser/doc.go
+++ b/pkg/parser/doc.go
@@ -70,7 +70,7 @@
 //
 // [evaluator]: https://pkg.go.dev/foxygo.at/evy/pkg/evaluator
 // [Abstract Syntax Tree]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
-// [grammar]: https://github.com/foxygoat/evy/blob/master/docs/spec.md#evy-syntax-grammar
-// [language specification]: https://github.com/foxygoat/evy/blob/master/docs/spec.md
+// [grammar]: https://github.com/foxygoat/evy/blob/main/docs/spec.md#evy-syntax-grammar
+// [language specification]: https://github.com/foxygoat/evy/blob/main/docs/spec.md
 // [Pratt parser]: https://en.wikipedia.org/wiki/Operator-precedence_parser#Pratt_parsing
 package parser

--- a/pkg/parser/doc.go
+++ b/pkg/parser/doc.go
@@ -68,7 +68,7 @@
 // This structure closely resembles the [grammar] of the Evy programming
 // language, as defined in the [language specification].
 //
-// [evaluator]: https://pkg.go.dev/foxygo.at/evy/pkg/evaluator
+// [evaluator]: https://pkg.go.dev/evylang.dev/evy/pkg/evaluator
 // [Abstract Syntax Tree]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
 // [grammar]: https://github.com/foxygoat/evy/blob/main/docs/spec.md#evy-syntax-grammar
 // [language specification]: https://github.com/foxygoat/evy/blob/main/docs/spec.md

--- a/pkg/parser/doc.go
+++ b/pkg/parser/doc.go
@@ -70,7 +70,7 @@
 //
 // [evaluator]: https://pkg.go.dev/evylang.dev/evy/pkg/evaluator
 // [Abstract Syntax Tree]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
-// [grammar]: https://github.com/foxygoat/evy/blob/main/docs/spec.md#evy-syntax-grammar
-// [language specification]: https://github.com/foxygoat/evy/blob/main/docs/spec.md
+// [grammar]: https://github.com/evylang/evy/blob/main/docs/spec.md#evy-syntax-grammar
+// [language specification]: https://github.com/evylang/evy/blob/main/docs/spec.md
 // [Pratt parser]: https://en.wikipedia.org/wiki/Operator-precedence_parser#Pratt_parsing
 package parser

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"foxygo.at/evy/pkg/lexer"
+	"evylang.dev/evy/pkg/lexer"
 )
 
 type precedence int

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"foxygo.at/evy/pkg/assert"
+	"evylang.dev/evy/pkg/assert"
 )
 
 func TestParseTopLevelExpression(t *testing.T) {

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"foxygo.at/evy/pkg/assert"
+	"evylang.dev/evy/pkg/assert"
 )
 
 func TestFuncCallStmtFormat(t *testing.T) {

--- a/pkg/parser/multiline_test.go
+++ b/pkg/parser/multiline_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"foxygo.at/evy/pkg/assert"
+	"evylang.dev/evy/pkg/assert"
 )
 
 func TestArrayLiteralMultiline(t *testing.T) {

--- a/pkg/parser/operator.go
+++ b/pkg/parser/operator.go
@@ -1,6 +1,6 @@
 package parser
 
-import "foxygo.at/evy/pkg/lexer"
+import "evylang.dev/evy/pkg/lexer"
 
 // Operator represents the operators used in binary and unary
 // expressions. For example, the OP_ASTERISK operator represents the

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"foxygo.at/evy/pkg/lexer"
+	"evylang.dev/evy/pkg/lexer"
 )
 
 // Builtins holds all predefined, built-in function and event handler

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"foxygo.at/evy/pkg/assert"
+	"evylang.dev/evy/pkg/assert"
 )
 
 func TestParseDecl(t *testing.T) {

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"foxygo.at/evy/pkg/lexer"
+	"evylang.dev/evy/pkg/lexer"
 )
 
 // TypeName represents the enumerable basic types (such as num, string,

--- a/pkg/wasm/exports.go
+++ b/pkg/wasm/exports.go
@@ -2,7 +2,7 @@
 
 package main
 
-import "foxygo.at/evy/pkg/evaluator"
+import "evylang.dev/evy/pkg/evaluator"
 
 // This file contains Go/WASM functions exported to and called by JS.
 

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"foxygo.at/evy/pkg/evaluator"
+	"evylang.dev/evy/pkg/evaluator"
 )
 
 const minSleepDur = time.Millisecond

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"strings"
 
-	"foxygo.at/evy/pkg/evaluator"
-	"foxygo.at/evy/pkg/parser"
+	"evylang.dev/evy/pkg/evaluator"
+	"evylang.dev/evy/pkg/parser"
 )
 
 var (

--- a/scripts/firebase-deploy
+++ b/scripts/firebase-deploy
@@ -77,7 +77,7 @@ post_pr_comment() {
 	pr_num=$(get_pr_num)
 
 	comment_id=$(
-		gh api -H "Accept: application/vnd.github+json" "/repos/foxygoat/evy/issues/${pr_num}/comments" |
+		gh api -H "Accept: application/vnd.github+json" "/repos/evylang/evy/issues/${pr_num}/comments" |
 			jq 'map(select(.body | contains ("<!--- bot:firebase-url --->"))) | .[] .id' |
 			head -n1
 	)
@@ -88,7 +88,7 @@ post_pr_comment() {
 	fi
 	# update comment
 	gh api --method PATCH -H "Accept: application/vnd.github+json" \
-		"/repos/foxygoat/evy/issues/comments/${comment_id}" \
+		"/repos/evylang/evy/issues/comments/${comment_id}" \
 		-f body="${body}"
 }
 


### PR DESCRIPTION
Rename go module and references from `foxygoat` to `evylang`.
There were also a few leftover `master` to `main` renames outstanding.