### PR TITLE
parser: Abort parsing for invalid function signatures

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -22,8 +22,11 @@ type Builtins struct {
 // and returns program's AST.
 func Parse(input string, builtins Builtins) (*Program, error) {
 	parser := newParser(input, builtins)
+	if len(parser.errors) > 0 {
+		return nil, parser.errors
+	}
 	prog := parser.parse()
-	if parser.errors != nil {
+	if len(parser.errors) > 0 {
 		return nil, parser.errors
 	}
 	return prog, nil

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -1584,6 +1585,25 @@ fn {x:a}
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error())
 	}
+}
+
+func TestBadFuncSignature(t *testing.T) {
+	input := `
+left_pos := {x:0 y:50}
+
+func draw_paddle paddle:map
+    print paddle.x paddle.y-10
+end
+
+draw_paddle left_pos
+`
+	_, err := Parse(input, testBuiltins())
+	parseErrors := &Errors{}
+	assert.Equal(t, true, errors.As(err, parseErrors))
+
+	got := (*parseErrors)[0].Error()
+	want := `line 4 column 18: invalid type declaration for "paddle"`
+	assert.Equal(t, want, got)
 }
 
 func TestDemo(t *testing.T) {


### PR DESCRIPTION
There is a prepare step parsing all function signatures. If an error is
encountered in this stage, abort further parsing. This addresses a bug report
as covered in the added test.

Thank you @alecthomas for the report.