### PR TITLE
parser: Reorder methods in ast.go

### DIFF
--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -38,6 +38,36 @@ type Program struct {
 	formatting  *formatting
 }
 
+// Format returns a string of the formatted program with consistent
+// indentation and vertical whitespace.
+func (p *Program) Format() string {
+	var sb strings.Builder
+	p.formatting.w = &sb
+	p.formatting.format(p)
+	return sb.String()
+}
+
+// String returns a string representation of the Program node.
+func (p *Program) String() string {
+	return newlineList(p.Statements)
+}
+
+// Token returns the token of the Evy source program associated with the
+// Program node.
+func (p *Program) Token() *lexer.Token {
+	return p.token
+}
+
+// Type returns [NONE_TYPE] for Program because a program does not have
+// a type.
+func (*Program) Type() *Type {
+	return NONE_TYPE
+}
+
+func (p *Program) alwaysTerminates() bool {
+	return p.alwaysTerms
+}
+
 // EmptyStmt is an AST node that represents an empty statement. An empty
 // statement is a statement that does nothing. Empty statement is used
 // for formatting, such as to add a blank line between statements.
@@ -47,189 +77,20 @@ type EmptyStmt struct {
 	token *lexer.Token // The NL token
 }
 
-// FuncCallStmt is an AST node that represents a standalone function
-// call statement. It is a statement that calls a function without any
-// surrounding expressions.
-//
-// FuncCallStmt implements the [Node] interface.
-type FuncCallStmt struct {
-	token    *lexer.Token // The IDENT of the function
-	FuncCall *FuncCall
-}
-
-// FuncCall is an AST node that represents a function call. It can be
-// used either as a standalone statement or as part of an expression.
-//
-// FuncCall implements the [Node] interface.
-type FuncCall struct {
-	token     *lexer.Token // The IDENT of the function
-	Name      string
-	Arguments []Node
-	FuncDef   *FuncDefStmt
-}
-
-// UnaryExpression is an AST node that represents a unary expression,
-// such as: -n.
-//
-// UnaryExpression implements the [Node] interface.
-type UnaryExpression struct {
-	token *lexer.Token // The unary operation token, e.g. !
-	Op    Operator
-	Right Node
-}
-
-// BinaryExpression is an AST node that represents a binary expression.
-// A binary expression is an expression that has two operands and an
-// operator, such as a + b.
-//
-// BinaryExpression implements the [Node] interface.
-type BinaryExpression struct {
-	T     *Type
-	token *lexer.Token // The binary operation token, e.g. +
-	Op    Operator
-	Left  Node
-	Right Node
-}
-
-// IndexExpression is an AST node that represents an indexing
-// expression. It accesses the value of an element in an array, map or
-// string. For example: array[i].
-//
-// IndexExpression implements the [Node] interface.
-type IndexExpression struct {
-	T     *Type
-	token *lexer.Token // The [ token
-	Left  Node
-	Index Node
-}
-
-// SliceExpression is an AST node
-// that represents a slice expression. A slice expression is used
-// to access a subsequence of an array or string, such as: array[1:4].
-//
-// SliceExpression implements the [Node] interface.
-type SliceExpression struct {
-	T     *Type
-	token *lexer.Token // The [ token
-	Left  Node
-	Start Node
-	End   Node
-}
-
-// DotExpression is an AST node that represents a field access
-// expression. A field access expression is an expression that accesses
-// the value of a field in a map, such as person.age.
-//
-// DotExpression implements the [Node] interface.
-type DotExpression struct {
-	T     *Type
-	token *lexer.Token // The . token
-	Left  Node
-	Key   string // m := { age: 42}; m.age => key: "age"
-}
-
-// TypeAssertion is an AST node that represents a type assertion
-// expression. A type assertion expression is used to enforce the
-// specific type of an any value. For example:
-//
-//	val:any
-//	val = 1
-//	print val.(num)+2 // 3
-//
-// TypeAssertion implements the [Node] interface.
-type TypeAssertion struct {
-	T     *Type
-	token *lexer.Token
-	Left  Node
-}
-
-// GroupExpression is an AST node that represents a parenthesized
-// expression. It groups together an expression so that it can be
-// evaluated as a single unit, such as:(a+b)*3.
-//
-// GroupExpression implements the [Node] interface.
-type GroupExpression struct {
-	token *lexer.Token
-	Expr  Node
-}
-
-// Decl is an AST node that represents a variable declaration. A
-// variable declaration is a statement that creates a new variable and
-// assigns it a value. Variable declarations are used in
-// [TypedDeclStmt] and [InferredDeclStmt] statements.
-//
-// Decl implements the [Node] interface.
-type Decl struct {
-	token *lexer.Token
-	Var   *Var
-	Value Node // literal, expression, variable, ...
-}
-
-// TypedDeclStmt is an AST node that represents a typed declaration
-// statement. A typed declaration statement declares a variable of an
-// explicitly specified type, such as n:num.
-//
-// TypedDeclStmt implements the [Node] interface.
-type TypedDeclStmt struct {
-	token *lexer.Token
-	Decl  *Decl
-}
-
-// InferredDeclStmt is an AST node that represents an inferred
-// declaration statement. It declares a variable with a type that is
-// inferred from the value that is assigned to it. For example: n :=
-// 1.
-//
-// InferredDeclStmt implements the [Node] interface.
-type InferredDeclStmt struct {
-	token *lexer.Token
-	Decl  *Decl
-}
-
-// AssignmentStmt is an AST node that represents an assignment
-// statement. An assignment statement assigns a value to a variable,
-// such as n = 2.
-//
-// AssignmentStmt implements the [Node] interface.
-type AssignmentStmt struct {
-	token  *lexer.Token
-	Target Node // Variable, index or field expression
-	Value  Node // literal, expression, variable...
-}
-
-// ReturnStmt is an AST node that represents a return statement. A
-// return statement terminates the execution of a function and can
-// return a value. For example:
-//
-//	func square:num n:num
-//	    return n * n
-//	end
-//
-// ReturnStmt implements the [Node] interface.
-type ReturnStmt struct {
-	token *lexer.Token
-	Value Node // literal, expression, variable, ...
-	T     *Type
-}
-
-// BreakStmt is an AST node that represents a break statement. A break
-// statement is used to terminate the current loop statement, for
-// example:
-//
-//	while true
-//	    break
-//	end
-//
-// BreakStmt implements the [Node] interface.
-type BreakStmt struct {
-	token *lexer.Token
+// String returns a string representation of the EmptyStmt node.
+func (e *EmptyStmt) String() string {
+	return ""
 }
 
 // Token returns the token of the Evy source program associated with the
-// FuncDefStmt node.
-func (f *FuncDefStmt) Token() *lexer.Token {
-	return f.token
+// EmptyStmt node.
+func (e *EmptyStmt) Token() *lexer.Token {
+	return e.token
 }
+
+// Type returns [NONE_TYPE] for EmptyStmt because the empty statement
+// does not have a type.
+func (*EmptyStmt) Type() *Type { return NONE_TYPE }
 
 // FuncDefStmt is an AST node that represents a function definition. It
 // defines a new function with a name, a parameter list, return type,
@@ -252,10 +113,66 @@ type FuncDefStmt struct {
 	isCalled bool
 }
 
+// String returns a string representation of the FuncDefStmt node.
+func (f *FuncDefStmt) String() string {
+	s := make([]string, len(f.Params))
+	for i, param := range f.Params {
+		s[i] = param.String()
+	}
+	params := strings.Join(s, ", ")
+	if f.VariadicParam != nil {
+		params += f.VariadicParam.String() + "..."
+	}
+	signature := f.Name + "(" + params + ")"
+	body := ""
+	if f.Body != nil {
+		body = f.Body.String()
+	}
+	return signature + "{\n" + body + "}\n"
+}
+
 // Token returns the token of the Evy source program associated with the
-// IfStmt node.
-func (i *IfStmt) Token() *lexer.Token {
-	return i.token
+// FuncDefStmt node.
+func (f *FuncDefStmt) Token() *lexer.Token {
+	return f.token
+}
+
+// Type returns the return type of the function.
+func (f *FuncDefStmt) Type() *Type {
+	return f.ReturnType
+}
+
+// EventHandlerStmt is an AST node that represents an event handler
+// definition. It includes the handler body, such as:
+//
+//	on key k:string
+//	    print "key pressed:" k
+//	end
+//
+// EventHandlerStmt implements the [Node] interface.
+type EventHandlerStmt struct {
+	token  *lexer.Token // The "on" token
+	Name   string
+	Params []*Var
+	Body   *BlockStatement
+}
+
+// String returns a string representation of the EventHandlerStmt node.
+func (e *EventHandlerStmt) String() string {
+	body := e.Body.String()
+	return "on " + e.Name + " {\n" + body + "}\n"
+}
+
+// Token returns the token of the Evy source program associated with the
+// EventHandlerStmt node.
+func (e *EventHandlerStmt) Token() *lexer.Token {
+	return e.token
+}
+
+// Type returns [NONE_TYPE] for EventHandlerStmt because an event
+// handler definition does not have a type.
+func (e *EventHandlerStmt) Type() *Type {
+	return NONE_TYPE
 }
 
 // IfStmt is an AST node that represents a conditional statement. It
@@ -275,10 +192,43 @@ type IfStmt struct {
 	Else         *BlockStatement
 }
 
+// String returns a string representation of the IfStmt node.
+func (i *IfStmt) String() string {
+	result := "if " + i.IfBlock.String()
+	for _, elseif := range i.ElseIfBlocks {
+		result += "else if" + elseif.String()
+	}
+	if i.Else != nil {
+		result += "else {\n" + i.Else.String() + "}\n"
+	}
+	return result
+}
+
 // Token returns the token of the Evy source program associated with the
-// WhileStmt node.
-func (w *WhileStmt) Token() *lexer.Token {
-	return w.token
+// IfStmt node.
+func (i *IfStmt) Token() *lexer.Token {
+	return i.token
+}
+
+// Type returns [NONE_TYPE] for IfStmt because an if statement doest not
+// have a type.
+func (i *IfStmt) Type() *Type {
+	return NONE_TYPE
+}
+
+func (i *IfStmt) alwaysTerminates() bool {
+	if i.Else == nil || !i.Else.alwaysTerminates() {
+		return false
+	}
+	if !i.IfBlock.alwaysTerminates() {
+		return false
+	}
+	for _, b := range i.ElseIfBlocks {
+		if !b.alwaysTerminates() {
+			return false
+		}
+	}
+	return true
 }
 
 // WhileStmt is an AST node that represents a while statement, such as
@@ -292,10 +242,25 @@ type WhileStmt struct {
 	ConditionalBlock
 }
 
+// String returns a string representation of the WhileStmt node.
+func (w *WhileStmt) String() string {
+	return "while " + w.ConditionalBlock.String()
+}
+
 // Token returns the token of the Evy source program associated with the
-// ForStmt node.
-func (f *ForStmt) Token() *lexer.Token {
-	return f.token
+// WhileStmt node.
+func (w *WhileStmt) Token() *lexer.Token {
+	return w.token
+}
+
+// Type returns [NONE_TYPE] for WhileStmt because a while statement does
+// not have a type.
+func (w *WhileStmt) Type() *Type {
+	return NONE_TYPE
+}
+
+func (*WhileStmt) alwaysTerminates() bool {
+	return false
 }
 
 // ForStmt is an AST node that represents a for loop. A for loop is a
@@ -316,10 +281,562 @@ type ForStmt struct {
 	Block *BlockStatement
 }
 
+// String returns a string representation of the ForStmt node.
+func (f *ForStmt) String() string {
+	header := "for "
+	if f.LoopVar != nil {
+		header += f.LoopVar.Name + " := "
+	}
+	header += f.Range.String()
+	return header + " {\n" + f.Block.String() + "}"
+}
+
 // Token returns the token of the Evy source program associated with the
-// StepRange node.
-func (s *StepRange) Token() *lexer.Token {
+// ForStmt node.
+func (f *ForStmt) Token() *lexer.Token {
+	return f.token
+}
+
+// Type returns [NONE_TYPE] for ForStmt because a while statement does
+// not have a type.
+func (f *ForStmt) Type() *Type {
+	return NONE_TYPE
+}
+
+func (*ForStmt) alwaysTerminates() bool {
+	return false
+}
+
+// TypedDeclStmt is an AST node that represents a typed declaration
+// statement. A typed declaration statement declares a variable of an
+// explicitly specified type, such as n:num.
+//
+// TypedDeclStmt implements the [Node] interface.
+type TypedDeclStmt struct {
+	token *lexer.Token
+	Decl  *Decl
+}
+
+// String returns a string representation of the TypedDeclStmt node.
+func (d *TypedDeclStmt) String() string {
+	return d.Decl.String()
+}
+
+// Token returns the token of the Evy source program associated with the
+// TypedDeclStmt node.
+func (d *TypedDeclStmt) Token() *lexer.Token {
+	return d.token
+}
+
+// Type returns the type of the variable that is declared.
+func (d *TypedDeclStmt) Type() *Type {
+	return d.Decl.Var.T
+}
+
+// InferredDeclStmt is an AST node that represents an inferred
+// declaration statement. It declares a variable with a type that is
+// inferred from the value that is assigned to it. For example: n :=
+// 1.
+//
+// InferredDeclStmt implements the [Node] interface.
+type InferredDeclStmt struct {
+	token *lexer.Token
+	Decl  *Decl
+}
+
+// String returns a string representation of the InferredDeclStmt node.
+func (d *InferredDeclStmt) String() string {
+	return d.Decl.String()
+}
+
+// Token returns the token of the Evy source program associated with the
+// InferredDeclStmt node.
+func (d *InferredDeclStmt) Token() *lexer.Token {
+	return d.token
+}
+
+// Type returns the type of the variable that is declared.
+func (d *InferredDeclStmt) Type() *Type {
+	return d.Decl.Var.T
+}
+
+// AssignmentStmt is an AST node that represents an assignment
+// statement. An assignment statement assigns a value to a variable,
+// such as n = 2.
+//
+// AssignmentStmt implements the [Node] interface.
+type AssignmentStmt struct {
+	token  *lexer.Token
+	Target Node // Variable, index or field expression
+	Value  Node // literal, expression, variable...
+}
+
+// String returns a string representation of the AssignmentStmt node.
+func (a *AssignmentStmt) String() string {
+	return a.Target.String() + " = " + a.Value.String()
+}
+
+// Token returns the token of the Evy source program associated with the
+// AssignmentStmt node.
+func (a *AssignmentStmt) Token() *lexer.Token {
+	return a.token
+}
+
+// Type returns the type of the variable that is assigned.
+func (a *AssignmentStmt) Type() *Type {
+	return a.Target.Type()
+}
+
+// FuncCallStmt is an AST node that represents a standalone function
+// call statement. It is a statement that calls a function without any
+// surrounding expressions.
+//
+// FuncCallStmt implements the [Node] interface.
+type FuncCallStmt struct {
+	token    *lexer.Token // The IDENT of the function
+	FuncCall *FuncCall
+}
+
+// String returns a string representation of the FuncCallStmt node.
+func (f *FuncCallStmt) String() string {
+	return f.FuncCall.String()
+}
+
+// Token returns the token of the Evy source program associated with the
+// FuncCallStmt node.
+func (f *FuncCallStmt) Token() *lexer.Token {
+	return f.token
+}
+
+// Type returns the return type of the called function.
+func (f *FuncCallStmt) Type() *Type {
+	return f.FuncCall.FuncDef.ReturnType
+}
+
+// ReturnStmt is an AST node that represents a return statement. A
+// return statement terminates the execution of a function and can
+// return a value. For example:
+//
+//	func square:num n:num
+//	    return n * n
+//	end
+//
+// ReturnStmt implements the [Node] interface.
+type ReturnStmt struct {
+	token *lexer.Token
+	Value Node // literal, expression, variable, ...
+	T     *Type
+}
+
+// String returns a string representation of the ReturnStmt node.
+func (r *ReturnStmt) String() string {
+	if r.Value == nil {
+		return "return"
+	}
+	return "return " + r.Value.String()
+}
+
+// Token returns the token of the Evy source program associated with the
+// ReturnStmt node.
+func (r *ReturnStmt) Token() *lexer.Token {
+	return r.token
+}
+
+// Type returns the type of the value returned by the return statement.
+func (r *ReturnStmt) Type() *Type {
+	return r.T
+}
+
+func (*ReturnStmt) alwaysTerminates() bool {
+	return true
+}
+
+// BreakStmt is an AST node that represents a break statement. A break
+// statement is used to terminate the current loop statement, for
+// example:
+//
+//	while true
+//	    break
+//	end
+//
+// BreakStmt implements the [Node] interface.
+type BreakStmt struct {
+	token *lexer.Token
+}
+
+// String returns a string representation of the eakStmt node.
+func (*BreakStmt) String() string {
+	return "break"
+}
+
+// Token returns the token of the Evy source program associated with the
+// BreakStmt node.
+func (b *BreakStmt) Token() *lexer.Token {
+	return b.token
+}
+
+// Type returns [NONE_TYPE] for BreakStmt because the empty statement
+// does not have a type.
+func (*BreakStmt) Type() *Type {
+	return NONE_TYPE
+}
+
+func (b *BreakStmt) alwaysTerminates() bool {
+	return true
+}
+
+// BlockStatement is an AST node that represents a block of statements.
+// A block of statements is a sequence of statements that are executed
+// together, such as those used in [FuncDefStmt] and [IfStmt].
+//
+// BlockStatement implements the [Node] interface.
+type BlockStatement struct {
+	token       *lexer.Token // the NL before the first statement
+	Statements  []Node
+	alwaysTerms bool
+}
+
+// String returns a string representation of the BlockStatement node.
+func (b *BlockStatement) String() string {
+	return newlineList(b.Statements)
+}
+
+// Token returns the token of the Evy source program associated with the
+// BlockStatement node.
+func (b *BlockStatement) Token() *lexer.Token {
+	return b.token
+}
+
+// Type returns [NONE_TYPE] for BlockStatement because a block statement
+// does not have a type.
+func (b *BlockStatement) Type() *Type {
+	return NONE_TYPE
+}
+
+func (b *BlockStatement) alwaysTerminates() bool {
+	return b.alwaysTerms
+}
+
+// ConditionalBlock is an AST node that represents a conditional block.
+// A conditional block is a block of statements that is executed only
+// if a certain condition is met. Conditional blocks are used in
+// [IfStmt] and [WhileStmt] statements.
+//
+// ConditionalBlock implements the [Node] interface.
+type ConditionalBlock struct {
+	token     *lexer.Token
+	Condition Node // must be of type bool
+	Block     *BlockStatement
+}
+
+// String returns a string representation of the ConditionalBlock node.
+func (c *ConditionalBlock) String() string {
+	condition := "(" + c.Condition.String() + ")"
+	return condition + " {\n" + c.Block.String() + "}"
+}
+
+// Token returns the token of the Evy source program associated with the
+// ConditionalBlock node.
+func (c *ConditionalBlock) Token() *lexer.Token {
+	return c.token
+}
+
+// Type returns [NONE_TYPE] for ConditionalBlock because a conditional
+// block statement does not have a type.
+func (c *ConditionalBlock) Type() *Type {
+	return NONE_TYPE
+}
+
+func (c *ConditionalBlock) alwaysTerminates() bool {
+	return c.Block.alwaysTerminates()
+}
+
+// FuncCall is an AST node that represents a function call. It can be
+// used either as a standalone statement or as part of an expression.
+//
+// FuncCall implements the [Node] interface.
+type FuncCall struct {
+	token     *lexer.Token // The IDENT of the function
+	Name      string
+	Arguments []Node
+	FuncDef   *FuncDefStmt
+}
+
+// String returns a string representation of the FuncCall node.
+func (f *FuncCall) String() string {
+	s := make([]string, len(f.Arguments))
+	for i, arg := range f.Arguments {
+		s[i] = arg.String()
+	}
+	args := strings.Join(s, ", ")
+	return f.Name + "(" + args + ")"
+}
+
+// Token returns the token of the Evy source program associated with the
+// FuncCall node.
+func (f *FuncCall) Token() *lexer.Token {
+	return f.token
+}
+
+// Type returns the return type of the called function.
+func (f *FuncCall) Type() *Type {
+	return f.FuncDef.ReturnType
+}
+
+// UnaryExpression is an AST node that represents a unary expression,
+// such as: -n.
+//
+// UnaryExpression implements the [Node] interface.
+type UnaryExpression struct {
+	token *lexer.Token // The unary operation token, e.g. !
+	Op    Operator
+	Right Node
+}
+
+// Token returns the token of the Evy source program associated with the
+// UnaryExpression node.
+func (u *UnaryExpression) Token() *lexer.Token {
+	return u.token
+}
+
+// String returns a string representation of the UnaryExpression node.
+func (u *UnaryExpression) String() string {
+	return "(" + u.Op.String() + u.Right.String() + ")"
+}
+
+// Type returns the type of the UnaryExpression, such as bool or num.
+func (u *UnaryExpression) Type() *Type {
+	return u.Right.Type()
+}
+
+// BinaryExpression is an AST node that represents a binary expression.
+// A binary expression is an expression that has two operands and an
+// operator, such as a + b.
+//
+// BinaryExpression implements the [Node] interface.
+type BinaryExpression struct {
+	T     *Type
+	token *lexer.Token // The binary operation token, e.g. +
+	Op    Operator
+	Left  Node
+	Right Node
+}
+
+// String returns a string representation of the BinaryExpression node.
+func (b *BinaryExpression) String() string {
+	if b.Op == OP_AND || b.Op == OP_OR {
+		return "(" + b.Left.String() + " " + b.Op.String() + " " + b.Right.String() + ")"
+	}
+	return "(" + b.Left.String() + b.Op.String() + b.Right.String() + ")"
+}
+
+// Token returns the token of the Evy source program associated with the
+// BinaryExpression node.
+func (b *BinaryExpression) Token() *lexer.Token {
+	return b.token
+}
+
+// Type returns the type of the BinaryExpression, such as bool, num or string.
+func (b *BinaryExpression) Type() *Type {
+	return b.T
+}
+
+func (b *BinaryExpression) infer() {
+	if b.T == EMPTY_ARRAY {
+		b.T = &Type{Name: ARRAY, Sub: ANY_TYPE}
+	}
+}
+
+// IndexExpression is an AST node that represents an indexing
+// expression. It accesses the value of an element in an array, map or
+// string. For example: array[i].
+//
+// IndexExpression implements the [Node] interface.
+type IndexExpression struct {
+	T     *Type
+	token *lexer.Token // The [ token
+	Left  Node
+	Index Node
+}
+
+// String returns a string representation of the IndexExpression node.
+func (i *IndexExpression) String() string {
+	return "(" + i.Left.String() + "[" + i.Index.String() + "])"
+}
+
+// Token returns the token of the Evy source program associated with the
+// IndexExpression node.
+func (i *IndexExpression) Token() *lexer.Token {
+	return i.token
+}
+
+// Type returns the type of the IndexExpression, for example num for an
+// array of numbers with type []num.
+func (i *IndexExpression) Type() *Type {
+	return i.T
+}
+
+// SliceExpression is an AST node
+// that represents a slice expression. A slice expression is used
+// to access a subsequence of an array or string, such as: array[1:4].
+//
+// SliceExpression implements the [Node] interface.
+type SliceExpression struct {
+	T     *Type
+	token *lexer.Token // The [ token
+	Left  Node
+	Start Node
+	End   Node
+}
+
+// String returns a string representation of the SliceExpression node.
+func (s *SliceExpression) String() string {
+	start := ""
+	if s.Start != nil {
+		start = s.Start.String()
+	}
+	end := ""
+	if s.End != nil {
+		end = s.End.String()
+	}
+	return "(" + s.Left.String() + "[" + start + ":" + end + "])"
+}
+
+// Token returns the token of the Evy source program associated with the
+// SliceExpression node.
+func (s *SliceExpression) Token() *lexer.Token {
 	return s.token
+}
+
+// Type returns the type of the SliceExpression, which is the same type
+// as the array that is sliced or string if a string is sliced.
+func (s *SliceExpression) Type() *Type {
+	return s.T
+}
+
+// DotExpression is an AST node that represents a field access
+// expression. A field access expression is an expression that accesses
+// the value of a field in a map, such as person.age.
+//
+// DotExpression implements the [Node] interface.
+type DotExpression struct {
+	T     *Type
+	token *lexer.Token // The . token
+	Left  Node
+	Key   string // m := { age: 42}; m.age => key: "age"
+}
+
+// String returns a string representation of the DotExpression node.
+func (d *DotExpression) String() string {
+	return "(" + d.Left.String() + "." + d.Key + ")"
+}
+
+// Token returns the token of the Evy source program associated with the
+// DotExpression node.
+func (d *DotExpression) Token() *lexer.Token {
+	return d.token
+}
+
+// Type returns the type of the DotExpression, which is the type of the
+// map's values. For map := {a: true}, the type of map.a is bool.
+func (d *DotExpression) Type() *Type {
+	return d.T
+}
+
+// GroupExpression is an AST node that represents a parenthesized
+// expression. It groups together an expression so that it can be
+// evaluated as a single unit, such as:(a+b)*3.
+//
+// GroupExpression implements the [Node] interface.
+type GroupExpression struct {
+	token *lexer.Token
+	Expr  Node
+}
+
+// String returns a string representation of the GroupExpression node.
+func (d *GroupExpression) String() string {
+	return d.Expr.String()
+}
+
+// Token returns the token of the Evy source program associated with the
+// GroupExpression node.
+func (d *GroupExpression) Token() *lexer.Token {
+	return d.token
+}
+
+// Type returns the type of the GroupExpression, for example num for
+// 2*(3+4).
+func (d *GroupExpression) Type() *Type {
+	return d.Expr.Type()
+}
+
+func (d *GroupExpression) infer() {
+	if d.Type() == EMPTY_ARRAY {
+		d.Expr.(inferrer).infer()
+	}
+}
+
+// TypeAssertion is an AST node that represents a type assertion
+// expression. A type assertion expression is used to enforce the
+// specific type of an any value. For example:
+//
+//	val:any
+//	val = 1
+//	print val.(num)+2 // 3
+//
+// TypeAssertion implements the [Node] interface.
+type TypeAssertion struct {
+	T     *Type
+	token *lexer.Token
+	Left  Node
+}
+
+// String returns a string representation of the TypeAssertion node.
+func (t *TypeAssertion) String() string {
+	return "(" + t.Left.String() + "." + "(" + t.T.String() + ")" + ")"
+}
+
+// Token returns the token of the Evy source program associated with the
+// TypeAssertion node.
+func (t *TypeAssertion) Token() *lexer.Token {
+	return t.token
+}
+
+// Type returns the type of the TypeAssertion, which is the type that is
+// asserted.
+func (t *TypeAssertion) Type() *Type {
+	return t.T
+}
+
+// Decl is an AST node that represents a variable declaration. A
+// variable declaration is a statement that creates a new variable and
+// assigns it a value. Variable declarations are used in
+// [TypedDeclStmt] and [InferredDeclStmt] statements.
+//
+// Decl implements the [Node] interface.
+type Decl struct {
+	token *lexer.Token
+	Var   *Var
+	Value Node // literal, expression, variable, ...
+}
+
+// String returns a string representation of the Decl node.
+func (d *Decl) String() string {
+	if d.Value == nil {
+		return d.Var.String()
+	}
+	return d.Var.String() + "=" + d.Value.String()
+}
+
+// Token returns the token of the Evy source program associated with the
+// Decl node.
+func (d *Decl) Token() *lexer.Token {
+	return d.token
+}
+
+// Type returns the type of the variable that is declared.
+func (d *Decl) Type() *Type {
+	return d.Var.T
 }
 
 // StepRange is an AST node that represents a step range in a for loop.
@@ -340,49 +857,30 @@ type StepRange struct {
 	Step  Node // num expression or nil
 }
 
-// Token returns the token of the Evy source program associated with the
-// ConditionalBlock node.
-func (c *ConditionalBlock) Token() *lexer.Token {
-	return c.token
-}
-
-// ConditionalBlock is an AST node that represents a conditional block.
-// A conditional block is a block of statements that is executed only
-// if a certain condition is met. Conditional blocks are used in
-// [IfStmt] and [WhileStmt] statements.
-//
-// ConditionalBlock implements the [Node] interface.
-type ConditionalBlock struct {
-	token     *lexer.Token
-	Condition Node // must be of type bool
-	Block     *BlockStatement
+// String returns a string representation of the StepRange node.
+func (s *StepRange) String() string {
+	start := "0"
+	if s.Start != nil {
+		start = s.Start.String()
+	}
+	stop := s.Stop.String()
+	step := "1"
+	if s.Step != nil {
+		step = s.Step.String()
+	}
+	return start + " " + stop + " " + step
 }
 
 // Token returns the token of the Evy source program associated with the
-// EventHandlerStmt node.
-func (e *EventHandlerStmt) Token() *lexer.Token {
-	return e.token
+// StepRange node.
+func (s *StepRange) Token() *lexer.Token {
+	return s.token
 }
 
-// EventHandlerStmt is an AST node that represents an event handler
-// definition. It includes the handler body, such as:
-//
-//	on key k:string
-//	    print "key pressed:" k
-//	end
-//
-// EventHandlerStmt implements the [Node] interface.
-type EventHandlerStmt struct {
-	token  *lexer.Token // The "on" token
-	Name   string
-	Params []*Var
-	Body   *BlockStatement
-}
-
-// Token returns the token of the Evy source program associated with the
-// Var node.
-func (v *Var) Token() *lexer.Token {
-	return v.token
+// Type returns [NUM_TYPE] for StepRange as a step range always
+// represents a set of number value.
+func (s *StepRange) Type() *Type {
+	return NUM_TYPE
 }
 
 // Var is an AST node that represents a variable, its name and type but
@@ -396,27 +894,20 @@ type Var struct {
 	isUsed bool
 }
 
-// Token returns the token of the Evy source program associated with the
-// BlockStatement node.
-func (b *BlockStatement) Token() *lexer.Token {
-	return b.token
-}
-
-// BlockStatement is an AST node that represents a block of statements.
-// A block of statements is a sequence of statements that are executed
-// together, such as those used in [FuncDefStmt] and [IfStmt].
-//
-// BlockStatement implements the [Node] interface.
-type BlockStatement struct {
-	token       *lexer.Token // the NL before the first statement
-	Statements  []Node
-	alwaysTerms bool
+// String returns a string representation of the Var node.
+func (v *Var) String() string {
+	return v.Name
 }
 
 // Token returns the token of the Evy source program associated with the
-// BoolLiteral node.
-func (b *BoolLiteral) Token() *lexer.Token {
-	return b.token
+// Var node.
+func (v *Var) Token() *lexer.Token {
+	return v.token
+}
+
+// Type returns the type of the variable.
+func (v *Var) Type() *Type {
+	return v.T
 }
 
 // BoolLiteral is an AST node that represents a boolean literal. A
@@ -428,25 +919,21 @@ type BoolLiteral struct {
 	Value bool
 }
 
-// Token returns the token of the Evy source program associated with the
-// NumLiteral node.
-func (n *NumLiteral) Token() *lexer.Token {
-	return n.token
-}
-
-// NumLiteral is an AST node that represents a numeric literal. A
-// numeric literal is a number, such as 12 or 34.567.
-//
-// NumLiteral implements the [Node] interface.
-type NumLiteral struct {
-	token *lexer.Token
-	Value float64
+// String returns a string representation of the BoolLiteral node.
+func (b *BoolLiteral) String() string {
+	return strconv.FormatBool(b.Value)
 }
 
 // Token returns the token of the Evy source program associated with the
-// StringLiteral node.
-func (s *StringLiteral) Token() *lexer.Token {
-	return s.token
+// BoolLiteral node.
+func (b *BoolLiteral) Token() *lexer.Token {
+	return b.token
+}
+
+// Type returns [BOOL_TYPE] for BoolLiteral as a bool literal always has
+// the bool type.
+func (b *BoolLiteral) Type() *Type {
+	return BOOL_TYPE
 }
 
 // StringLiteral is an AST node that represents a string literal. A
@@ -459,10 +946,47 @@ type StringLiteral struct {
 	Value string
 }
 
+// String returns a string representation of the StringLiteral node.
+func (s *StringLiteral) String() string {
+	return fmt.Sprintf("%q", s.Value)
+}
+
 // Token returns the token of the Evy source program associated with the
-// ArrayLiteral node.
-func (a *ArrayLiteral) Token() *lexer.Token {
-	return a.token
+// StringLiteral node.
+func (s *StringLiteral) Token() *lexer.Token {
+	return s.token
+}
+
+// Type returns [STRING_TYPE] for StringLiteral as a string literal
+// always has the string type.
+func (s *StringLiteral) Type() *Type {
+	return STRING_TYPE
+}
+
+// NumLiteral is an AST node that represents a numeric literal. A
+// numeric literal is a number, such as 12 or 34.567.
+//
+// NumLiteral implements the [Node] interface.
+type NumLiteral struct {
+	token *lexer.Token
+	Value float64
+}
+
+// String returns a string representation of the NumLiteral node.
+func (n *NumLiteral) String() string {
+	return strconv.FormatFloat(n.Value, 'f', -1, 64)
+}
+
+// Token returns the token of the Evy source program associated with the
+// NumLiteral node.
+func (n *NumLiteral) Token() *lexer.Token {
+	return n.token
+}
+
+// Type returns [NUM_TYPE] for NumLiteral as a number literal always has
+// the num type.
+func (n *NumLiteral) Type() *Type {
+	return NUM_TYPE
 }
 
 // ArrayLiteral is an AST node that represents an array literal, such
@@ -475,10 +999,33 @@ type ArrayLiteral struct {
 	T        *Type
 }
 
+// String returns a string representation of the ArrayLiteral node.
+func (a *ArrayLiteral) String() string {
+	elements := make([]string, len(a.Elements))
+	for i, e := range a.Elements {
+		elements[i] = e.String()
+	}
+	return "[" + strings.Join(elements, ", ") + "]"
+}
+
 // Token returns the token of the Evy source program associated with the
-// MapLiteral node.
-func (m *MapLiteral) Token() *lexer.Token {
-	return m.token
+// ArrayLiteral node.
+func (a *ArrayLiteral) Token() *lexer.Token {
+	return a.token
+}
+
+// Type returns the type of the array literal, such as []num for [1 2 3].
+func (a *ArrayLiteral) Type() *Type {
+	return a.T
+}
+
+func (a *ArrayLiteral) infer() {
+	a.T = a.T.infer()
+	for _, el := range a.Elements {
+		if inf, ok := el.(inferrer); ok {
+			inf.infer()
+		}
+	}
 }
 
 // MapLiteral is an AST node that represents a map literal. A map
@@ -492,6 +1039,36 @@ type MapLiteral struct {
 	T     *Type
 }
 
+// String returns a string representation of the MapLiteral node.
+func (m *MapLiteral) String() string {
+	pairs := make([]string, 0, len(m.Pairs))
+	for _, key := range m.Order {
+		val := m.Pairs[key]
+		pairs = append(pairs, key+":"+val.String())
+	}
+	return "{" + strings.Join(pairs, ", ") + "}"
+}
+
+// Token returns the token of the Evy source program associated with the
+// MapLiteral node.
+func (m *MapLiteral) Token() *lexer.Token {
+	return m.token
+}
+
+// Type returns the type of the map literal such as {}num for {a:1 b:2}.
+func (m *MapLiteral) Type() *Type {
+	return m.T
+}
+
+func (m *MapLiteral) infer() {
+	m.T = m.T.infer()
+	for _, val := range m.Pairs {
+		if inf, ok := val.(inferrer); ok {
+			inf.infer()
+		}
+	}
+}
+
 // Any is an AST node that wraps literals and non-any variables if the target
 // assignable requires it.
 type Any struct {
@@ -499,15 +1076,15 @@ type Any struct {
 	Value Node
 }
 
-// Type always returns [ANY_TYPE].
-func (*Any) Type() *Type { return ANY_TYPE }
+// String returns a string representation of the Program node.
+func (a *Any) String() string { return "any(" + a.Value.String() + ")" }
 
 // Token returns the token of the Evy source program associated with the
 // Any node.
 func (a *Any) Token() *lexer.Token { return a.Value.Token() }
 
-// String returns a string representation of the Program node.
-func (a *Any) String() string { return "any(" + a.Value.String() + ")" }
+// Type always returns [ANY_TYPE].
+func (*Any) Type() *Type { return ANY_TYPE }
 
 type inferrer interface {
 	infer()
@@ -612,586 +1189,9 @@ func isConst(node Node) bool {
 	return false
 }
 
-// Token returns the token of the Evy source program associated with the
-// Program node.
-func (p *Program) Token() *lexer.Token {
-	return p.token
-}
-
-// String returns a string representation of the Program node.
-func (p *Program) String() string {
-	return newlineList(p.Statements)
-}
-
-// Format returns a string of the formatted program with consistent
-// indentation and vertical whitespace.
-func (p *Program) Format() string {
-	var sb strings.Builder
-	p.formatting.w = &sb
-	p.formatting.format(p)
-	return sb.String()
-}
-
-// Type returns [NONE_TYPE] for Program because a program does not have
-// a type.
-func (*Program) Type() *Type {
-	return NONE_TYPE
-}
-
-func (p *Program) alwaysTerminates() bool {
-	return p.alwaysTerms
-}
-
-// Token returns the token of the Evy source program associated with the
-// EmptyStmt node.
-func (e *EmptyStmt) Token() *lexer.Token {
-	return e.token
-}
-
-// String returns a string representation of the EmptyStmt node.
-func (e *EmptyStmt) String() string {
-	return ""
-}
-
-// Type returns [NONE_TYPE] for EmptyStmt because the empty statement
-// does not have a type.
-func (*EmptyStmt) Type() *Type { return NONE_TYPE }
-
-// Token returns the token of the Evy source program associated with the
-// FuncCall node.
-func (f *FuncCall) Token() *lexer.Token {
-	return f.token
-}
-
-// String returns a string representation of the FuncCall node.
-func (f *FuncCall) String() string {
-	s := make([]string, len(f.Arguments))
-	for i, arg := range f.Arguments {
-		s[i] = arg.String()
-	}
-	args := strings.Join(s, ", ")
-	return f.Name + "(" + args + ")"
-}
-
-// Type returns the return type of the called function.
-func (f *FuncCall) Type() *Type {
-	return f.FuncDef.ReturnType
-}
-
-// Token returns the token of the Evy source program associated with the
-// FuncCallStmt node.
-func (f *FuncCallStmt) Token() *lexer.Token {
-	return f.token
-}
-
-// String returns a string representation of the FuncCallStmt node.
-func (f *FuncCallStmt) String() string {
-	return f.FuncCall.String()
-}
-
-// Type returns the return type of the called function.
-func (f *FuncCallStmt) Type() *Type {
-	return f.FuncCall.FuncDef.ReturnType
-}
-
-// Token returns the token of the Evy source program associated with the
-// UnaryExpression node.
-func (u *UnaryExpression) Token() *lexer.Token {
-	return u.token
-}
-
-// String returns a string representation of the UnaryExpression node.
-func (u *UnaryExpression) String() string {
-	return "(" + u.Op.String() + u.Right.String() + ")"
-}
-
-// Type returns the type of the UnaryExpression, such as bool or num.
-func (u *UnaryExpression) Type() *Type {
-	return u.Right.Type()
-}
-
-// Token returns the token of the Evy source program associated with the
-// BinaryExpression node.
-func (b *BinaryExpression) Token() *lexer.Token {
-	return b.token
-}
-
-// String returns a string representation of the BinaryExpression node.
-func (b *BinaryExpression) String() string {
-	if b.Op == OP_AND || b.Op == OP_OR {
-		return "(" + b.Left.String() + " " + b.Op.String() + " " + b.Right.String() + ")"
-	}
-	return "(" + b.Left.String() + b.Op.String() + b.Right.String() + ")"
-}
-
-// Type returns the type of the BinaryExpression, such as bool, num or string.
-func (b *BinaryExpression) Type() *Type {
-	return b.T
-}
-
-func (b *BinaryExpression) infer() {
-	if b.T == EMPTY_ARRAY {
-		b.T = &Type{Name: ARRAY, Sub: ANY_TYPE}
-	}
-}
-
-// Token returns the token of the Evy source program associated with the
-// IndexExpression node.
-func (i *IndexExpression) Token() *lexer.Token {
-	return i.token
-}
-
-// String returns a string representation of the IndexExpression node.
-func (i *IndexExpression) String() string {
-	return "(" + i.Left.String() + "[" + i.Index.String() + "])"
-}
-
-// Type returns the type of the IndexExpression, for example num for an
-// array of numbers with type []num.
-func (i *IndexExpression) Type() *Type {
-	return i.T
-}
-
-// Token returns the token of the Evy source program associated with the
-// SliceExpression node.
-func (s *SliceExpression) Token() *lexer.Token {
-	return s.token
-}
-
-// String returns a string representation of the SliceExpression node.
-func (s *SliceExpression) String() string {
-	start := ""
-	if s.Start != nil {
-		start = s.Start.String()
-	}
-	end := ""
-	if s.End != nil {
-		end = s.End.String()
-	}
-	return "(" + s.Left.String() + "[" + start + ":" + end + "])"
-}
-
-// Type returns the type of the SliceExpression, which is the same type
-// as the array that is sliced or string if a string is sliced.
-func (s *SliceExpression) Type() *Type {
-	return s.T
-}
-
-// Token returns the token of the Evy source program associated with the
-// DotExpression node.
-func (d *DotExpression) Token() *lexer.Token {
-	return d.token
-}
-
-// String returns a string representation of the DotExpression node.
-func (d *DotExpression) String() string {
-	return "(" + d.Left.String() + "." + d.Key + ")"
-}
-
-// Type returns the type of the DotExpression, which is the type of the
-// map's values. For map := {a: true}, the type of map.a is bool.
-func (d *DotExpression) Type() *Type {
-	return d.T
-}
-
-// Token returns the token of the Evy source program associated with the
-// TypeAssertion node.
-func (t *TypeAssertion) Token() *lexer.Token {
-	return t.token
-}
-
-// String returns a string representation of the TypeAssertion node.
-func (t *TypeAssertion) String() string {
-	return "(" + t.Left.String() + "." + "(" + t.T.String() + ")" + ")"
-}
-
-// Type returns the type of the TypeAssertion, which is the type that is
-// asserted.
-func (t *TypeAssertion) Type() *Type {
-	return t.T
-}
-
-// Token returns the token of the Evy source program associated with the
-// GroupExpression node.
-func (d *GroupExpression) Token() *lexer.Token {
-	return d.token
-}
-
-// String returns a string representation of the GroupExpression node.
-func (d *GroupExpression) String() string {
-	return d.Expr.String()
-}
-
-// Type returns the type of the GroupExpression, for example num for
-// 2*(3+4).
-func (d *GroupExpression) Type() *Type {
-	return d.Expr.Type()
-}
-
-func (d *GroupExpression) infer() {
-	if d.Type() == EMPTY_ARRAY {
-		d.Expr.(inferrer).infer()
-	}
-}
-
-// Token returns the token of the Evy source program associated with the
-// Decl node.
-func (d *Decl) Token() *lexer.Token {
-	return d.token
-}
-
-// String returns a string representation of the Decl node.
-func (d *Decl) String() string {
-	if d.Value == nil {
-		return d.Var.String()
-	}
-	return d.Var.String() + "=" + d.Value.String()
-}
-
-// Type returns the type of the variable that is declared.
-func (d *Decl) Type() *Type {
-	return d.Var.T
-}
-
-// Token returns the token of the Evy source program associated with the
-// TypedDeclStmt node.
-func (d *TypedDeclStmt) Token() *lexer.Token {
-	return d.token
-}
-
-// String returns a string representation of the TypedDeclStmt node.
-func (d *TypedDeclStmt) String() string {
-	return d.Decl.String()
-}
-
-// Type returns the type of the variable that is declared.
-func (d *TypedDeclStmt) Type() *Type {
-	return d.Decl.Var.T
-}
-
-// Token returns the token of the Evy source program associated with the
-// InferredDeclStmt node.
-func (d *InferredDeclStmt) Token() *lexer.Token {
-	return d.token
-}
-
-// String returns a string representation of the InferredDeclStmt node.
-func (d *InferredDeclStmt) String() string {
-	return d.Decl.String()
-}
-
-// Type returns the type of the variable that is declared.
-func (d *InferredDeclStmt) Type() *Type {
-	return d.Decl.Var.T
-}
-
-// Token returns the token of the Evy source program associated with the
-// ReturnStmt node.
-func (r *ReturnStmt) Token() *lexer.Token {
-	return r.token
-}
-
-// String returns a string representation of the ReturnStmt node.
-func (r *ReturnStmt) String() string {
-	if r.Value == nil {
-		return "return"
-	}
-	return "return " + r.Value.String()
-}
-
-// Type returns the type of the value returned by the return statement.
-func (r *ReturnStmt) Type() *Type {
-	return r.T
-}
-
-func (*ReturnStmt) alwaysTerminates() bool {
-	return true
-}
-
-// Token returns the token of the Evy source program associated with the
-// BreakStmt node.
-func (b *BreakStmt) Token() *lexer.Token {
-	return b.token
-}
-
-// String returns a string representation of the eakStmt node.
-func (*BreakStmt) String() string {
-	return "break"
-}
-
-// Type returns [NONE_TYPE] for BreakStmt because the empty statement
-// does not have a type.
-func (*BreakStmt) Type() *Type {
-	return NONE_TYPE
-}
-
-func (b *BreakStmt) alwaysTerminates() bool {
-	return true
-}
-
-// Token returns the token of the Evy source program associated with the
-// AssignmentStmt node.
-func (a *AssignmentStmt) Token() *lexer.Token {
-	return a.token
-}
-
-// String returns a string representation of the AssignmentStmt node.
-func (a *AssignmentStmt) String() string {
-	return a.Target.String() + " = " + a.Value.String()
-}
-
-// Type returns the type of the variable that is assigned.
-func (a *AssignmentStmt) Type() *Type {
-	return a.Target.Type()
-}
-
-// String returns a string representation of the FuncDefStmt node.
-func (f *FuncDefStmt) String() string {
-	s := make([]string, len(f.Params))
-	for i, param := range f.Params {
-		s[i] = param.String()
-	}
-	params := strings.Join(s, ", ")
-	if f.VariadicParam != nil {
-		params += f.VariadicParam.String() + "..."
-	}
-	signature := f.Name + "(" + params + ")"
-	body := ""
-	if f.Body != nil {
-		body = f.Body.String()
-	}
-	return signature + "{\n" + body + "}\n"
-}
-
-// Type returns the return type of the function.
-func (f *FuncDefStmt) Type() *Type {
-	return f.ReturnType
-}
-
-// String returns a string representation of the IfStmt node.
-func (i *IfStmt) String() string {
-	result := "if " + i.IfBlock.String()
-	for _, elseif := range i.ElseIfBlocks {
-		result += "else if" + elseif.String()
-	}
-	if i.Else != nil {
-		result += "else {\n" + i.Else.String() + "}\n"
-	}
-	return result
-}
-
-// Type returns [NONE_TYPE] for IfStmt because an if statement doest not
-// have a type.
-func (i *IfStmt) Type() *Type {
-	return NONE_TYPE
-}
-
-func (i *IfStmt) alwaysTerminates() bool {
-	if i.Else == nil || !i.Else.alwaysTerminates() {
-		return false
-	}
-	if !i.IfBlock.alwaysTerminates() {
-		return false
-	}
-	for _, b := range i.ElseIfBlocks {
-		if !b.alwaysTerminates() {
-			return false
-		}
-	}
-	return true
-}
-
-// String returns a string representation of the EventHandlerStmt node.
-func (e *EventHandlerStmt) String() string {
-	body := e.Body.String()
-	return "on " + e.Name + " {\n" + body + "}\n"
-}
-
-// Type returns [NONE_TYPE] for EventHandlerStmt because an event
-// handler definition does not have a type.
-func (e *EventHandlerStmt) Type() *Type {
-	return NONE_TYPE
-}
-
-// String returns a string representation of the Var node.
-func (v *Var) String() string {
-	return v.Name
-}
-
-// Type returns the type of the variable.
-func (v *Var) Type() *Type {
-	return v.T
-}
-
-// String returns a string representation of the BlockStatement node.
-func (b *BlockStatement) String() string {
-	return newlineList(b.Statements)
-}
-
-// Type returns [NONE_TYPE] for BlockStatement because a block statement
-// does not have a type.
-func (b *BlockStatement) Type() *Type {
-	return NONE_TYPE
-}
-
-func (b *BlockStatement) alwaysTerminates() bool {
-	return b.alwaysTerms
-}
-
 func alwaysTerms(n Node) bool {
 	r, ok := n.(interface{ alwaysTerminates() bool })
 	return ok && r.alwaysTerminates()
-}
-
-// String returns a string representation of the WhileStmt node.
-func (w *WhileStmt) String() string {
-	return "while " + w.ConditionalBlock.String()
-}
-
-// Type returns [NONE_TYPE] for WhileStmt because a while statement does
-// not have a type.
-func (w *WhileStmt) Type() *Type {
-	return NONE_TYPE
-}
-
-func (*WhileStmt) alwaysTerminates() bool {
-	return false
-}
-
-// String returns a string representation of the ForStmt node.
-func (f *ForStmt) String() string {
-	header := "for "
-	if f.LoopVar != nil {
-		header += f.LoopVar.Name + " := "
-	}
-	header += f.Range.String()
-	return header + " {\n" + f.Block.String() + "}"
-}
-
-// Type returns [NONE_TYPE] for ForStmt because a while statement does
-// not have a type.
-func (f *ForStmt) Type() *Type {
-	return NONE_TYPE
-}
-
-// String returns a string representation of the StepRange node.
-func (s *StepRange) String() string {
-	start := "0"
-	if s.Start != nil {
-		start = s.Start.String()
-	}
-	stop := s.Stop.String()
-	step := "1"
-	if s.Step != nil {
-		step = s.Step.String()
-	}
-	return start + " " + stop + " " + step
-}
-
-// Type returns [NUM_TYPE] for StepRange as a step range always
-// represents a set of number value.
-func (s *StepRange) Type() *Type {
-	return NUM_TYPE
-}
-
-func (*ForStmt) alwaysTerminates() bool {
-	return false
-}
-
-// String returns a string representation of the ConditionalBlock node.
-func (c *ConditionalBlock) String() string {
-	condition := "(" + c.Condition.String() + ")"
-	return condition + " {\n" + c.Block.String() + "}"
-}
-
-// Type returns [NONE_TYPE] for ConditionalBlock because a conditional
-// block statement does not have a type.
-func (c *ConditionalBlock) Type() *Type {
-	return NONE_TYPE
-}
-
-func (c *ConditionalBlock) alwaysTerminates() bool {
-	return c.Block.alwaysTerminates()
-}
-
-// String returns a string representation of the BoolLiteral node.
-func (b *BoolLiteral) String() string {
-	return strconv.FormatBool(b.Value)
-}
-
-// Type returns [BOOL_TYPE] for BoolLiteral as a bool literal always has
-// the bool type.
-func (b *BoolLiteral) Type() *Type {
-	return BOOL_TYPE
-}
-
-// String returns a string representation of the NumLiteral node.
-func (n *NumLiteral) String() string {
-	return strconv.FormatFloat(n.Value, 'f', -1, 64)
-}
-
-// Type returns [NUM_TYPE] for NumLiteral as a number literal always has
-// the num type.
-func (n *NumLiteral) Type() *Type {
-	return NUM_TYPE
-}
-
-// String returns a string representation of the StringLiteral node.
-func (s *StringLiteral) String() string {
-	return fmt.Sprintf("%q", s.Value)
-}
-
-// Type returns [STRING_TYPE] for StringLiteral as a string literal
-// always has the string type.
-func (s *StringLiteral) Type() *Type {
-	return STRING_TYPE
-}
-
-// String returns a string representation of the ArrayLiteral node.
-func (a *ArrayLiteral) String() string {
-	elements := make([]string, len(a.Elements))
-	for i, e := range a.Elements {
-		elements[i] = e.String()
-	}
-	return "[" + strings.Join(elements, ", ") + "]"
-}
-
-// Type returns the type of the array literal, such as []num for [1 2 3].
-func (a *ArrayLiteral) Type() *Type {
-	return a.T
-}
-
-func (a *ArrayLiteral) infer() {
-	a.T = a.T.infer()
-	for _, el := range a.Elements {
-		if inf, ok := el.(inferrer); ok {
-			inf.infer()
-		}
-	}
-}
-
-// String returns a string representation of the MapLiteral node.
-func (m *MapLiteral) String() string {
-	pairs := make([]string, 0, len(m.Pairs))
-	for _, key := range m.Order {
-		val := m.Pairs[key]
-		pairs = append(pairs, key+":"+val.String())
-	}
-	return "{" + strings.Join(pairs, ", ") + "}"
-}
-
-// Type returns the type of the map literal such as {}num for {a:1 b:2}.
-func (m *MapLiteral) Type() *Type {
-	return m.T
-}
-
-func (m *MapLiteral) infer() {
-	m.T = m.T.infer()
-	for _, val := range m.Pairs {
-		if inf, ok := val.(inferrer); ok {
-			inf.infer()
-		}
-	}
 }
 
 func newlineList(nodes []Node) string {


### PR DESCRIPTION
Reorder methods in ast.go, such that they all come straight after the
receivers type definition. Publich methods, alphabetically sorted come first,
then private methods.

This is a pure code movement - nothing added or removed. It is only made for
readability.