### PR TITLE
Replace boxygoatbot with evlangbot creds

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -31,8 +31,8 @@ jobs:
           fetch-depth: 0
       - run: ./bin/make release
         env:
-          GITHUB_APP_ID: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
-          GITHUB_APP_PEM: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}
+          GITHUB_APP_ID: ${{ secrets.EVYLANGBOT_GITHUB_APP_ID }}
+          GITHUB_APP_PEM: ${{ secrets.EVYLANGBOT_GITHUB_APP_PEM }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ./bin/make firebase-deploy-prod
         env:


### PR DESCRIPTION
Replace `boxygoatbot` with `evlangbot` credentials so that hopefully we can
release again. 🤞

This is trying to address the following failed CI release job:
https://github.com/evylang/evy/actions/runs/6419265641/job/17428830002