### PR TITLE
github: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @juliaogris @camh-


### PR DESCRIPTION
Add CODEOWNERS file as we are about to add a few more contributors with write
access to the evy repo. We want to make sure that Cam or I have had a look at
a PR before merging.