### PR TITLE
deploy: Rewrite live site generation in Go

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
     - ireturn
     - lll
     - maligned
+    - nestif
     - nlreturn
     - nilnil
     - nosnakecase

--- a/build-tools/firebase-deploy
+++ b/build-tools/firebase-deploy
@@ -13,18 +13,21 @@ main() {
 
 	environ=$(get_environment "${1:-stage}") || exit $?
 	channel=$(get_channel "${2:-}")
+
 	rm -rf out/firebase
 	cp -r firebase out/
-	cp -r frontend out/firebase/public
+
 	if [[ "${channel}" == "live" ]]; then
-		hash_css_js out/firebase/public
-		update_refs "${environ}"
+		local domain
+		[[ "${environ}" == "prod" ]] && domain="evy.dev" || domain="evystage.dev"
+		go run ./build-tools/site-gen --cache-bust --domain="$domain" frontend out/firebase/public
 		# `firebase deploy` must be used with live channel
 		firebase --config out/firebase/firebase.json --project "${environ}" deploy --only hosting
 		on_ci && make_env_urls "${environ}" >>"$GITHUB_ENV"
 		exit 0
 	fi
 
+	go run ./build-tools/site-gen frontend out/firebase/public
 	# `firebase hosting:channel:deploy` must be used with preview/non-live channels
 	result=$(firebase --json --config out/firebase/firebase.json --project "${environ}" hosting:channel:deploy "${channel}")
 	check_deploy_error "${result}"
@@ -78,143 +81,6 @@ get_pr_num() {
 	pr_num=${pr_num#refs/pull/}
 	pr_num=${pr_num%/merge}
 	echo "${pr_num}"
-}
-
-hash_css_js() {
-	local dir="$1" files file hash hashed_file
-	mapfile -t files < <(find "${dir}" -name '*.css' -o -name '*.js')
-	for file in "${files[@]}"; do
-		hash=$(get_hash "${file}")
-		hashed_file="${file%.*}.${hash}.${file##*.}"
-		mv "${file}" "${hashed_file}"
-		ln -s "${hashed_file##*/}" "${file}"
-	done
-}
-
-get_hash() {
-	local file="$1"
-	#  Hashes with 32 bits, or 8 chars[0-9a-f] and 100 file changes in a year
-	#  (cache expiry is one year) has a collision probability of less than
-	#  0.0000000005%.
-	shasum -a 256 "${file}" | cut -c -8
-}
-
-# udpate_refs updates references in hrefs and src attributes and also
-# generates an importmap in all **.html files in the frontend directory.
-update_refs() {
-	local environ="$1" domain="evystage.dev" file htmlfiles
-	if [[ "${environ}" == "prod" ]]; then
-		domain="evy.dev"
-	fi
-	echo "update hrefs for subdomains on $domain"
-	mapfile -t htmlfiles < <(find frontend -name '*.html')
-	for file in "${htmlfiles[@]}"; do
-		update_refs_in_file "${domain}" "${file}"
-	done
-}
-
-# update_refs_in_file updates references in hrefs and src attributes and also
-# generates an importmap in given HTML file.
-update_refs_in_file() {
-	local domain="$1" file="$2" target cssfiles jsfiles modulefiles
-	target="out/firebase/public/${file#frontend/}"
-
-	# TODO this needs to be reworked for `../css/index.css` and other relative file paths.
-	mapfile -t cssfiles < <(cd out/firebase/public && find css -name '*.*.css')
-	mapfile -t jsfiles < <(cd out/firebase/public && find . -name '*.*.js' | cut -c3-)
-	mapfile -t modulefiles < <(cd out/firebase/public && find ./module -name '*.*.js')
-	update_subdomain_href "${domain}" <"${file}" |
-		update_css_href "${cssfiles[@]}" |
-		update_js_src "${jsfiles[@]}" |
-		update_importmap "${modulefiles[@]}" \
-			>"${target}"
-
-	diff -u "${file}" "${target}" || true
-}
-
-# update_subdomain_href replaces hrefs and values starting
-# with /discord, /docs, /learn or /play with the correct subdomain, e.g.:
-#
-#   href="/discord" -> href="https://discord.evy.dev"
-update_subdomain_href() {
-	local domain="$1"
-	sed -E 's (href|value)="/(discord|docs|learn|play) \1="https://\2.'"${domain} g"
-}
-
-# update_css_href updates CSS file name links in the HTML contents provided
-# on stdin and writes the result to stdout.
-#
-# update_css_href takes a list of target CSS file names with hashes as input.
-# Filenames must match "NAME.HASH.css", e.g.: css/index.123bf.css.
-# update_css_href replaces the the unhashed CSS file names with the hashes
-# target CSS filenames:
-#
-#   target: css/index.123bf.css
-#   source: css/index.css
-#   match: <link rel="stylesheet" href="css/index.css" type="text/css" />
-#
-# Using hashed CSS filenames allows to set a long cache lifetime for CSS.
-update_css_href() {
-	local src target args=()
-	for target in "$@"; do
-		src="${target%.*.css}.css"
-		args+=(-e "s href=\"${src}\" href=\"${target}\" ")
-	done
-	sed "${args[@]}"
-}
-
-# update_js_src updates JS file name src attributes in the HTML contents
-# provided on stdin and writes the result to stdout.
-#
-# update_js_src takes a list of target JS file names with hashes as input.
-# Filenames must match "NAME.HASH.js", e.g.: js/index.123bf.js.
-# update_js_src replaces the the unhashed JS file names with the hashes
-# target JS filenames:
-#
-#   target: js/index.123bf.js
-#   source: js/index.js
-#   match: <script src="js/index.js" type="module" defer></script>
-#
-# Using hashed JS filenames allows to set a long cache lifetime for JS.
-update_js_src() {
-	local src target args=()
-	for target in "$@"; do
-		src="${target%.*.js}.js"
-		args+=(-e "s src=\"${src}\" src=\"${target}\" ")
-	done
-	sed "${args[@]}"
-}
-
-# update_importmap generates an [importmap] JSON and places it inside the
-# matched `<script type="importmap></script>` tag.
-#
-# update_importmap takes a list of target JS file names with hashes as input.
-# Filenames must match "js/NAME.HASH.css", e.g.: js/index.123bf.js. The
-# unhashed import has the `js/` directory stripped:
-#
-#   target: js/index.123bf.js
-#   source: index.js
-#   match: <script type="importmap"></script>
-#   generate:
-#   {
-#     "imports": {
-#       "index.js": "js/index.123bf.js",
-#       "yace-editor.js": "js/yace-editor-2346675.js"
-#     }
-#   }
-#
-# [importmap]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
-update_importmap() {
-	local src target args=()
-	for target in "$@"; do
-		src="${target%.*.js}.js"
-		src="${src#js/}"
-		args+=("${src}" "${target}")
-	done
-	printf -v importmap '\\n    "%s": "%s",' "${args[@]}"
-	importmap=${importmap%,}
-	printf -v importmap '\\n{\\n  "imports": {%s\\n  }\\n}' "${importmap}"
-	sed -e "s|^\( *\)<script type=\"importmap\"></script>|\1<script type=\"importmap\">${importmap//\\n/\\n\\1  }\n\1</script>|"
 }
 
 check_deploy_error() {

--- a/build-tools/site-gen/main.go
+++ b/build-tools/site-gen/main.go
@@ -1,0 +1,323 @@
+// Command site-gen generates the website files to be deployed to firebase.
+//
+// Usage: site-gen <src-dir> <dest-dir> <domain>
+//
+// When deploying to firebase (any other hosting site), we need to make a few
+// changes to the HTML, CSS and JS files in the site:
+//   - Replace href/values with leading paths of /discord, /docs, /learn and /play
+//     with a subdomain instead, so /docs/foo with docs.<domain>/foo
+//   - Rename .css, .js and .wasm files to include a short-sha of the SHA256 of the
+//     contents of the file and update any references to those files in .html
+//     files to include the filename with the short-sha. This is to perform
+//     cache busting when the files change.
+//   - Update the importmap in .html files to include the short-sha in the
+//     javascript imports.
+//     e.g. "./module/editor.js": "./module/editor.js"
+//     becomes "./module/editor.js": "./module/editor.1a2b3c4d.js"
+//   - Update the wasmImports map in .html files to include the short-sha in
+//     wasm imports. The wasmImports allows for cache busting hashed filenames
+//     for wasm files. The replacements are of the same form as the importmap.
+//
+// The site generation process copies the source hierarchy to a destination
+// directory and performs these updates as it copies the files.
+package main
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/alecthomas/kong"
+)
+
+type app struct {
+	CacheBust bool   `help:"Rename .css, .js, and .wasm files to include short hash"`
+	Domain    string `help:"Rewrite top-level paths to subdomains"`
+	SrcDir    string `arg:"" required:""`
+	DestDir   string `arg:"" required:""`
+}
+
+func main() {
+	kctx := kong.Parse(&app{})
+	kctx.FatalIfErrorf(kctx.Run())
+}
+
+func (a *app) Run() error {
+	skippedFiles, renamedFiles, err := a.copyTree()
+	if err != nil {
+		return err
+	}
+
+	return a.copyHTMLFiles(skippedFiles, renamedFiles)
+}
+
+// Copy the contents of the `src` filetree to the `dest` directory. When we
+// copy it, files with extension `.css`, `.js`, or `.wasm` are renamed to put a
+// short sha into the name for cache busting purposes (e.g. foo.css ->
+// foo.1a2b3c4d.css). We delay copying html files until after we have walked
+// the src filetree and copy them in a second pass afterwards so that we can
+// update any references to renamed files in them. Return the skipped files
+// (html) and a map of the files we renamed, or an error if something went
+// wrong.
+func (a *app) copyTree() ([]string, map[string]string, error) {
+	skippedFiles := []string{}
+	renamedFiles := make(map[string]string)
+
+	srcFS := os.DirFS(a.SrcDir)
+	err := fs.WalkDir(srcFS, ".", func(filename string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Errors from WalkDir do not include `src` in the path making
+			// the error messages not useful. Add src back in.
+			var pe *fs.PathError
+			if errors.As(err, &pe) {
+				pe.Path = filepath.Join(a.SrcDir, pe.Path)
+				return pe
+			}
+			return err
+		}
+		srcfile := filepath.Join(a.SrcDir, filename)
+		destfile := filepath.Join(a.DestDir, filename)
+		ext := filepath.Ext(filename)
+
+		switch mode := d.Type() & fs.ModeType; mode {
+		case fs.ModeDir:
+			return os.Mkdir(destfile, 0o777) //nolint:gosec // erroneous linter
+		case fs.ModeSymlink:
+			// Treat symlinks as files, duplicating the contents.
+			// This is because sometimes we want to embed the site
+			// into evy and Go embedding will not embed symlinks.
+			// Symlinks to directories are hard (loops, recursion,
+			// nested mappings and so on), so error out if we see
+			// one.
+			target, err := filepath.EvalSymlinks(srcfile)
+			if err != nil {
+				return err
+			}
+			fi, err := os.Stat(target)
+			if err != nil {
+				return err
+			}
+			if fi.Mode()&fs.ModeType == fs.ModeDir {
+				//nolint:goerr113 // dynamic errors in package main is ok
+				return fmt.Errorf("symlink dirs not allowed: %s", srcfile)
+			}
+			// continues past switch to copying files
+
+		case 0: // normal file
+			// handled below
+		default:
+			//nolint:goerr113 // dynamic errors in package main is ok
+			return fmt.Errorf("unknown file type: %s: %s", mode, srcfile)
+		}
+
+		if ext == ".html" {
+			skippedFiles = append(skippedFiles, filename)
+			return nil
+		}
+		if a.CacheBust && (ext == ".js" || ext == ".css" || ext == ".wasm") {
+			shortSha, err := hashFile(srcfile)
+			if err != nil {
+				return err
+			}
+			basename := strings.TrimSuffix(filepath.Base(filename), ext)
+			target := basename + "." + shortSha + ext
+			destfile = filepath.Join(filepath.Dir(destfile), target)
+			if _, ok := renamedFiles[filename]; ok {
+				//nolint:goerr113 // dynamic errors in package main is ok
+				return fmt.Errorf("duplicate filename: %s", srcfile)
+			}
+			renamedFiles[filename] = target
+		}
+		return copyFile(srcfile, destfile)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return skippedFiles, renamedFiles, nil
+}
+
+func (a *app) copyHTMLFiles(skippedFiles []string, renamedFiles map[string]string) error {
+	for _, filename := range skippedFiles {
+		in, out, err := openInOut(filepath.Join(a.SrcDir, filename), filepath.Join(a.DestDir, filename))
+		if err != nil {
+			return err
+		}
+		defer in.Close() //nolint:errcheck // don't care about close failing on read-only files
+		err = a.updateHTMLFile(out, in, filename, renamedFiles)
+		if err != nil {
+			out.Close() //nolint:errcheck,gosec // we're returning the more important error
+			return err
+		}
+		if err := out.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// hashFile returns a short hash of the contents of filename. The short hash is
+// 32 bits, or 8 chars[0-9a-f] and with 100 file changes in a year (cache
+// expiry is one year) has a collision probability of less than 0.0000000005%.
+func hashFile(filename string) (string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck // don't care about close failing on read-only files
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	sha := h.Sum(nil)
+	return hex.EncodeToString(sha[:4]), nil
+}
+
+func openInOut(src, dest string) (io.ReadCloser, io.WriteCloser, error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		in.Close() //nolint:errcheck,gosec // we're returning the more important error
+		return nil, nil, err
+	}
+	return in, out, nil
+}
+
+func copyFile(src, dest string) error {
+	in, out, err := openInOut(src, dest)
+	if err != nil {
+		return err
+	}
+	defer in.Close() //nolint:errcheck // don't care about close failing on read-only files
+	_, err = io.Copy(out, in)
+	if err != nil {
+		out.Close() //nolint:errcheck,gosec // we're returning the more important error
+		return err
+	}
+	return out.Close()
+}
+
+var (
+	subdomainRE = regexp.MustCompile(`(href|value)="/(discord|docs|learn|play)`)
+	jscssRefRE  = regexp.MustCompile(`(href|src)="(.*\.(?:css|js))"`)
+	importmapRE = regexp.MustCompile(`"(.*\.js)": "(.*\.js)"`)
+	wasmmapRE   = regexp.MustCompile(`"(.*\.wasm)": "(.*\.wasm)"`)
+)
+
+// updateHTMLFile reads an HTML file from `r` and writes it to `w` making the
+// following alterations:
+//   - href and value attributes referencing /discord, /docs, /learn and /play
+//     are transformed to top-level domains - discord.<domain>, docs.<domain>,
+//     etc.
+//   - href and src attributes referencing .css or .js files that have been
+//     renamed to include their hash are updated to that name with the hash
+//   - The .js files referenced in an importmap are updated if the referenced
+//     .js file was renamed to include a hash.
+//   - The .wasm files referenced in the wasmImports map are updated if the
+//     referenced .wasm file was renamed to include a hash.
+func (a *app) updateHTMLFile(w io.Writer, r io.Reader, filename string, renamedFiles map[string]string) error {
+	inImportmap := false
+	inWASMImports := false
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Rewrite top-level path to subdomain reference
+		if a.Domain != "" {
+			line = subdomainRE.ReplaceAllString(line, `$1="https://$2.`+a.Domain)
+		}
+
+		if a.CacheBust {
+			// Track if we are in an importmap or wasmimports
+			if strings.Contains(line, `<script type="importmap">`) {
+				inImportmap = true
+			}
+			if inImportmap && strings.Contains(line, `</script>`) {
+				inImportmap = false
+			}
+			if strings.Contains(line, `const wasmImports = {`) {
+				inWASMImports = true
+			}
+			if inWASMImports && strings.Contains(line, `</script>`) {
+				inWASMImports = false
+			}
+
+			line = updateRefs(filename, line, renamedFiles)
+			if inImportmap {
+				line = updateImportMap(filename, line, renamedFiles)
+			}
+			if inWASMImports {
+				line = updateWASMImports(filename, line, renamedFiles)
+			}
+		}
+
+		_, err := w.Write([]byte(line + "\n"))
+		if err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+func updateRefs(filename, line string, renamedFiles map[string]string) string {
+	// Rewrite .js and .css in href and src attributes
+	if matches := jscssRefRE.FindStringSubmatch(line); len(matches) > 0 {
+		newname := getNewName(filename, matches[2], renamedFiles)
+		if newname != "" {
+			replacement := `$1="` + newname + `"`
+			line = jscssRefRE.ReplaceAllString(line, replacement)
+		}
+	}
+	return line
+}
+
+func updateImportMap(filename, line string, renamedFiles map[string]string) string {
+	// Rewrite .js filenames in importmap
+	if matches := importmapRE.FindStringSubmatch(line); len(matches) > 0 {
+		newname := getNewName(filename, matches[2], renamedFiles)
+		if newname != "" {
+			replacement := `"$1": "./` + newname + `"`
+			line = importmapRE.ReplaceAllString(line, replacement)
+		}
+	}
+	return line
+}
+
+func updateWASMImports(filename, line string, renamedFiles map[string]string) string {
+	// Rewrite .wasm filenames in wasm map
+	if matches := wasmmapRE.FindStringSubmatch(line); len(matches) > 0 {
+		newname := getNewName(filename, matches[2], renamedFiles)
+		if newname != "" {
+			replacement := `"$1": "./` + newname + `"`
+			line = wasmmapRE.ReplaceAllString(line, replacement)
+		}
+	}
+	return line
+}
+
+// getNewName returns the filename in `match` that appeared in `filename` as a
+// renamed filename if it appears in `renamedFiles`. e.g. If the file
+// `./play/index.html` contained a match of `../css/fonts.css` and the file
+// `./css/fonts.css` was renamed to `fonts.12345678.css`, getNewName will
+// return `../css/fonts.12345678.css`. If the file referenced by `match` was
+// not renamed, an empty string is returned.
+func getNewName(filename, match string, renamedFiles map[string]string) string {
+	src := filepath.Join(filepath.Dir(filename), filepath.FromSlash(match))
+	target := filepath.Clean(src)
+	hashedName, ok := renamedFiles[target]
+	if !ok {
+		return ""
+	}
+	return path.Join(path.Dir(match), hashedName)
+}

--- a/frontend/play/index.html
+++ b/frontend/play/index.html
@@ -11,7 +11,14 @@
     <link rel="stylesheet" href="css/primary.css" type="text/css" />
     <link rel="stylesheet" href="css/play.css" type="text/css" />
     <link rel="stylesheet" href="css/fonts.css" type="text/css" />
-    <script type="importmap"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "./module/confetti.js": "./module/confetti.js",
+          "./module/editor.js": "./module/editor.js"
+        }
+      }
+    </script>
     <script>
       const wasmImports = {
         // Replaced for cache busting, e.g. as "./module/evy.wasm": "./module/evy.11738cdd.wasm"


### PR DESCRIPTION
Rewrite the part of the `firebase-deploy` shell script that generates
the site in Go. To properly track the file renames in arbitrary
directories was going to get messy in shell, so this does it in Go.

The site generator does:
* Optionally rewrite URLs in `.html` files to some top-level paths to
  subdomains (discord, docs, learn, and play)
* Optionally rename `.js`, `.css` and `.wasm` files to include a
  cache-busting short hash of the content in the filename, and update
  any references to the renamed files in any `.html` files. These
  references include the stylesheet and javascript HTML references as
  well as an embedded javascript importmap and our custom embedded
  wasmImport map.

This adds a restriction that the site must not symlink directories -
instead it should create a directory and symlink the contents. Following
directory symlinks adds a lot of complexity for detecting loops,
recursively walking subtrees and tracking renames across that recursion
that it is much simpler to forbid directory symlinks.

The generated site can be used to deploy to a live firebase channel
(with subdomain rewriting and cache busting), to a PR channel (without
either) or to be embedded in a Go binary (all symlinks removed, no cache
busting or subdomain rewriting).