### PR TITLE
deploy: Simplify deployment process

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: ./bin/make ci
         env:
           TERM: vt100
-      - run: ./bin/make firebase-deploy
+      - run: ./bin/make deploy
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
           GITHUB_APP_ID: ${{ secrets.EVYLANGBOT_GITHUB_APP_ID }}
           GITHUB_APP_PEM: ${{ secrets.EVYLANGBOT_GITHUB_APP_PEM }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./bin/make firebase-deploy-prod
+      - run: ./bin/make deploy-prod
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /.hermit/
 /firebase/*.log
 /firebase/.firebase/
-/firebase/public/
 /frontend/evy.wasm
 /frontend/version.json
 /frontend/wasm_exec.js

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /firebase/.firebase/
 /firebase/public/
 /frontend/evy.wasm
+/frontend/version.json
 /frontend/wasm_exec.js
 /out/

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ frontend: tiny | $(O)
 	rm -rf $(O)/public
 	cp -r frontend $(O)/public
 
-## Build frontend and serve on free port
-frontend-serve: frontend
-	servedir $(O)/public
+## Serve frontend on free port
+serve:
+	servedir frontend
 
 ## Format code with prettier
 prettier: | $(NODELIB)
@@ -147,7 +147,7 @@ check-prettier: | $(NODELIB)
 $(NODELIB):
 	@mkdir -p $@
 
-.PHONY: check-prettier frontend frontend-serve prettier
+.PHONY: check-prettier frontend prettier serve
 
 # --- firebase -----------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -144,28 +144,24 @@ $(NODELIB):
 
 .PHONY: check-prettier prettier serve
 
-# --- firebase -----------------------------------------------------------------
+# --- deploy -----------------------------------------------------------------
 
 ## Deploy to live channel on firebase prod, use with care!
 ## `firebase login` for first time local usage
-firebase-deploy-prod: tiny
+deploy-prod: tiny
 	./scripts/firebase-deploy prod live
 
 ## Deploy to live channel on firebase stage.
 ## `firebase login` for first time local usage
-firebase-deploy-stage: tiny
+deploy-stage: tiny
 	./scripts/firebase-deploy stage live
 
 ## Deploy to dev (or other) channel on firebase stage.
 ## `firebase login` for first time local usage
-firebase-deploy: tiny
+deploy: tiny
 	./scripts/firebase-deploy stage
 
-## Run firebase emulator for auth, hosting and datastore
-firebase-emulate: tiny
-	firebase --config firebase/firebase.json emulators:start
-
-.PHONY: firebase-deploy firebase-deploy-prod firebase-deploy-stage firebase-emulate
+.PHONY: deploy deploy-prod deploy-stage
 
 # --- scripts ------------------------------------------------------------------
 SCRIPTS = scripts/firebase-deploy .github/scripts/app_token

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ tiny: go-version | $(O)
 	GOOS=wasip1 GOARCH=wasm tinygo build -o $(O)/evy-unopt.wasm -no-debug -ldflags='$(GO_LDFLAGS)' -stack-size=512kb ./pkg/wasm
 	wasm-opt -O3 $(O)/evy-unopt.wasm -o frontend/evy.wasm
 	cp -f $$(tinygo env TINYGOROOT)/targets/wasm_exec.js frontend/
+	echo '{ "version": "$(VERSION)" }' | jq > frontend/version.json
 
 ## Tidy go modules with "go mod tidy"
 tidy:
@@ -54,6 +55,7 @@ fmt:
 clean::
 	-rm -f frontend/evy.wasm
 	-rm -f frontend/wasm_exec.js
+	-rm -f frontend/version.json
 
 .PHONY: build go-version install tidy tiny
 
@@ -129,7 +131,6 @@ NODELIB = .hermit/node/lib
 frontend: tiny | $(O)
 	rm -rf $(O)/public
 	cp -r frontend $(O)/public
-	echo '{ "version": "$(VERSION)" }' | jq > $(O)/public/version.json
 
 ## Build frontend and serve on free port
 frontend-serve: frontend

--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,6 @@ godoc: install
 # --- frontend -----------------------------------------------------------------
 NODELIB = .hermit/node/lib
 
-## Build frontend, typically iterate with npm and inside frontend
-frontend: tiny | $(O)
-	rm -rf $(O)/public
-	cp -r frontend $(O)/public
-
 ## Serve frontend on free port
 serve:
 	servedir frontend
@@ -147,30 +142,30 @@ check-prettier: | $(NODELIB)
 $(NODELIB):
 	@mkdir -p $@
 
-.PHONY: check-prettier frontend prettier serve
+.PHONY: check-prettier prettier serve
 
 # --- firebase -----------------------------------------------------------------
 
 ## Deploy to live channel on firebase prod, use with care!
 ## `firebase login` for first time local usage
-firebase-deploy-prod: frontend
+firebase-deploy-prod: tiny
 	./scripts/firebase-deploy prod live
 
 ## Deploy to live channel on firebase stage.
 ## `firebase login` for first time local usage
-firebase-deploy-stage: frontend
+firebase-deploy-stage: tiny
 	./scripts/firebase-deploy stage live
 
 ## Deploy to dev (or other) channel on firebase stage.
 ## `firebase login` for first time local usage
-firebase-deploy: frontend
+firebase-deploy: tiny
 	./scripts/firebase-deploy stage
 
 ## Run firebase emulator for auth, hosting and datastore
-firebase-emulate: frontend
+firebase-emulate: tiny
 	firebase --config firebase/firebase.json emulators:start
 
-.PHONY: firebase-deploy firebase-deploy-prod firebase-emulate
+.PHONY: firebase-deploy firebase-deploy-prod firebase-deploy-stage firebase-emulate
 
 # --- scripts ------------------------------------------------------------------
 SCRIPTS = scripts/firebase-deploy .github/scripts/app_token

--- a/scripts/firebase-deploy
+++ b/scripts/firebase-deploy
@@ -14,7 +14,7 @@ main() {
 	environ=$(get_environment "${1:-stage}") || exit $?
 	channel=$(get_channel "${2:-}")
 	rm -rf firebase/public
-	cp -r out/public firebase
+	cp -r frontend firebase/public
 	if [[ "${channel}" == "live" ]]; then
 		update_links "${environ}"
 		# `firebase deploy` must be used with live channel
@@ -81,7 +81,7 @@ get_pr_num() {
 # discord, docs, learn and play.
 update_links_in_file() {
 	local domain="$1" file="$2" target
-	target="firebase/${file#out/}"
+	target="firebase/public/${file#frontend/}"
 	sed -E \
 		-e 's (href|value)="/(discord|docs|learn|play) \1="https://\2.'"${domain} g" \
 		"${file}" >"${target}"
@@ -97,7 +97,7 @@ update_links() {
 	fi
 
 	echo "update links $domain"
-	find out/public -name "*.html" -exec bash -c 'update_links_in_file "$1" "$2"' _ ${domain} {} \;
+	find frontend -name "*.html" -exec bash -c 'update_links_in_file "$1" "$2"' _ ${domain} {} \;
 }
 
 check_deploy_error() {

--- a/scripts/firebase-deploy
+++ b/scripts/firebase-deploy
@@ -13,17 +13,18 @@ main() {
 
 	environ=$(get_environment "${1:-stage}") || exit $?
 	channel=$(get_channel "${2:-}")
-	rm -rf firebase/public
-	cp -r frontend firebase/public
+	rm -rf out/firebase
+	cp -r firebase out/
+	cp -r frontend out/firebase/public
 	if [[ "${channel}" == "live" ]]; then
 		update_links "${environ}"
 		# `firebase deploy` must be used with live channel
-		firebase --config firebase/firebase.json --project "${environ}" deploy --only hosting
+		firebase --config out/firebase/firebase.json --project "${environ}" deploy --only hosting
 		exit 0
 	fi
 
 	# `firebase hosting:channel:deploy` must be used with preview/non-live channels
-	result=$(firebase --json --config firebase/firebase.json --project "${environ}" hosting:channel:deploy "${channel}")
+	result=$(firebase --json --config out/firebase/firebase.json --project "${environ}" hosting:channel:deploy "${channel}")
 	check_deploy_error "${result}"
 	urls=$(get_urls "${result}")
 	printf "Deployed to \n%s\n" "${urls}"
@@ -91,7 +92,7 @@ update_links() {
 # discord, docs, learn and play.
 update_links_in_file() {
 	local domain="$1" file="$2" target
-	target="firebase/public/${file#frontend/}"
+	target="out/firebase/public/${file#frontend/}"
 	sed -E \
 		-e 's (href|value)="/(discord|docs|learn|play) \1="https://\2.'"${domain} g" \
 		"${file}" >"${target}"

--- a/scripts/firebase-deploy
+++ b/scripts/firebase-deploy
@@ -76,6 +76,16 @@ get_pr_num() {
 	echo "${pr_num}"
 }
 
+update_links() {
+	local environ="$1" domain="evystage.dev"
+	if [[ "${environ}" == "prod" ]]; then
+		domain="evy.dev"
+	fi
+
+	echo "update links $domain"
+	find frontend -name "*.html" -exec bash -c 'update_links_in_file "$1" "$2"' _ ${domain} {} \;
+}
+
 # update_links_in_file updates links in the given HTML file to subdomain,
 # e.g.: href="/docs" → href="https://docs.evy.dev" relevant subdomains are:
 # discord, docs, learn and play.
@@ -89,16 +99,6 @@ update_links_in_file() {
 }
 
 export -f update_links_in_file
-
-update_links() {
-	local environ="$1" domain="evystage.dev"
-	if [[ "${environ}" == "prod" ]]; then
-		domain="evy.dev"
-	fi
-
-	echo "update links $domain"
-	find frontend -name "*.html" -exec bash -c 'update_links_in_file "$1" "$2"' _ ${domain} {} \;
-}
 
 check_deploy_error() {
 	local result="$1" status


### PR DESCRIPTION
Simplify deployment process by copying files from `frontend/**` to
`out/firebase/public/**` once only. Copy all firebase configs to out/firebase
and run deployment from there. Clean up various little make things along the
way.