### PR TITLE
frontend: Turn off auto-capitalise on mobile devices

### DIFF
--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -31,9 +31,9 @@ export default class Yace {
   init() {
     this.textarea = document.createElement("textarea")
     this.textarea.spellcheck = false
-    this.textarea.autocorrect = false
-    this.textarea.autocomplete = false
-    this.textarea.autocapitalize = false
+    this.textarea.autocorrect = "off"
+    this.textarea.autocomplete = "off"
+    this.textarea.autocapitalize = "none"
     this.textarea.wrap = "off"
 
     this.highlighted = document.createElement("pre")


### PR DESCRIPTION
Turn off auto-capitalise on mobile devices. The values were incorrectly set to
false rather than `"off"` and `"none"`.
