### PR TITLE
parser: Refactor UNTYPED_ARRY and UNTYPED_MAP names

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -225,7 +225,7 @@ func sprintf(s string, vals []value) string {
 var joinDecl = &parser.FuncDefStmt{
 	Name: "join",
 	Params: []*parser.Var{
-		{Name: "arr", T: parser.UNTYPED_ARRAY},
+		{Name: "arr", T: parser.GENERIC_ARRAY},
 		{Name: "sep", T: parser.STRING_TYPE},
 	},
 	ReturnType: parser.STRING_TYPE,
@@ -464,7 +464,7 @@ func lenFunc(_ *scope, args []value) (value, error) {
 var hasDecl = &parser.FuncDefStmt{
 	Name: "has",
 	Params: []*parser.Var{
-		{Name: "m", T: parser.UNTYPED_MAP},
+		{Name: "m", T: parser.GENERIC_MAP},
 		{Name: "key", T: parser.STRING_TYPE},
 	},
 	ReturnType: parser.BOOL_TYPE,
@@ -480,7 +480,7 @@ func hasFunc(_ *scope, args []value) (value, error) {
 var delDecl = &parser.FuncDefStmt{
 	Name: "del",
 	Params: []*parser.Var{
-		{Name: "m", T: parser.UNTYPED_MAP},
+		{Name: "m", T: parser.GENERIC_MAP},
 		{Name: "key", T: parser.STRING_TYPE},
 	},
 	ReturnType: parser.NONE_TYPE,
@@ -671,7 +671,7 @@ func dashFunc(dashFn func([]float64)) builtinFunc {
 
 var fontDecl = &parser.FuncDefStmt{
 	Name:       "font",
-	Params:     []*parser.Var{{Name: "properties", T: parser.UNTYPED_MAP}},
+	Params:     []*parser.Var{{Name: "properties", T: parser.GENERIC_MAP}},
 	ReturnType: parser.NONE_TYPE,
 }
 

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -524,10 +524,10 @@ func wrapAny(val Node, targetType *Type) Node {
 		}
 		return &Any{token: val.Token(), Value: val}
 	}
-	if targetType == UNTYPED_ARRAY || targetType == UNTYPED_MAP { // generic builtins
+	if targetType == GENERIC_ARRAY || targetType == GENERIC_MAP { // generic builtins
 		return val
 	}
-	if valType == UNTYPED_ARRAY {
+	if valType == EMPTY_ARRAY {
 		switch v := val.(type) {
 		case *ArrayLiteral:
 			v.T = targetType
@@ -543,7 +543,7 @@ func wrapAny(val Node, targetType *Type) Node {
 		}
 		panic(fmt.Sprintf("internal error: untyped array: %s incompatible types: target %v, value %v", val.Token().Location(), targetType, valType))
 	}
-	if valType == UNTYPED_MAP {
+	if valType == EMPTY_MAP {
 		switch v := val.(type) {
 		case *MapLiteral:
 			v.T = targetType
@@ -730,7 +730,7 @@ func (b *BinaryExpression) Type() *Type {
 }
 
 func (b *BinaryExpression) infer() {
-	if b.T == UNTYPED_ARRAY {
+	if b.T == EMPTY_ARRAY {
 		b.T = &Type{Name: ARRAY, Sub: ANY_TYPE}
 	}
 }
@@ -829,7 +829,7 @@ func (d *GroupExpression) Type() *Type {
 }
 
 func (d *GroupExpression) infer() {
-	if d.Type() == UNTYPED_ARRAY {
+	if d.Type() == EMPTY_ARRAY {
 		d.Expr.(inferrer).infer()
 	}
 }

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -151,7 +151,7 @@ func (p *parser) parseBinaryExpr(left Node) Node {
 	if binaryExp.Right == nil {
 		return nil // previous error
 	}
-	if expType == UNTYPED_ARRAY {
+	if expType == EMPTY_ARRAY {
 		binaryExp.T = binaryExp.Right.Type() // array concatenation e.g. [] + [1 2]
 	}
 	p.validateBinaryType(binaryExp)
@@ -417,7 +417,7 @@ func (p *parser) parseArrayLiteral() Node {
 		return nil
 	}
 	p.advance() // advance past ]
-	arrayLit := &ArrayLiteral{token: tok, T: UNTYPED_ARRAY}
+	arrayLit := &ArrayLiteral{token: tok, T: EMPTY_ARRAY}
 	p.formatting.recordMultiline(arrayLit, multi)
 	if len(elements) == 0 {
 		return arrayLit
@@ -460,7 +460,7 @@ func (p *parser) parseMapLiteral() Node {
 	p.pushWSS(false)
 	defer p.popWSS()
 	tok := p.cur
-	mapLit := &MapLiteral{token: tok, Pairs: map[string]Node{}, T: UNTYPED_MAP}
+	mapLit := &MapLiteral{token: tok, Pairs: map[string]Node{}, T: EMPTY_MAP}
 	p.advance() // advance past {
 
 	if ok := p.parseMapPairs(mapLit); !ok {

--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -333,7 +333,7 @@ func (f *formatting) formatMapLiteral(n *MapLiteral) {
 
 func (f *formatting) formatType(t *Type) {
 	f.write(t.Name.String())
-	if t.Sub != nil && t != UNTYPED_ARRAY && t != UNTYPED_MAP {
+	if t.Sub != nil && t != EMPTY_ARRAY && t != EMPTY_MAP {
 		f.formatType(t.Sub)
 	}
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1060,7 +1060,7 @@ func TestEmptyArray(t *testing.T) {
 		parser := newParser(input, testBuiltins())
 		_ = parser.parse()
 		assertNoParseError(t, parser, input)
-		assert.Equal(t, NONE_TYPE, UNTYPED_ARRAY.Sub)
+		assert.Equal(t, NONE_TYPE, EMPTY_ARRAY.Sub)
 	}
 }
 
@@ -1079,7 +1079,7 @@ end`,
 		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 
-		assert.Equal(t, NONE_TYPE, UNTYPED_ARRAY.Sub)
+		assert.Equal(t, NONE_TYPE, EMPTY_ARRAY.Sub)
 	}
 }
 
@@ -1638,7 +1638,7 @@ func testBuiltins() Builtins {
 		"has": {
 			Name: "has",
 			Params: []*Var{
-				{Name: "map", T: UNTYPED_MAP},
+				{Name: "map", T: GENERIC_MAP},
 				{Name: "key", T: STRING_TYPE},
 			},
 			ReturnType: NONE_TYPE,
@@ -1646,7 +1646,7 @@ func testBuiltins() Builtins {
 		"join": {
 			Name: "join",
 			Params: []*Var{
-				{Name: "arr", T: UNTYPED_MAP},
+				{Name: "arr", T: GENERIC_MAP},
 				{Name: "sep", T: STRING_TYPE},
 			},
 			ReturnType: STRING_TYPE,

--- a/pkg/parser/type_test.go
+++ b/pkg/parser/type_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestInfer(t *testing.T) {
 	// arr := [[]]
-	arr := &Type{Name: ARRAY, Sub: UNTYPED_ARRAY}
+	arr := &Type{Name: ARRAY, Sub: EMPTY_ARRAY}
 	got := arr.infer()
 	want := &Type{
 		Name: ARRAY,


### PR DESCRIPTION
Rename UNTYPED_ARRY and UNTYPED_MAP to EMPTY_ARRY and EMPTY_MAP if they 
represent an empty array or map and to GENERIC_ARRAY and GENERIC_MAP if
they are used as generic parameters to builtins.

---

This PR is based on PR217. Only the last commit is relevant.