### PR TITLE
e2e: Initialize end to end testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 /.hermit/
+/e2e/test-results
 /firebase/*.log
 /firebase/.firebase/
 /frontend/evy.wasm
 /frontend/version.json
 /frontend/wasm_exec.js
 /out/
+
+node_modules/

--- a/e2e/index.test.js
+++ b/e2e/index.test.js
@@ -1,0 +1,15 @@
+const { test, expect } = require("@playwright/test")
+
+test("title", async ({ page, baseURL }) => {
+  await page.goto(baseURL)
+  await expect(page).toHaveTitle("evy | Playground")
+})
+
+test("console output", async ({ page, baseURL }) => {
+  await page.goto(baseURL)
+  await page.waitForLoadState("networkidle")
+  await page.getByRole("button", { name: "Run" }).click()
+  const console = page.locator("css=#console")
+  await expect(console).toContainText("x: 12")
+  await expect(console).toContainText("🍦 big x")
+})

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@playwright/test": "^1.40.1",
+        "playwright": "^1.40.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.40.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.40.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,7 @@
+{
+  "private": "true",
+  "devDependencies": {
+    "@playwright/test": "^1.40.1",
+    "playwright": "^1.40.1"
+  }
+}

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,6 @@
+const { defineConfig, devices } = require("@playwright/test")
+module.exports = defineConfig({
+  use: {
+    baseURL: process.env.BASEURL || "http://localhost:8080",
+  },
+})


### PR DESCRIPTION
Initialize end to end testing in top level directory e2e. 

**On CI e2 testing runs against https://evy.dev at the moment!**

Initialize `e2e` node package with

    echo '{"private": true}' > e2e/package.json
    npm install --save-dev --prefix e2e playwright
    npm install --save-dev --prefix e2e @playwright/test@latest

Add `node_modules/` to .gitignore.

Add a minimal `index.test.js` test file that loads the Evy playground `index.html`
page. It runs two tests on it:

- ensure the title is `"Evy | Playground"`
- execute `Run` and ensure the console output contains expected contents.

Setup basic playwright test config that will allow to parametrize the `baseURL`
for tests - it expects a `BASEURL` environment variable and falls back to `https://localhost:8080` by default. For local development run

    SERVEDIR_PORT=8080 make serve
 
and in other terminal

    cd e2e; npx playwright test [--ui]

Add `e2e` target to make file, triggered by `ci` target.
If `BASEURL` environment variable is not set, make will set it to `https://evy.dev` 
for now. This allows us to prototype e2e testing until we can extract the per-PR 
preview deployment URL from the firebase-deploy run. 
We will add this in a follow up PR.

Despite concerns it seems that the CI runtime has increased by only less than 30 seconds at this stage.

Part 1/2 for https://github.com/evylang/todo/issues/43