### PR TITLE
make: Fix circular dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,11 @@ test-tiny: go-version | $(O)
 	tinygo test ./...
 
 ## Check that test coverage meets the required level
-check-coverage: test
+check-coverage: test-go
 	@go tool cover -func=$(COVERFILE) | $(CHECK_COVERAGE) || $(FAIL_COVERAGE)
 
 ## Show test coverage in your browser
-cover: test
+cover: test-go
 	go tool cover -html=$(COVERFILE)
 
 CHECK_COVERAGE = awk -F '[ \t%]+' '/^total:/ {print; if ($$3 < $(COVERAGE)) exit 1}'


### PR DESCRIPTION
Fix the dependency that `check-coverage` and `cover` have on `test`.
This should be `test-go` as the `test` target was changed to `test-go`
in aa0139ed. The circular dependency is due to `make test` depending on
`check-coverage` which then depends on `test`, causing make to emit the
error:

    make: Circular check-coverage <- test dependency dropped.