### PR TITLE
ci: Fix prod workflow to checkout on deploy

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -30,6 +30,9 @@ jobs:
     needs: release
     environment: prod
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: ./bin/make deploy-prod
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}


### PR DESCRIPTION
Checkout the repository on the prod/deploy job so that it can actually
work. This was split off the release job which does the checkout - the
split needed to add the checkout to the new job.