### PR TITLE
doctest: Exit with an error when errors occur

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -474,7 +474,7 @@ fraction of a second, e.g. `sleep 0.1`.
 
 #### Example
 
-```evy expect_err
+```evy:err
 input := "not a number"
 n := str2num input
 
@@ -501,7 +501,7 @@ immediately. It is used to report unrecoverable errors.
 
 #### Example
 
-```evy exepect_err
+```evy:err
 scale := -5
 
 if (scale) <= 0


### PR DESCRIPTION
Ensure awk exits with an error when there is an error in an evy code block.
Prior to this, an error was printed but awk still exited with 0 allowing CI
and `make doctest` to continue.

Emit a document line number when an error is reported to make it easier to
locate where the error is.

Change the tagging of evy code that is expected to exit with an error
from `evy expect_err` to `evy:err`. Update the builtins docs to use this
(and fix a misspelling at the same time that mismarked a block).