### PR TITLE
frontend: Fix mobile style and UI buglets

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -520,8 +520,10 @@ button.primary {
   transition: background 0.3s ease-in-out;
   text-decoration: none;
 }
-button:hover:enabled.primary {
-  background: var(--btn-bg-hover);
+@media (hover: hover) {
+  button:hover:enabled.primary {
+    background: var(--btn-bg-hover);
+  }
 }
 
 .run button#run,

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -753,6 +753,7 @@ dialog .err {
 }
 
 #dialog-about main {
+  padding-top: 42px;
   max-height: 100vh;
   overflow: auto;
 }
@@ -768,7 +769,7 @@ dialog .err {
 }
 
 embed {
-  height: min(20vw, 12rem);
+  height: min(50vw, 12rem);
   margin-left: auto;
   margin-right: auto;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,7 +137,7 @@
         </header>
         <main>
           <div class="copy">
-            <input type="text" autofocus value="https://evy.dev/play#asldkjfalsdkjf" />
+            <input type="text" value="https://evy.dev/play#asldkjfalsdkjf" />
             <button type="button">
               <svg width="1.25rem" height="1.25rem">
                 <use href="#icon-copy" />

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -337,8 +337,7 @@ async function initUI() {
   window.addEventListener("hashchange", handleHashChange)
   document.querySelector("#modal-close").onclick = hideModal
   document.querySelector("#share").onclick = share
-  const about = document.querySelector("#dialog-about")
-  document.querySelector("#sidemenu-about").onclick = () => about.showModal()
+  document.querySelector("#sidemenu-about").onclick = showAbout
   document.querySelector("#sidemenu-share").onclick = share
   document.querySelector("#sidemenu-icon-share").onclick = share
   initModal()
@@ -912,6 +911,12 @@ function initDialog() {
     input.value = "Copied!"
     setTimeout(() => (input.value = url), 2000)
   }
+}
+
+function showAbout() {
+  const about = document.querySelector("#dialog-about")
+  hideSidemenu()
+  about.showModal()
 }
 
 // --- UI: Confetti Easter Egg -----------------------------------------

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -989,6 +989,7 @@ async function share() {
   const input = document.querySelector("#dialog-share .copy input")
   input.value = `${baseurl}#content=${encoded}`
   input.setSelectionRange(0, 0)
+  input.blur()
   document.querySelector("#dialog-share").showModal()
 }
 


### PR DESCRIPTION
- Remove autofocus from copy input to avoid virtual keyboard popping up
- Fix size and padding of evy-e in about dialog
- Hide sidebar when showing "About" dialog, to avoid flicker on close
- Fix sticky hover state on run button on mobile