### PR TITLE
bytecode: Create bytecode package

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -1,0 +1,98 @@
+package bytecode
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+const (
+	// OpConstant defines a constant that will be referred to by index
+	// in the bytecode.
+	OpConstant Opcode = iota
+	// OpGetGlobal retrieves a symbol from the symbol table at the
+	// specified index.
+	OpGetGlobal
+	// OpSetGlobal adds a symbol to the specified index in the symbol
+	// table.
+	OpSetGlobal
+)
+
+// ErrUnknownOp is returned when an unknown opcode is encountered.
+var ErrUnknownOp = errors.New("unknown opcode")
+
+// definitions is a mapping of OpCode to OpDefinition.
+var definitions = map[Opcode]*OpDefinition{
+	// The definition for OpConstant says that its only operand is two
+	// bytes wide, which makes it a uint16. This means that an evy
+	// bytecode program can only have 65535 constants defined.
+	OpConstant:  {"OpConstant", []int{2}},
+	OpGetGlobal: {"OpGetGlobal", []int{2}},
+	OpSetGlobal: {"OpSetGlobal", []int{2}},
+}
+
+// OpDefinition defines a name and expected operand width for each OpCode.
+type OpDefinition struct {
+	Name          string
+	OperandWidths []int
+}
+
+// Opcode defines the type of operation to be performed when reading
+// the bytecode.
+type Opcode byte
+
+// Make assembles and returns a single bytecode instruction out
+// of an Opcode and an optional list of operands. An error will
+// be returned if there is no definition for the provided Opcode.
+func Make(op Opcode, operands ...int) ([]byte, error) {
+	def, err := Lookup(op)
+	if err != nil {
+		return nil, err
+	}
+	instructionLen := 1
+	for _, w := range def.OperandWidths {
+		instructionLen += w
+	}
+	instruction := make([]byte, instructionLen)
+	instruction[0] = byte(op)
+	offset := 1
+	for i, o := range operands {
+		width := def.OperandWidths[i]
+		if width == 2 {
+			binary.BigEndian.PutUint16(instruction[offset:], uint16(o))
+		}
+		offset += width
+	}
+	return instruction, nil
+}
+
+// ReadOperands will read from the provided Instructions based on the
+// width of the provided OpDefinition. It returns the operands and the
+// read offset inside the Instructions.
+func ReadOperands(def *OpDefinition, ins Instructions) ([]int, int) {
+	operands := make([]int, len(def.OperandWidths))
+	offset := 0
+	for i, width := range def.OperandWidths {
+		if width == 2 {
+			operands[i] = int(ReadUint16(ins[offset:]))
+		}
+		offset += width
+	}
+	return operands, offset
+}
+
+// ReadUint16 is exposed to allow reading without performing a Lookup to
+// get an OpDefinition to pass to ReadOperands.
+func ReadUint16(ins Instructions) uint16 {
+	return binary.BigEndian.Uint16(ins)
+}
+
+// Lookup returns an OpDefinition for the value of an Opcode, any
+// unknown value will result in an error.
+func Lookup(op Opcode) (*OpDefinition, error) {
+	def, ok := definitions[op]
+	if !ok {
+		return nil, fmt.Errorf("%w: %d", ErrUnknownOp, op)
+	}
+	return def, nil
+}

--- a/pkg/bytecode/code_test.go
+++ b/pkg/bytecode/code_test.go
@@ -1,0 +1,61 @@
+package bytecode
+
+import (
+	"testing"
+
+	"evylang.dev/evy/pkg/assert"
+)
+
+func TestMake(t *testing.T) {
+	tests := []struct {
+		op       Opcode
+		operands []int
+		expected []byte
+	}{
+		{OpConstant, []int{65534}, []byte{byte(OpConstant), 255, 254}},
+	}
+	for _, tt := range tests {
+		instruction, err := Make(tt.op, tt.operands...)
+		assert.NoError(t, err)
+		assert.Equal(t, tt.expected, instruction)
+	}
+}
+
+func TestInstructionsString(t *testing.T) {
+	instructions := []Instructions{
+		mustMake(t, OpConstant, 2),
+		mustMake(t, OpConstant, 65535),
+	}
+	expected := "0000 OpConstant 2\n0003 OpConstant 65535\n"
+	concatted := Instructions{}
+	for _, ins := range instructions {
+		concatted = append(concatted, ins...)
+	}
+	assert.Equal(t, expected, concatted.String(), "instructions wrongly formatted.")
+}
+
+func TestReadOperands(t *testing.T) {
+	tests := []struct {
+		op        Opcode
+		operands  []int
+		bytesRead int
+	}{
+		{OpConstant, []int{65535}, 2},
+	}
+	for _, tt := range tests {
+		instruction, err := Make(tt.op, tt.operands...)
+		assert.NoError(t, err)
+		def, err := Lookup(tt.op)
+		assert.NoError(t, err)
+		operandsRead, read := ReadOperands(def, instruction[1:])
+		assert.Equal(t, read, tt.bytesRead, "wrong num bytes read")
+		assert.Equal(t, tt.operands, operandsRead, "wrong operands")
+	}
+}
+
+func mustMake(t *testing.T, op Opcode, operands ...int) []byte {
+	t.Helper()
+	ins, err := Make(op, operands...)
+	assert.NoError(t, err)
+	return ins
+}

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -1,0 +1,120 @@
+package bytecode
+
+import (
+	"errors"
+	"fmt"
+
+	"evylang.dev/evy/pkg/parser"
+)
+
+// ErrUndefinedVar is returned when a variable name cannot
+// be resolved in the symbol table.
+var ErrUndefinedVar = errors.New("undefined variable")
+
+// Compiler is responsible for turning a parsed evy program into
+// bytecode.
+type Compiler struct {
+	constants    []value
+	instructions Instructions
+	globals      *SymbolTable
+}
+
+// Bytecode represents raw evy bytecode.
+type Bytecode struct {
+	Constants    []value
+	Instructions Instructions
+}
+
+// NewCompiler returns a new compiler.
+func NewCompiler() *Compiler {
+	return &Compiler{
+		constants:    []value{},
+		instructions: Instructions{},
+		globals:      NewSymbolTable(),
+	}
+}
+
+// Compile accepts an AST node and renders it to bytecode internally.
+func (c *Compiler) Compile(node parser.Node) error {
+	switch node := node.(type) {
+	case *parser.Program:
+		return c.compileProgram(node)
+	case *parser.InferredDeclStmt:
+		return c.compileDecl(node.Decl)
+	case *parser.AssignmentStmt:
+		return c.compileAssignment(node)
+	case *parser.Var:
+		return c.compileVar(node)
+	case *parser.NumLiteral:
+		num := &numVal{V: node.Value}
+		if err := c.emit(OpConstant, c.addConstant(num)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Bytecode renders the compiler instructions into Bytecode.
+func (c *Compiler) Bytecode() *Bytecode {
+	return &Bytecode{
+		Instructions: c.instructions,
+		Constants:    c.constants,
+	}
+}
+
+// addConstant appends the provided value to the constants
+// and returns the index of that constant.
+func (c *Compiler) addConstant(obj value) int {
+	c.constants = append(c.constants, obj)
+	return len(c.constants) - 1
+}
+
+// addInstruction appends bytes to the instruction set and returns the
+// position of the instruction.
+func (c *Compiler) addInstruction(ins []byte) {
+	c.instructions = append(c.instructions, ins...)
+}
+
+// emit makes and writes an instruction to the bytecode and returns the
+// position of the instruction.
+func (c *Compiler) emit(op Opcode, operands ...int) error {
+	ins, err := Make(op, operands...)
+	if err != nil {
+		return err
+	}
+	c.addInstruction(ins)
+	return nil
+}
+
+func (c *Compiler) compileProgram(prog *parser.Program) error {
+	for _, s := range prog.Statements {
+		if err := c.Compile(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Compiler) compileDecl(decl *parser.Decl) error {
+	if err := c.Compile(decl.Value); err != nil {
+		return err
+	}
+	symbol := c.globals.Define(decl.Var.Name)
+	return c.emit(OpSetGlobal, symbol.Index)
+}
+
+func (c *Compiler) compileAssignment(stmt *parser.AssignmentStmt) error {
+	if err := c.Compile(stmt.Target); err != nil {
+		return err
+	}
+	symbol := c.globals.Define(stmt.Value.String())
+	return c.emit(OpSetGlobal, symbol.Index)
+}
+
+func (c *Compiler) compileVar(variable *parser.Var) error {
+	symbol, ok := c.globals.Resolve(variable.Name)
+	if !ok {
+		return fmt.Errorf("%w %s", ErrUndefinedVar, variable.Name)
+	}
+	return c.emit(OpGetGlobal, symbol.Index)
+}

--- a/pkg/bytecode/compiler_test.go
+++ b/pkg/bytecode/compiler_test.go
@@ -1,0 +1,88 @@
+package bytecode
+
+import (
+	"testing"
+
+	"evylang.dev/evy/pkg/assert"
+	"evylang.dev/evy/pkg/parser"
+)
+
+type compilerTestCase struct {
+	input                string
+	expectedConstants    []interface{}
+	expectedInstructions []Instructions
+}
+
+func TestGlobalVarStatements(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "x := 1\nx = x",
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []Instructions{
+				mustMake(t, OpConstant, 0),
+				mustMake(t, OpSetGlobal, 0),
+				mustMake(t, OpGetGlobal, 0),
+				mustMake(t, OpSetGlobal, 0),
+			},
+		},
+		{
+			input:             "x := 2\nx = x",
+			expectedConstants: []interface{}{2},
+			expectedInstructions: []Instructions{
+				mustMake(t, OpConstant, 0),
+				mustMake(t, OpSetGlobal, 0),
+				mustMake(t, OpGetGlobal, 0),
+				mustMake(t, OpSetGlobal, 0),
+			},
+		},
+	}
+	for _, tt := range tests {
+		program, err := parser.Parse(tt.input, parser.Builtins{})
+		assert.NoError(t, err, "parser error")
+		compiler := NewCompiler()
+		err = compiler.Compile(program)
+		assert.NoError(t, err, "compiler error")
+		bytecode := compiler.Bytecode()
+		assertInstructions(t, tt.expectedInstructions, bytecode.Instructions)
+		assertConstants(t, tt.expectedConstants, bytecode.Constants)
+	}
+}
+
+func assertInstructions(t *testing.T, expected []Instructions, actual Instructions) {
+	t.Helper()
+	concatted := concatInstructions(expected)
+	assert.Equal(t, len(concatted), len(actual), "wrong instructions length")
+	for i, ins := range concatted {
+		assert.Equal(t, ins, actual[i], "wrong instruction %d", i)
+	}
+}
+
+func concatInstructions(s []Instructions) Instructions {
+	out := Instructions{}
+	for _, ins := range s {
+		out = append(out, ins...)
+	}
+	return out
+}
+
+func assertConstants(t *testing.T, expected []interface{}, actual []value) {
+	t.Helper()
+	assert.Equal(t, len(expected), len(actual), "wrong number of constants")
+	for i, constant := range expected {
+		switch constant := constant.(type) {
+		case int:
+			assertNumValue(t, float64(constant), actual[i])
+		case float64:
+			assertNumValue(t, constant, actual[i])
+		default:
+			t.Errorf("unknown constant type %v", constant)
+		}
+	}
+}
+
+func assertNumValue(t *testing.T, expected float64, actual value) {
+	t.Helper()
+	result, ok := actual.(*numVal)
+	assert.Equal(t, true, ok, "object is not a NumVal. got=%T (%+v)", actual, actual)
+	assert.Equal(t, expected, result.V, "object has wrong value")
+}

--- a/pkg/bytecode/doc.go
+++ b/pkg/bytecode/doc.go
@@ -1,0 +1,14 @@
+// Package bytecode contains a custom bytecode compiler and
+// virtual machine.
+//
+// Initially, an Evy program is turned into a sequence of tokens by the
+// [lexer]. Then, the [parser] generates an Abstract Syntax Tree (AST)
+// from the tokens. The [Compiler] of this package walks the AST and
+// writes the instructions to custom bytecode. For more on the AST
+// refer to the [parser] package documentation.
+//
+// The [VM] can read the bytecode and execute the encoded instructions,
+// providing a runtime similar to the [evaluator]. The virtual machine
+// is a straight-forward stack implementation that does not use any
+// additional registers.
+package bytecode

--- a/pkg/bytecode/instructions.go
+++ b/pkg/bytecode/instructions.go
@@ -1,0 +1,41 @@
+package bytecode
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Instructions represents raw bytecode, which is composed of opcodes
+// and an optional number of operands after each opcode.
+type Instructions []byte
+
+// String prints opcodes and their associated operands.
+func (ins Instructions) String() string {
+	var out bytes.Buffer
+	for i := 0; i < len(ins); {
+		def, err := Lookup(Opcode(ins[i]))
+		if err != nil {
+			panic(err.Error())
+		}
+		operands, read := ReadOperands(def, ins[i+1:])
+		fmt.Fprintf(&out, "%04d %s\n", i, fmtInstruction(def, operands))
+		i += 1 + read
+	}
+	return out.String()
+}
+
+func fmtInstruction(def *OpDefinition, operands []int) string {
+	operandCount := len(def.OperandWidths)
+	if len(operands) != operandCount {
+		return fmt.Sprintf("ERROR: operand len %d does not match defined %d\n",
+			len(operands), operandCount)
+	}
+	switch operandCount {
+	case 0:
+		return def.Name
+	case 1:
+		return fmt.Sprintf("%s %d", def.Name, operands[0])
+	default:
+		return fmt.Sprintf("ERROR: unhandled operandCount for %s\n", def.Name)
+	}
+}

--- a/pkg/bytecode/instructions_test.go
+++ b/pkg/bytecode/instructions_test.go
@@ -1,0 +1,22 @@
+package bytecode
+
+import (
+	"testing"
+
+	"evylang.dev/evy/pkg/assert"
+)
+
+func TestString(t *testing.T) {
+	expected := "0000 OpConstant 0\n"
+	var ins Instructions = mustMake(t, OpConstant, 0)
+	assert.Equal(t, expected, ins.String())
+}
+
+func TestStringUnknownOpcode(t *testing.T) {
+	_, exp := Lookup(0xff)
+	defer func() {
+		assert.Equal(t, exp.Error(), recover())
+	}()
+	var ins Instructions = []byte{0xff, 0x00, 0x00}
+	_ = ins.String()
+}

--- a/pkg/bytecode/symbol.go
+++ b/pkg/bytecode/symbol.go
@@ -1,0 +1,46 @@
+package bytecode
+
+// SymbolScope defines a type of scope that a symbol can be defined inside.
+type SymbolScope string
+
+const (
+	// GlobalScope is the top level scope of an evy program.
+	GlobalScope SymbolScope = "GLOBAL"
+)
+
+// Symbol is a variable inside an evy program.
+type Symbol struct {
+	Name  string
+	Scope SymbolScope
+	Index int
+}
+
+// SymbolTable is a mapping of string identifiers to symbols.
+type SymbolTable struct {
+	store map[string]Symbol
+}
+
+// NewSymbolTable returns a new SymbolTable.
+func NewSymbolTable() *SymbolTable {
+	return &SymbolTable{
+		store: make(map[string]Symbol),
+	}
+}
+
+// Define adds a symbol definition to the table or returns an
+// already defined symbol with the same name.
+func (s *SymbolTable) Define(name string) Symbol {
+	if existing, found := s.store[name]; found {
+		return existing
+	}
+	symbol := Symbol{Name: name, Index: len(s.store), Scope: GlobalScope}
+	s.store[name] = symbol
+	return symbol
+}
+
+// Resolve returns the Symbol with the specified name,
+// or false if there is no such Symbol.
+func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
+	obj, ok := s.store[name]
+	return obj, ok
+}

--- a/pkg/bytecode/symbol_test.go
+++ b/pkg/bytecode/symbol_test.go
@@ -1,0 +1,37 @@
+package bytecode
+
+import (
+	"testing"
+
+	"evylang.dev/evy/pkg/assert"
+)
+
+func TestDefine(t *testing.T) {
+	expected := []Symbol{
+		{Name: "a", Scope: GlobalScope, Index: 0},
+		{Name: "b", Scope: GlobalScope, Index: 1},
+		{Name: "b", Scope: GlobalScope, Index: 1},
+	}
+	global := NewSymbolTable()
+	for _, sym := range expected {
+		actual := global.Define(sym.Name)
+		assert.Equal(t, sym, actual)
+	}
+}
+
+func TestResolveGlobal(t *testing.T) {
+	expected := []Symbol{
+		{Name: "a", Scope: GlobalScope, Index: 0},
+		{Name: "b", Scope: GlobalScope, Index: 1},
+	}
+	global := NewSymbolTable()
+	for _, sym := range expected {
+		global.Define(sym.Name)
+		result, ok := global.Resolve(sym.Name)
+		if !ok {
+			t.Errorf("name %s not resolvable", sym.Name)
+			continue
+		}
+		assert.Equal(t, sym, result, "wrong value for %s")
+	}
+}

--- a/pkg/bytecode/value.go
+++ b/pkg/bytecode/value.go
@@ -1,0 +1,38 @@
+package bytecode
+
+import (
+	"strconv"
+
+	"evylang.dev/evy/pkg/parser"
+)
+
+type value interface {
+	Type() *parser.Type
+	Equals(value) bool
+	String() string
+	Set(value)
+}
+
+type numVal struct {
+	V float64
+}
+
+func (n *numVal) Type() *parser.Type { return parser.NUM_TYPE }
+
+func (n *numVal) String() string { return strconv.FormatFloat(n.V, 'f', -1, 64) }
+
+func (n *numVal) Equals(v value) bool {
+	n2, ok := v.(*numVal)
+	if !ok {
+		panic("internal error: Num.Equals called with non-Num value")
+	}
+	return n.V == n2.V
+}
+
+func (n *numVal) Set(v value) {
+	n2, ok := v.(*numVal)
+	if !ok {
+		panic("internal error: Num.Set called with with non-Num value")
+	}
+	*n = *n2
+}

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -1,0 +1,95 @@
+package bytecode
+
+import (
+	"errors"
+)
+
+const (
+	// StackSize defines an upper limit for the size of the stack.
+	StackSize = 2048
+	// GlobalsSize is the total number of globals that can be specified
+	// in an evy program.
+	GlobalsSize = 65536
+)
+
+// ErrStackOverflow is returned when the stack exceeds its size limit.
+var ErrStackOverflow = errors.New("stack overflow")
+
+// VM is responsible for executing evy programs from bytecode.
+type VM struct {
+	constants    []value
+	globals      []value
+	instructions Instructions
+	stack        []value
+	// sp is the stack pointer and always points to
+	// the next value in the stack. The top of the stack is stack[sp-1].
+	sp int
+}
+
+// NewVM returns a new VM.
+func NewVM(bytecode *Bytecode) *VM {
+	return &VM{
+		constants:    bytecode.Constants,
+		globals:      make([]value, GlobalsSize),
+		instructions: bytecode.Instructions,
+		stack:        make([]value, StackSize),
+		sp:           0,
+	}
+}
+
+// Run executes the provided bytecode instructions in order, any error
+// will stop the execution.
+func (vm *VM) Run() error {
+	for ip := 0; ip < len(vm.instructions); ip++ {
+		// This loop is the hot path of the vm, avoid unnecessary
+		// lookups or memory movement.
+		op := Opcode(vm.instructions[ip])
+		switch op {
+		case OpConstant:
+			constIndex := ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+			err := vm.push(vm.constants[constIndex])
+			if err != nil {
+				return err
+			}
+		case OpGetGlobal:
+			globalIndex := ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+			err := vm.push(vm.globals[globalIndex])
+			if err != nil {
+				return err
+			}
+		case OpSetGlobal:
+			globalIndex := ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+			vm.globals[globalIndex] = vm.pop()
+		}
+	}
+	return nil
+}
+
+// lastPoppedStackElem returns the last element that was
+// popped from the stack. It is used in testing to
+// check that the state of the vm is correct.
+func (vm *VM) lastPoppedStackElem() value {
+	return vm.stack[vm.sp]
+}
+
+func (vm *VM) push(o value) error {
+	if vm.sp >= StackSize {
+		return ErrStackOverflow
+	}
+	vm.stack[vm.sp] = o
+	vm.sp++
+	return nil
+}
+
+func (vm *VM) pop() value {
+	// Ignore stack underflow errors as that indicates an error in the
+	// vm and the out-of-bounds slice panic is sufficient for that,
+	// as opposed to the stack overflow above which can occur due to
+	// a user program that the vm is running.
+	o := vm.stack[vm.sp-1]
+	vm.sp--
+	return o
+}

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -1,0 +1,39 @@
+package bytecode
+
+import (
+	"testing"
+
+	"evylang.dev/evy/pkg/assert"
+	"evylang.dev/evy/pkg/parser"
+)
+
+func TestIntegerArithmetic(t *testing.T) {
+	tests := []vmTestCase{
+		{"x := 1\nx = x", 1},
+		{"y := 2\ny = y", 2},
+	}
+	for _, tt := range tests {
+		program, err := parser.Parse(tt.input, parser.Builtins{})
+		assert.NoError(t, err, "parser error")
+		comp := NewCompiler()
+		err = comp.Compile(program)
+		assert.NoError(t, err, "compiler error")
+		vm := NewVM(comp.Bytecode())
+		err = vm.Run()
+		assert.NoError(t, err, "vm error")
+		stackElem := vm.lastPoppedStackElem()
+		switch expected := tt.expected.(type) {
+		case int:
+			assertNumValue(t, float64(expected), stackElem)
+		case float64:
+			assertNumValue(t, expected, stackElem)
+		default:
+			t.Errorf("unexpected object type %v", expected)
+		}
+	}
+}
+
+type vmTestCase struct {
+	input    string
+	expected interface{}
+}


### PR DESCRIPTION
Create a bytecode package that compiles the parser AST into bytecode
and executes it in a virtual machine. Currently this initial
implementation only supports the simplest evy program; an inferred
type declaration from a constant, followed by an assignment.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>