### PR TITLE
docs: Fix build badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Evy
 
 [![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://evy.dev/discord)
-[![GitHub Build](https://img.shields.io/github/actions/workflow/status/evylang/evy/cicd.yaml?style=flat-square&branch=main&logo=github)](https://github.com/evylang/evy/actions/workflows/cicd.yaml?query=branch%3Amain)
+[![GitHub Build](https://img.shields.io/github/actions/workflow/status/evylang/evy/prod.yaml?style=flat-square&branch=main&logo=github)](https://github.com/evylang/evy/actions/workflows/prod.yaml?query=branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/evylang.dev/evy.svg)](https://pkg.go.dev/evylang.dev/evy)
 [![GitHub Sponsorship](https://img.shields.io/badge/sponsor-%E2%99%A5-eb5c95?style=flat-square&logo=github&logoColor=white)](https://github.com/sponsors/evylang)
 


### PR DESCRIPTION
Fix the build badge in the README as it is currently orange and says "repo or
workflow not found". We have moved `cicd.yaml` to `stage.yaml` and
`prod.yaml` `prod.yaml` is the only workflow used on `main` so use it for
build status.