### PR TITLE
parser: Prepare assignability refactor

### DIFF
--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -292,7 +292,7 @@ func (p *parser) parseTypeAssertion(left Node) Node {
 	p.advance() // advance past (
 	t := p.parseType()
 	switch t {
-	case ILLEGAL_TYPE:
+	case nil:
 		msg := fmt.Sprintf("invalid type in type assertion of %q", left.String())
 		p.appendErrorForToken(msg, tok)
 	case ANY_TYPE:

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -426,7 +426,7 @@ func (p *parser) parseArrayLiteral() Node {
 	for i, e := range elements {
 		types[i] = e.Type()
 	}
-	arrayLit.T = &Type{Name: ARRAY, Sub: p.combineTypes(types)}
+	arrayLit.T = &Type{Name: ARRAY, Sub: combineTypes(types)}
 	arrayLit.Elements = elements
 	return arrayLit
 }
@@ -452,25 +452,6 @@ func (p *parser) parseExprWSS() Node {
 	return p.parseExpr(lowestPrec)
 }
 
-func (p *parser) combineTypes(types []*Type) *Type {
-	combinedT := types[0]
-	for _, t := range types[1:] {
-		if combinedT.accepts(t) {
-			continue
-		}
-		if t.accepts(combinedT) {
-			combinedT = t
-			continue
-		}
-		if t.sameComposite(combinedT) {
-			combinedT = &Type{Name: t.Name, Sub: ANY_TYPE}
-			continue
-		}
-		return ANY_TYPE
-	}
-	return combinedT
-}
-
 func (p *parser) parseMapLiteral() Node {
 	p.pushWSS(false)
 	defer p.popWSS()
@@ -492,7 +473,7 @@ func (p *parser) parseMapLiteral() Node {
 	for _, n := range mapLit.Pairs {
 		types = append(types, n.Type())
 	}
-	mapLit.T = &Type{Name: MAP, Sub: p.combineTypes(types)}
+	mapLit.T = &Type{Name: MAP, Sub: combineTypes(types)}
 	return mapLit
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1036,31 +1036,30 @@ func TestEmptyArray(t *testing.T) {
 		`print []+[]`,
 		`print [[]]+[[]]`,
 		`
-for i := range []
-	print i
-end`,
+		for i := range []
+			print i
+		end`,
 
 		`
-arr := []
-for i := range arr
-	print i
-end`,
+		arr := []
+		for i := range arr
+			print i
+		end`,
 		`
-a := []
-b := []+[]
-print a b`,
+		a := []
+		b := []+[]
+		print a b`,
 		`
-func nums n:[]num
-	print n
-end
+		func nums n:[]num
+			print n
+		end
 
-nums []`,
+		nums []`,
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
 		_ = parser.parse()
 		assertNoParseError(t, parser, input)
-
 		assert.Equal(t, NONE_TYPE, UNTYPED_ARRAY.Sub)
 	}
 }

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -1,9 +1,5 @@
 package parser
 
-import (
-	"evylang.dev/evy/pkg/lexer"
-)
-
 // TypeName represents the enumerable basic types (such as num, string,
 // and bool), categories of composite types (such as array and map),
 // the dynamic type (any), and the none type, which is used where no
@@ -14,8 +10,7 @@ type TypeName int
 // The enumerated basic types, categories of composite types, any and
 // none are defined as constants.
 const (
-	ILLEGAL TypeName = iota
-	NUM
+	NUM TypeName = iota
 	STRING
 	BOOL
 	ANY
@@ -30,7 +25,6 @@ const (
 //
 // [interned]: https://en.wikipedia.org/wiki/Interning_(computer_science)
 var (
-	ILLEGAL_TYPE  = &Type{Name: ILLEGAL}
 	NUM_TYPE      = &Type{Name: NUM}
 	BOOL_TYPE     = &Type{Name: BOOL}
 	STRING_TYPE   = &Type{Name: STRING}
@@ -40,30 +34,19 @@ var (
 	UNTYPED_MAP   = &Type{Name: MAP, Sub: NONE_TYPE}
 )
 
-func compositeTypeName(t lexer.TokenType) TypeName {
-	switch t {
-	case lexer.LBRACKET:
-		return ARRAY
-	case lexer.LCURLY:
-		return MAP
-	}
-	return ILLEGAL
-}
-
 type typeNameString struct {
 	name   string
 	format string
 }
 
 var typeNameStrings = map[TypeName]typeNameString{
-	ILLEGAL: {name: "ILLEGAL", format: "ILLEGAL"},
-	NUM:     {name: "num", format: "num"},
-	STRING:  {name: "string", format: "string"},
-	BOOL:    {name: "bool", format: "bool"},
-	ANY:     {name: "any", format: "any"},
-	ARRAY:   {name: "array", format: "[]"},
-	MAP:     {name: "map", format: "{}"},
-	NONE:    {name: "none", format: "none"},
+	NUM:    {name: "num", format: "num"},
+	STRING: {name: "string", format: "string"},
+	BOOL:   {name: "bool", format: "bool"},
+	ANY:    {name: "any", format: "any"},
+	ARRAY:  {name: "array", format: "[]"},
+	MAP:    {name: "map", format: "{}"},
+	NONE:   {name: "none", format: "none"},
 }
 
 func (t TypeName) String() string {
@@ -85,6 +68,9 @@ type Type struct {
 }
 
 func (t *Type) String() string {
+	if t == nil {
+		return "ILLEGAL"
+	}
 	if t.Sub == nil || t == UNTYPED_ARRAY || t == UNTYPED_MAP {
 		return t.Name.String()
 	}
@@ -92,11 +78,14 @@ func (t *Type) String() string {
 }
 
 func (t *Type) accepts(t2 *Type) bool {
+	if t == nil || t2 == nil {
+		return t == t2
+	}
 	if t.acceptsStrict(t2) {
 		return true
 	}
 	n, n2 := t.Name, t2.Name
-	if n == ANY && n2 != ILLEGAL && n2 != NONE {
+	if n == ANY && n2 != NONE {
 		return true
 	}
 	// empty Array of none_type accepted by all arrays.
@@ -112,6 +101,9 @@ func (t *Type) accepts(t2 *Type) bool {
 //	[] + [1]
 //	[1] + []
 func (t *Type) Matches(t2 *Type) bool {
+	if t == nil || t2 == nil {
+		return t == t2
+	}
 	if t == t2 {
 		return true
 	}
@@ -145,10 +137,10 @@ func (t *Type) infer() *Type {
 
 // []any (ARRAY ANY) DOES NOT accept []num (ARRAY NUM).
 func (t *Type) acceptsStrict(t2 *Type) bool {
-	n, n2 := t.Name, t2.Name
-	if n == ILLEGAL || n2 == ILLEGAL {
-		return false
+	if t == nil || t2 == nil {
+		return t == t2
 	}
+	n, n2 := t.Name, t2.Name
 	if n != n2 {
 		return false
 	}

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -67,6 +67,7 @@ type Type struct {
 	Sub  *Type    // e.g.: `[]int` : Type{Name: "array", Sub: &Type{Name: "int"} }
 }
 
+// String returns a string representation of the Type.
 func (t *Type) String() string {
 	if t == nil {
 		return "ILLEGAL"

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -175,3 +175,22 @@ func (t *Type) sameComposite(t2 *Type) bool {
 	}
 	return false
 }
+
+func combineTypes(types []*Type) *Type {
+	combinedT := types[0]
+	for _, t := range types[1:] {
+		if combinedT.accepts(t) {
+			continue
+		}
+		if t.accepts(combinedT) {
+			combinedT = t
+			continue
+		}
+		if t.sameComposite(combinedT) {
+			combinedT = &Type{Name: t.Name, Sub: ANY_TYPE}
+			continue
+		}
+		return ANY_TYPE
+	}
+	return combinedT
+}

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -166,16 +166,6 @@ func (t *Type) acceptsStrict(t2 *Type) bool {
 	return t.Sub.acceptsStrict(t2.Sub)
 }
 
-func (t *Type) sameComposite(t2 *Type) bool {
-	if t.Name == ARRAY && t2.Name == ARRAY {
-		return true
-	}
-	if t.Name == MAP && t2.Name == MAP {
-		return true
-	}
-	return false
-}
-
 func combineTypes(types []*Type) *Type {
 	combinedT := types[0]
 	for _, t := range types[1:] {
@@ -186,7 +176,7 @@ func combineTypes(types []*Type) *Type {
 			combinedT = t
 			continue
 		}
-		if t.sameComposite(combinedT) {
+		if (t.Name == ARRAY || t.Name == MAP) && t.Name == combinedT.Name {
 			combinedT = &Type{Name: t.Name, Sub: ANY_TYPE}
 			continue
 		}


### PR DESCRIPTION
In yet another attempt to wrangle the complexities around assignability, shave
off a bunch of preparatory commits:

- Pre pare pkg/parser/types.go refactor by 
  * moving `combineTypes` into it
  * removing `sameComposite` in favour of inlining
- Add a missing godoc comment in parser
- Fix whitespace in tests