### PR TITLE
frontend: Improve initial load UX on slow networks

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -541,7 +541,9 @@ button.primary {
 .run button.running#run,
 .run button.running#run-mobile,
 .run button.running#run:hover,
-.run button.running#run-mobile:hover {
+.run button.running#run:active,
+.run button.running#run-mobile:hover,
+.run button.running#run-mobile:active {
   color: var(--btn-color-active);
   letter-spacing: 0.2em;
   transition: 0s;

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -597,10 +597,11 @@ button.primary {
 }
 .modal-main {
   font-family: var(--ff);
-  padding: 36px;
+  padding: 36px 36px 16px;
   overflow-y: auto;
   display: flex;
   flex-wrap: wrap;
+  height: calc(100% - var(--header-height));
 }
 #modal .modal-main .section {
   width: var(--modal-section-width);

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -62,7 +62,7 @@
   --dialog-width: min(100vw, 36rem);
 }
 
-@media (max-width: 767px), (max-height: 550px) {
+@media (max-width: 767px) {
   /* responsive mobile */
   :root {
     --display-desktop-only: none;
@@ -447,6 +447,13 @@ dialog .err {
   width: 100%;
   height: 100%;
   touch-action: pinch-zoom;
+}
+@media (max-height: 500px) {
+  .output .canvas canvas,
+  .output .canvas {
+    width: calc(100vh - 250px);
+    height: calc(100vh - 250px);
+  }
 }
 .read {
   display: flex;

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -537,13 +537,13 @@ button.primary {
 .run button#run-mobile {
   width: 100%;
 }
-.run button:disabled {
+.run button:disabled,
+.run button.loading {
   color: var(--btn-color-disabled);
   box-shadow:
     0 4px 0 hsl(0deg 0% 60%),
     0 16px 12px -8px hsl(0deg 0% 0% / 30%),
     inset 0 -2px 1px 1px hsl(0deg 0% 60%);
-  cursor: not-allowed;
 }
 .run button.running#run,
 .run button.running#run-mobile,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -89,13 +89,25 @@
           </div>
           <div class="console" id="console"></div>
           <div class="run desktop">
-            <button id="run" disabled class="primary">Run</button>
+            <button
+              id="run"
+              class="primary loading"
+              onclick="document.querySelector('#dialog-loading').showModal()"
+            >
+              Run
+            </button>
           </div>
         </div>
       </main>
       <!-- Add separate mobile button because of position:fixed and output transform -->
       <div class="run mobile">
-        <button id="run-mobile" disabled class="primary">Run</button>
+        <button
+          id="run-mobile"
+          class="primary loading"
+          onclick="document.querySelector('#dialog-loading').showModal()"
+        >
+          Run
+        </button>
       </div>
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,7 +44,36 @@
     <div class="max-width-wrapper">
       <main>
         <div class="editor-wrap">
-          <div class="editor"></div>
+          <div class="editor" style="padding-left: calc(2ch + 1.5rem)">
+            <!-- These editor sample contents are replaced by JS,  once evy toolchain and yace-editor are downloaded. -->
+            <pre class="lines">
+<span class="num">  1</span>
+<span class="num">  2</span>
+<span class="num">  3</span>
+<span class="num">  4</span>
+<span class="num">  5</span>
+<span class="num">  6</span>
+<span class="num">  7</span>
+<span class="num">  8</span>
+<span class="num">  9</span>
+<span class="num"> 10</span>
+<span class="num"> 11</span>
+<span class="num"> 12</span>
+            </pre>
+            <pre class="highlighted">
+<span class="builtin">move</span> <span class="num">10</span> <span class="num">20</span>
+<span class="builtin">line</span> <span class="num">50</span> <span class="num">50</span>
+<span class="builtin">rect</span> <span class="num">25</span> <span class="num">25</span>
+<span class="builtin">color</span> <span class="str">"red"</span>
+<span class="builtin">circle</span> <span class="num">10</span>
+
+<span class="ident">x</span> <span class="op">:=</span> <span class="num">12</span>
+<span class="builtin">print</span> <span class="str">"x:"</span> <span class="ident">x</span>
+<span class="keyword">if</span> <span class="ident">x</span> <span class="op">&gt;</span> <span class="num">10</span>
+<span class="builtin">    print</span> <span class="str">"🍦 big x"</span>
+<span class="keyword">end</span><br>
+            </pre>
+          </div>
         </div>
         <div class="output">
           <div class="canvas">
@@ -164,6 +193,22 @@
             <span class="err">parse error</span>
             first, please!
           </p>
+          <button class="primary">Ok</button>
+        </main>
+      </form>
+    </dialog>
+
+    <!-- Evy sharing error dialog -->
+    <dialog id="dialog-loading">
+      <form method="dialog">
+        <header>
+          <h1>Loading</h1>
+          <button class="header-icon">
+            <svg width="1.2em" height="1.2em"><use href="#icon-close" /></svg>
+          </button>
+        </header>
+        <main>
+          <p>Hold tight, getting the editor and compiler ready. 🧘</p>
           <button class="primary">Ok</button>
         </main>
       </form>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -18,17 +18,15 @@ let sidemenu
 
 // --- Initialise ------------------------------------------------------
 
-initWasm()
+await initWasm()
 initUI()
 initCanvas()
 
 // --- Wasm ------------------------------------------------------------
 
 // initWasm loads bytecode and initialises execution environment.
-function initWasm() {
-  WebAssembly.compileStreaming(fetch("evy.wasm"))
-    .then((obj) => (wasmModule = obj))
-    .catch((err) => console.error(err))
+async function initWasm() {
+  wasmModule = await WebAssembly.compileStreaming(fetch("evy.wasm"))
   const runButton = document.querySelector("#run")
   const runButtonMob = document.querySelector("#run-mobile")
   runButton.onclick = handleRun
@@ -341,10 +339,10 @@ async function initUI() {
   document.querySelector("#sidemenu-share").onclick = share
   document.querySelector("#sidemenu-icon-share").onclick = share
   initModal()
-  handleHashChange()
   initEditor()
   initSidemenu()
   initDialog()
+  handleHashChange()
 }
 
 async function fetchSamples() {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -30,9 +30,9 @@ async function initWasm() {
   const runButton = document.querySelector("#run")
   const runButtonMob = document.querySelector("#run-mobile")
   runButton.onclick = handleRun
-  runButton.disabled = false
+  runButton.classList.remove("loading")
   runButtonMob.onclick = handleMobRun
-  runButtonMob.disabled = false
+  runButtonMob.classList.remove("loading")
 }
 
 function newEvyGo() {

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -42,9 +42,7 @@ export default class Yace {
     this.lines.classList.add("lines")
     this.errorLines = {}
 
-    this.root.appendChild(this.textarea)
-    this.root.appendChild(this.lines)
-    this.root.appendChild(this.highlighted)
+    this.root.replaceChildren(this.textarea, this.lines, this.highlighted)
 
     this.addTextareaEvents()
     this.update({ value: this.options.value })


### PR DESCRIPTION
Improve initial loading user experience on slow networks by pre filling the
editor area with the Welcome example, fixing a load race condition and
showing a load dialog if the run button is clicked before the tool chain is
ready.

While at it fix a regression scroll bug for the example modal and add styling
for the runbutton active state to avoid the weird blue color on tap on
mobile.