### PR TITLE
github: Deploy to prod and stage on merge to main

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    environment: stage
     steps:
       - uses: actions/checkout@v3
         with:
@@ -16,15 +17,15 @@ jobs:
         env:
           TERM: vt100
       - run: ./bin/make firebase-deploy
-        if: ${{ github.event_name == 'pull_request' }} # only run on PR, deploy prod/main in release job
         env:
-          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG_STAGE }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     runs-on: ubuntu-latest
     needs: [ci]
     if: ${{ github.event_name == 'push' }} # only run on push to main
+    environment: prod
     steps:
       - uses: actions/checkout@v3
         with:

--- a/scripts/firebase-deploy
+++ b/scripts/firebase-deploy
@@ -79,8 +79,7 @@ update_links_in_file() {
 	local domain="$1" file="$2" target
 	target="firebase/${file#out/}"
 	sed -E \
-		-e 's href="/(discord|docs|learn|play) href="https://\1.'"${domain} g" \
-		-e 's value="/(discord|docs|learn|play) value="https://\1.'"${domain} g" \
+		-e 's (href|value)="/(discord|docs|learn|play) \1="https://\2.'"${domain} g" \
 		"${file}" >"${target}"
 	diff -u "${file}" "${target}"
 }

--- a/scripts/firebase-deploy
+++ b/scripts/firebase-deploy
@@ -28,12 +28,16 @@ main() {
 	urls=$(get_urls "${result}")
 	printf "Deployed to \n%s\n" "${urls}"
 
-	on_ci && post_pr_comment "${urls}"
+	on_pr && post_pr_comment "${urls}"
 	exit 0
 }
 
 on_ci() {
 	[[ -n "${CI:-}" ]]
+}
+
+on_pr() {
+	on_ci && [[ "${GITHUB_REF:-}" == refs/pull/* ]]
 }
 
 setup_ci_creds() {
@@ -56,13 +60,13 @@ get_channel() {
 	local channel="$1"
 	if [[ -n "${channel}" ]]; then
 		echo "${channel}"
-		return
-	fi
-	if [[ -z "${CI:-}" ]]; then
+	elif on_pr; then
+		get_pr_num
+	elif on_ci; then
+		echo "live"
+	else
 		echo "dev"
-		return
 	fi
-	get_pr_num
 }
 
 get_pr_num() {


### PR DESCRIPTION
Deploy to prod and now also to stage on merge to main. We do this via
separate GitHub environments: prod and stage and different GitHub actions
job using different `FIREBASE_SERVICE_ACCOUNT_EVY_LANG` secrets wired to
the corresponding firebase prod and stage environments.

When the CI job (not the release job!) is run on `main`, rather than
pull-request, we deploy to https://evystage.dev and its live channel,
rather than the PR preview channel. We don't post preview channels to any
PR. This is done via updates to the firebase-deploy script.

While at it, add a minor, non-functional improvement to sed expression in
firebase-deploy script.

I've setup stage and prod GitHub environments `prod` and `stage` separately via
clicky-clicky-admin, hopefully using the correct Firebase Service Account secrets 
and the correct branch protection rule for prod.

---

Fixes https://github.com/evylang/todo/issues/46
