### PR TITLE
housekeeping: Improve docs and make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ NODELIB = .hermit/node/lib
 frontend: tiny | $(O)
 	rm -rf $(O)/public
 	cp -r frontend $(O)/public
+	echo '{ "version": "$(VERSION)" }' | jq > $(O)/public/version.json
 
 ## Build frontend and serve on free port
 frontend-serve: frontend

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/evylang.dev/evy.svg)](https://pkg.go.dev/evylang.dev/evy)
 [![GitHub Sponsorship](https://img.shields.io/badge/sponsor-%E2%99%A5-eb5c95?style=flat-square&logo=github&logoColor=white)](https://github.com/sponsors/evylang)
 
-Evy is a simple programming language, made to learn coding.
+Evy is a simple programming language, made to learn coding. [Try it out].
 
 Evy bridges the gap between block-based languages like [Scratch] and
 conventional languages like Python or JavaScript. It has a minimalist
@@ -15,6 +15,7 @@ programming languages. Evy has a small set of
 remember, but it still is powerful enough for user interaction, games,
 and animations.
 
+[Try it out]: https://evy.dev/play
 [Scratch]: https://scratch.mit.edu/
 
 ## 🌱 Getting Started

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://evy.dev/discord)
 [![GitHub Build](https://img.shields.io/github/actions/workflow/status/evylang/evy/cicd.yaml?style=flat-square&branch=main&logo=github)](https://github.com/evylang/evy/actions/workflows/cicd.yaml?query=branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/evylang.dev/evy.svg)](https://pkg.go.dev/evylang.dev/evy)
-[![GitHub Sponsorship](https://img.shields.io/badge/sponsor-%E2%9D%A4-eb5c95?style=flat-square&logo=github&logoColor=white)](https://github.com/sponsors/evylang)
+[![GitHub Sponsorship](https://img.shields.io/badge/sponsor-%E2%99%A5-eb5c95?style=flat-square&logo=github&logoColor=white)](https://github.com/sponsors/evylang)
 
 Evy is a simple programming language, made to learn coding.
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,0 +1,30 @@
+# Releasing
+
+Evy automatically releases with every new merge to the `main` branch on GitHub.
+This process publishes artifacts for all major operating systems and
+architectures under [releases] as part of a successful CI run. Additionally,
+the `evylang/tap/evy` brew formula is updated to the latest version.
+
+By default, each release receives a semantic **patch** bump. For example, if the
+latest version is `v0.2.4`, the next one will be `v0.2.5` by default.
+
+To trigger a minor version bump, add a new file to the
+[release-notes directory]. A minor version bump indicates the completion of a
+[milestone]. The release notes file should be named according to the new
+version, for example, `v0.2.0.md`.
+
+To trigger a **minor** version bump a new file must be added to the
+[release-notes directory]. A minor version bump signifies the completion of a
+milestone. The release notes file is named according to the new version, for
+example `v0.2.0.md`.
+
+Evy's current major version is still 0, this may change in the future.
+Evy's language syntax, tooling, and public API are still under development
+and not yet considered stable. Additionally, for major version 0, the meaning
+of patch and minor versions does not conform to the standard
+[semantic versioning specifications].
+
+[releases]: https://github.com/evylang/evy/releases
+[milestone]: https://github.com/evylang/evy/milestones
+[release-notes directory]: https://github.com/evylang/evy/tree/main/docs/release-notes
+[semantic versioning specifications]: https://semver.org/

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -27,6 +27,12 @@
         "destination": "/",
         "type": 301
       }
+    ],
+    "rewrites": [
+      {
+        "source": "/version",
+        "destination": "/version.json"
+      }
     ]
   },
   "emulators": {


### PR DESCRIPTION
- Document release process.
- Make first README.md link point to evy.dev rather than scratch.
- Replace sponsorship red heart emoji with a white one for readability.

Update `make help` awk scripts for multi-line comments on top or rather than
next to target.

Add `/version` endpoint to deployment.

---

Fixes evylang/todo#2
Fixes evylang/todo#3
Fixes evylang/todo#5
Fixes evylang/todo#7
Fixes evylang/todo#8
