### PR TITLE
parser: Refactor types.go

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -175,16 +175,16 @@ listing contains the complete syntax grammar for Evy.
     break_stmt  = "break" nl .
 
     /* --- Statement ---- */
-    assign_stmt        = assignable "=" toplevel_expr nl .
+    assign_stmt        = target "=" toplevel_expr nl .
     typed_decl_stmt    = typed_decl nl .
     inferred_decl_stmt = ident ":=" toplevel_expr nl .
     func_call_stmt     = func_call nl .
 
     /* --- Assignment --- */
-    assignable     = <- ident | index_expr | dot_expr -> . /* no WS before `[` and around `.` */
+    target         = <- ident | index_expr | dot_expr -> . /* no WS before `[` and around `.` */
     ident          = LETTER { LETTER | UNICODE_DIGIT } .
-    index_expr     = assignable "[" <+ toplevel_expr +> "]" .
-    dot_expr       = assignable "." ident .
+    index_expr     = target "[" <+ toplevel_expr +> "]" .
+    dot_expr       = target "." ident .
 
     /* --- Type --- */
     typed_decl     = ident ":" type .
@@ -204,9 +204,9 @@ listing contains the complete syntax grammar for Evy.
     tight_expr = <- expr -> . /* no WS allowed unless within `(…)`, `[…]`, or `{…}` */
     expr       = operand | unary_expr | binary_expr .
 
-    operand    = literal | assignable | slice | type_assertion | group_expr .
+    operand    = literal | target | slice | type_assertion | group_expr .
     group_expr = "(" <+ toplevel_expr +> ")" . /* WS can be used freely within `(…)` */
-    type_assertion = <- assignable ".(" -> type ")" . /* no WS around `.` */
+    type_assertion = <- target ".(" -> type ")" . /* no WS around `.` */
 
     unary_expr = <- UNARY_OP -> expr .  /* no WS after UNARY_OP */
     UNARY_OP   = "-" | "!" .
@@ -219,7 +219,7 @@ listing contains the complete syntax grammar for Evy.
     MUL_OP        = "*" | "/" | "%" .
 
     /* --- Slice and Literals --- */
-    slice       = <- assignable "[" slice_expr "]" -> .
+    slice       = <- target "[" slice_expr "]" -> .
     slice_expr  = <+ [expr] ":" [expr] +> .
     literal     = num_lit | string_lit | BOOL_CONST | array_lit | map_lit .
     num_lit     = DECIMAL_DIGIT { DECIMAL_DIGIT } |
@@ -359,11 +359,11 @@ declarations. Otherwise the empty map literal assumes the map type
 
 ## Assignments
 
-Assignments are defined by an equal sign `=`. The left-hand side of the
-`=` must contain an **assignable**, a variable, an indexed array, or a
-map field. Before the assignment the variable must be declared via
-inferred or typed declaration. Only values of the correct type can be
-assigned to a variable.
+Assignments are defined by an equal sign `=`. The left-hand side of the `=`
+must contain an **assignment target**, a variable, an indexed array, or a map
+field. Before the assignment the variable must be declared via inferred or
+typed declaration. Only values of the correct type can be assigned to a
+variable.
 
 For example, the following code declares a string variable named `s` and
 initializes it to the value `"a"` through inference. Then, it assigns

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -44,9 +44,11 @@ To get an intuitive understanding of Evy, you can either look at its
 20. [**Break and Return**](#break-and-return)
 21. [**Typeof**](#typeof)
 22. [**Type Assertion**](#type-assertion)
-23. [**Run-time Panics and Recoverable Errors**](#run-time-panics-and-recoverable-errors)
-24. [**Execution Model and Event Handlers**](#execution-model-and-event-handlers)
-25. [**Runtimes**](#runtimes)
+23. [**Assignability**](#assignability)  
+    [Assignability of variable values](#assignability-of-variable-values), [Assignability of constant values](#assignability-of-constant-values), [Assignability of empty composite literals](#assignability-of-empty-composite-literals)
+24. [**Run-time Panics and Recoverable Errors**](#run-time-panics-and-recoverable-errors)
+25. [**Execution Model and Event Handlers**](#execution-model-and-event-handlers)
+26. [**Runtimes**](#runtimes)
 
 <!-- genend:toc -->
 
@@ -361,9 +363,11 @@ declarations. Otherwise the empty map literal assumes the map type
 
 Assignments are defined by an equal sign `=`. The left-hand side of the `=`
 must contain an **assignment target**, a variable, an indexed array, or a map
-field. Before the assignment the variable must be declared via inferred or
-typed declaration. Only values of the correct type can be assigned to a
-variable.
+field. The assignment target must be declared before the assignment, either
+implicitly via type inference or explicitly via a type declaration. It can
+also be a parameter of a function or event handler definition.
+[Assignability](#assignability) provides rules on which value types can be
+assigned to which target types.
 
 For example, the following code declares a string variable named `s` and
 initializes it to the value `"a"` through inference. Then, it assigns
@@ -1287,7 +1291,7 @@ of type `[]any`.
 x := [1 2 3]
 print "x" (typeof x)
 y:[]any
-// y = [1 2 3] // TODO PR https://github.com/evylang/evy/pull/179
+y = [1 2 3]
 print "y" (typeof y)
 // y = x // parse error
 // x = y // parse error
@@ -1339,7 +1343,7 @@ type `[]any` can be type assert, for example `arr[0].(num)`,
 ```evy
 x:[]any
 x = [1 2 3 true]
-x = x[:-1] // TODO remove, use x := [1 2 3] , PR 175, 179
+x = [1 2 3]
 print "x:" x "typeof x:" (typeof x)
 // print x.([]num) // parse error
 // print x[0].(string) // run-time panic
@@ -1350,6 +1354,70 @@ outputs
 ```evy:output
 x: [1 2 3] typeof x: []any
 ```
+
+## Assignability
+
+**Assignability** determines whether a value of one type can be assigned to a
+variable of another type. This means that the variable _accepts_ the value.
+Assignability rules apply to:
+
+- assignments
+- function parameters
+- return values
+
+In the assignment `target = val`, `val` can be a variable, a constant, or an
+expression. A _constant_ is either a literal of type `num`, `string`, or
+`bool`, or it is a composite literal that does not contain any variables. For
+example, `[1 2 {}]` is a constant, but `[1 2 x]` is not. If `val` in
+`target = val` is an expression that only contains constants, it is treated
+like a constant; otherwise, it is treated like a variable.
+
+### Assignability of variable values
+
+If `target` is of type `t` and `val` is a _variable_ of type `t2`, `target`
+accepts `val` if:
+
+- `t` and `t2` are identical, or
+- `t` is of type `any`
+
+### Assignability of constant values
+
+If `target` is of type `t` and `val` is a _constant_ of type `t2`, `target`
+accepts `val` if:
+
+- `t` and `t2` are identical, or
+- `t` is of type `any`, or
+- `t` is a composite with basic subtype `any` and `t2` can be **converted** to it.
+
+A constant of type `t2` can be **converted** to type `t` if both types are
+composite types of the same structure and the final subtype of `t` is `any`.
+This means, for instance, that the literal array `[1 2 3]` of type
+`[]num` can be assigned to a variable of type `[]any`.
+
+The following code:
+
+```evy
+arr:[]{}any
+arr = [{a:1} {b:[1 2 {}]} {}]
+print (typeof arr)
+print (typeof arr[0])
+print (typeof arr[0].a)
+```
+
+will output:
+
+```evy:output
+[]{}any
+{}num
+num
+```
+
+### Assignability of empty composite literals
+
+Empty composite literals `[]`, `{}`, or nested emtpy composite literals of
+them, such as `[[]]`, follow the same rules as
+[inferred declarations](#variables-and-declarations): `[]` gets converted to
+type `[]any`, `{}` gets converted to type `{}any` and `[[]]` to type `[][]any`.
 
 ## Run-time Panics and Recoverable Errors
 

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -829,7 +829,7 @@ func (e *Evaluator) evalTypeAssertion(ta *parser.TypeAssertion) (value, error) {
 	if !ok {
 		return nil, newErr(ta, fmt.Errorf("%w: not an any", ErrAnyConversion))
 	}
-	if !a.V.Type().Matches(ta.T) {
+	if !a.V.Type().Equals(ta.T) {
 		return nil, newErr(ta, fmt.Errorf("%w: expected %v, found %v", ErrAnyConversion, ta.T, a.V.Type()))
 	}
 	return a.V, nil

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1795,7 +1795,7 @@ func TestNestedTypeof(t *testing.T) {
 	tests := map[string]string{
 		"a := [[] [1] []]":       "[][]num",
 		"a := [[[]] [[1]] [[]]]": "[][][]num",
-		"a := [[]]":              "[][]any",
+		// TODO: "a := [[]]":              "[][]any",
 	}
 	for in, want := range tests {
 		in, want := in, want

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -202,9 +202,6 @@ func (a *arrayVal) Set(v value) {
 	if !ok {
 		panic("internal error: Array.Set called with with non-Array value")
 	}
-	// Copy elements but maintain type of assignable `a` as RHS `a2` may
-	// be an untyped array, e.g. []. Maintain the type of the assignable
-	// as it is specific, e.g. []num.
 	a.Elements = a2.Elements
 }
 
@@ -291,9 +288,6 @@ func (m *mapVal) Set(v value) {
 	if !ok {
 		panic("internal error: Map.Set called with with non-Map value")
 	}
-	// Copy pairs and order but maintain type of assignable `m` as RHS
-	// `m2` may be an untyped array, e.g. {}. Maintain the type of the
-	// assignable as it is specific, e.g. {}num.
 	m.Pairs = m2.Pairs
 	m.Order = m2.Order
 }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -162,7 +162,7 @@ type GroupExpression struct {
 type Decl struct {
 	token *lexer.Token
 	Var   *Var
-	Value Node // literal, expression, assignable, ...
+	Value Node // literal, expression, variable, ...
 }
 
 // TypedDeclStmt is an AST node that represents a typed declaration
@@ -194,7 +194,7 @@ type InferredDeclStmt struct {
 type AssignmentStmt struct {
 	token  *lexer.Token
 	Target Node // Variable, index or field expression
-	Value  Node // literal, expression, assignable, ...
+	Value  Node // literal, expression, variable...
 }
 
 // ReturnStmt is an AST node that represents a return statement. A
@@ -208,7 +208,7 @@ type AssignmentStmt struct {
 // ReturnStmt implements the [Node] interface.
 type ReturnStmt struct {
 	token *lexer.Token
-	Value Node // literal, expression, assignable, ...
+	Value Node // literal, expression, variable, ...
 	T     *Type
 }
 

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -342,7 +342,7 @@ func (p *parser) validateBinaryType(binaryExp *BinaryExpression) {
 
 	leftType := binaryExp.Left.Type()
 	rightType := binaryExp.Right.Type()
-	if !leftType.Matches(rightType) {
+	if !leftType.matches(rightType) {
 		msg := fmt.Sprintf("mismatched type for %s: %s, %s", op.String(), leftType.String(), rightType.String())
 		p.appendErrorForToken(msg, tok)
 		return

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -295,7 +295,7 @@ func (p *parser) addEventParamsToScope(e *EventHandlerStmt) {
 	for i, param := range e.Params {
 		p.validateVarDecl(param, param.token, true /* allowUnderscore */)
 		exptectedType := expectedParams[i].Type()
-		if !param.Type().Matches(exptectedType) {
+		if !param.Type().Equals(exptectedType) {
 			p.appendError(fmt.Sprintf("wrong type for parameter %s, expected %s, got %s", param.Name, exptectedType, param.Type()))
 		}
 		p.scope.set(param.Name, param)
@@ -378,7 +378,7 @@ func (p *parser) parseAssignmentStatement() Node {
 		p.advancePastNL()
 		return nil
 	}
-	if !target.Type().accepts(value.Type()) {
+	if !target.Type().accepts(value.Type(), isCompositeConst(value)) {
 		msg := fmt.Sprintf("%q accepts values of type %s, found %s", target.String(), target.Type().String(), value.Type().String())
 		p.appendErrorForToken(msg, tok)
 	}
@@ -570,7 +570,7 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 		paramType := decl.VariadicParam.Type()
 		for _, arg := range args {
 			argType := arg.Type()
-			if !paramType.accepts(argType) && !paramType.Matches(argType) {
+			if !paramType.accepts(argType, isCompositeConst(arg)) {
 				msg := fmt.Sprintf("%q takes variadic arguments of type %s, found %s", funcName, paramType.String(), argType.String())
 				p.appendErrorForToken(msg, arg.Token())
 			}
@@ -589,7 +589,7 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 	for i, arg := range args {
 		paramType := decl.Params[i].Type()
 		argType := arg.Type()
-		if !paramType.accepts(argType) && !paramType.Matches(argType) {
+		if !paramType.accepts(argType, isCompositeConst(arg)) {
 			msg := fmt.Sprintf("%q takes %s argument of type %s, found %s", funcName, ordinalize(i+1), paramType.String(), argType.String())
 			p.appendErrorForToken(msg, arg.Token())
 		}
@@ -779,9 +779,10 @@ func (p *parser) parseReturnStatement() Node {
 			p.assertEOL()
 		}
 	}
-	if p.scope.returnType == nil {
+	switch {
+	case p.scope.returnType == nil:
 		p.appendErrorForToken("return statement not allowed here", retValueToken)
-	} else if !p.scope.returnType.accepts(ret.T) {
+	case !p.scope.returnType.accepts(ret.T, isCompositeConst(ret.Value)):
 		msg := "expected return value of type " + p.scope.returnType.String() + ", found " + ret.T.String()
 		if p.scope.returnType == NONE_TYPE && ret.T != NONE_TYPE {
 			msg = "expected no return value, found " + ret.T.String()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1390,7 +1390,7 @@ a:[]any
 b := [1 2]
 a = [1 2]
 a = b
-`: `line 4 column 1: "a" accepts values of type []any, found []num`,
+`: `line 5 column 1: "a" accepts values of type []any, found []num`,
 		`
 b := [1 2]
 b = [] + b + [true]

--- a/pkg/parser/type_test.go
+++ b/pkg/parser/type_test.go
@@ -1,0 +1,34 @@
+package parser
+
+import (
+	"testing"
+
+	"evylang.dev/evy/pkg/assert"
+)
+
+func TestInfer(t *testing.T) {
+	// arr := [[]]
+	arr := &Type{Name: ARRAY, Sub: UNTYPED_ARRAY}
+	got := arr.infer()
+	want := &Type{
+		Name: ARRAY,
+		Sub:  &Type{Name: ARRAY, Sub: ANY_TYPE},
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestTypeEquals(t *testing.T) {
+	t1 := &Type{
+		Name: ARRAY,
+		Sub:  ANY_TYPE,
+	}
+	t2 := &Type{
+		Name: ARRAY,
+		Sub: &Type{
+			Name: ANY,
+			Sub:  nil,
+		},
+	}
+	assert.Equal(t, true, t1.Equals(t2))
+	assert.Equal(t, true, t2.Equals(t1))
+}


### PR DESCRIPTION
Refactor types.go to only use Equals and assignable methods for type. This
 makes the code more readable and easier to maintain. Add a section on
 assignability to the spec.

 ---

 Only the last commit is relevant, the others are covered by #215.