### PR TITLE
evy: Add serve command

### DIFF
--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -12,10 +12,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: ./bin/make check-uptodate
+      - run: ./bin/make check-uptodate build-go test
         env:
           TERM: vt100
-      - run: ./bin/make test
 
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ VERSION ?= $(shell git describe --tags --dirty  --always)
 GOFILES = $(shell find . -name '*.go')
 
 ## Build, test, check coverage and lint
-all: test lint
+all: build-go test lint
 	@if [ -e .git/rebase-merge ]; then git --no-pager log -1 --pretty='%h %s'; fi
 	@echo '$(COLOUR_GREEN)Success$(COLOUR_NORMAL)'
 
-test: build-go test-go build-tiny test-tiny check-coverage
+test: test-go test-tiny test-cli check-coverage
 
 lint: lint-go lint-sh check-prettier check-style check-fmt-evy
 
@@ -33,11 +33,15 @@ GO_LDFLAGS = -X main.version=$(VERSION)
 CMDS = .
 
 ## Build evy binaries
-build-go: | $(O)
+build-go: embed | $(O)
 	go build -o $(O) -ldflags='$(GO_LDFLAGS)' $(CMDS)
 
 ## Build and install binaries in $GOBIN
-install:
+install: embed
+	go install -ldflags='$(GO_LDFLAGS)' $(CMDS)
+
+## Build and install slim binaries without embedded frontend in $GOBIN
+install-slim: embed-slim
 	go install -ldflags='$(GO_LDFLAGS)' $(CMDS)
 
 # Use `go version` to ensure the right go version is installed when using tinygo.
@@ -52,6 +56,17 @@ build-tiny: go-version | $(O)
 	cp -f $$(tinygo env TINYGOROOT)/targets/wasm_exec.js frontend/module/
 	echo '{ "version": "$(VERSION)" }' | jq > frontend/version.json
 
+## Prepare frontend assets to be embedded into the binary
+embed: build-tiny | $(O)
+	rm -rf $(O)/embed
+	go run ./build-tools/site-gen frontend $(O)/embed
+
+## Prepare slim frontend assets, with placeholder index.html only, to be embedded into the binary
+embed-slim: | $(O)
+	rm -rf $(O)/embed
+	mkdir $(O)/embed
+	cp build-tools/embed-slim-index.html $(O)/embed/index.html
+
 ## Tidy go modules with "go mod tidy"
 tidy:
 	go mod tidy
@@ -65,14 +80,23 @@ clean::
 	-rm -f frontend/module/wasm_exec.js
 	-rm -f frontend/version.json
 
-.PHONY: build-go build-tiny go-version install tidy
+.PHONY: build-go build-tiny embed embed-slim go-version install install-slim tidy
 
 # --- Test ---------------------------------------------------------------------
 COVERFILE = $(O)/coverage.txt
+EXPORTDIR = $(O)/export-test
 
 ## Run non-tinygo tests and generate a coverage file
-test-go: | $(O)
+test-go: embed-slim | $(O)
 	go test -coverprofile=$(COVERFILE) ./...
+
+## Test evy CLI
+test-cli: build-go
+	rm -rf $(EXPORTDIR)
+	$(O)/evy serve export $(EXPORTDIR)
+	test -f $(EXPORTDIR)/index.html
+	test -f $(EXPORTDIR)/play/module/evy.wasm
+	test ! -L $(EXPORTDIR)/play/module/evy.wasm
 
 ## Run tinygo tests
 test-tiny: go-version | $(O)
@@ -89,13 +113,13 @@ cover: test-go
 CHECK_COVERAGE = awk -F '[ \t%]+' '/^total:/ {print; if ($$3 < $(COVERAGE)) exit 1}'
 FAIL_COVERAGE = { echo '$(COLOUR_RED)FAIL - Coverage below $(COVERAGE)%$(COLOUR_NORMAL)'; exit 1; }
 
-.PHONY: check-coverage cover test-go test-tiny
+.PHONY: check-coverage cover test-cli test-go test-tiny
 
 # --- Lint ---------------------------------------------------------------------
 EVY_FILES = $(shell find frontend/play/samples -name '*.evy')
 
 ## Lint go source code
-lint-go:
+lint-go: embed-slim
 	golangci-lint run
 
 ## Format evy sample code
@@ -112,7 +136,7 @@ doc: doctest godoc toc usage
 
 DOCTEST_CMD = ./build-tools/doctest.awk $(md) > $(O)/out.md && mv $(O)/out.md $(md)
 DOCTESTS = docs/builtins.md docs/spec.md
-doctest: install
+doctest: install-slim
 	$(foreach md,$(DOCTESTS),$(DOCTEST_CMD)$(nl))
 
 TOC_CMD = ./build-tools/toc.awk $(md) > $(O)/out.md && mv $(O)/out.md $(md)
@@ -122,12 +146,12 @@ toc:
 
 USAGE_CMD = ./build-tools/gencmd.awk $(md) > $(O)/out.md && mv $(O)/out.md $(md)
 USAGEFILES = docs/usage.md
-usage: install
+usage: install-slim
 	$(foreach md,$(USAGEFILES),$(USAGE_CMD)$(nl))
 
 GODOC_CMD = ./build-tools/gengodoc.awk $(filename) > $(O)/out.go && mv $(O)/out.go $(filename)
 GODOCFILES = main.go
-godoc: install
+godoc: install-slim
 	$(foreach filename,$(GODOCFILES),$(GODOC_CMD)$(nl))
 
 .PHONY: doc doctest godoc toc usage
@@ -242,7 +266,10 @@ fmt-sh:
 
 # --- Release -------------------------------------------------------------------
 ## Tag and release binaries for different OS on GitHub release
-release: nexttag
+# We need to run embed first to generate the full website including evy.wasm
+# for embedding in the go binary. goreleaser build hooks cannot be used as
+# they run in parallel for each os/arch and cause a race condition.
+release: nexttag embed
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)
 	[ -z "$(CI)" ] || GITHUB_TOKEN=$$(.github/scripts/app_token) || exit 1; \

--- a/build-tools/embed-slim-index.html
+++ b/build-tools/embed-slim-index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Evy</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡️</text></svg>"
+    />
+    <style type="text/css">
+      body {
+        margin: 32px auto auto auto;
+        padding: 0 16px 16px;
+        max-width: min(80vw, 30rem);
+        border: 2px solid orange;
+        border-radius: 8px;
+        font-family: arial, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Evy ⚡️</h1>
+    <p>
+      This is a
+      <strong>placeholder</strong>
+      for the Evy website.
+    </p>
+    <p>
+      Follow the
+      <a href="https://github.com/evylang/evy#-installation">installation instructions</a>
+      for an Evy binary with the full website. If you wish to build it yourself, use one of:
+    </p>
+    <ul>
+      <li><code>make release</code></li>
+      <li><code>make install</code></li>
+      <li><code>make build-go</code></li>
+    </ul>
+  </body>
+</html>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,6 +37,12 @@ You can also get help for each subcommand by running it with the
       fmt [<files> ...]
         Format Evy files.
 
+      serve export <dir>
+        Export embedded content
+
+      serve start
+        Start server, default action, use as "evy serve"
+
     Run "evy <command> --help" for more information on a command.
 
 <!-- genend -->

--- a/main.go
+++ b/main.go
@@ -23,6 +23,12 @@
 //	  fmt [<files> ...]
 //	    Format Evy files.
 //
+//	  serve export <dir>
+//	    Export embedded content
+//
+//	  serve start
+//	    Start server, default action, use as "evy serve"
+//
 //	Run "evy <command> --help" for more information on a command.
 //
 // [built-in functions]: https://github.com/evylang/evy/blob/main/docs/builtins.md
@@ -31,12 +37,18 @@ package main
 
 import (
 	"bufio"
+	"embed"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
 	"evylang.dev/evy/pkg/evaluator"
@@ -51,6 +63,9 @@ var (
 	errNotFormatted = errors.New("not formatted")
 	errParse        = errors.New("parse error")
 )
+
+//go:embed out/embed
+var content embed.FS
 
 // cliRuntime implements evaluator.Runtime.
 type cliRuntime struct {
@@ -109,6 +124,7 @@ type app struct {
 	Version kong.VersionFlag `short:"V" help:"Print version information"`
 	Run     runCmd           `cmd:"" help:"Run Evy program."`
 	Fmt     fmtCmd           `cmd:"" help:"Format Evy files."`
+	Serve   serveCmd         `cmd:"" help:"Start Evy server."`
 
 	Tokenize tokenizeCmd `cmd:"" help:"Tokenize evy program" hidden:""`
 	Parse    parseCmd    `cmd:"" help:"Parse evy program" hidden:""`
@@ -132,6 +148,23 @@ type fmtCmd struct {
 	Write bool     `short:"w" help:"update .evy file" xor:"mode"`
 	Check bool     `short:"c" help:"check if already formatted" xor:"mode"`
 	Files []string `arg:"" optional:"" help:"Source files. Default stdin"`
+}
+
+type serveCmd struct {
+	Export exportCmd `help:"Export embedded content" cmd:""`
+	Start  startCmd  `help:"Start server, default action, use as \"evy serve\"" cmd:"" default:"withargs"`
+}
+
+type exportCmd struct {
+	Dir   string `help:"Directory to export embedded content to" short:"d" arg:"" placeholder:"DIR"`
+	Force bool   `help:"Use non-empty directory" short:"f"`
+}
+
+type startCmd struct {
+	Port          int    `help:"Port to listen on" short:"p" default:"8080" env:"EVY_PORT"`
+	AllInterfaces bool   `help:"Listen only on all interfaces not just localhost"  short:"a" env:"EVY_ALL_INTERFACES"`
+	Dir           string `help:"Directory to serve instead of embedded content" short:"d" type:"existingdir" placeholder:"DIR"`
+	Root          string `help:"Directory to use as root for serving, subdirectory of DIR if given, eg \"play\", \"docs\"" placeholder:"DIR"`
 }
 
 type tokenizeCmd struct {
@@ -231,6 +264,101 @@ func format(r io.Reader, w io.StringWriter, checkOnly bool) error {
 	return nil
 }
 
+func (c *startCmd) Run() error {
+	serverRoot, err := c.rootDir()
+	if err != nil {
+		return err
+	}
+	http.Handle("/", http.FileServer(serverRoot))
+	addr := listenAddr(c.Port, c.AllInterfaces)
+	listenAddr, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	server := &http.Server{ReadHeaderTimeout: 30 * time.Second}
+	fmt.Printf("Starting HTTP server on %s\n", listenAddrURL(listenAddr.Addr()))
+	return server.Serve(listenAddr)
+}
+
+func (c *startCmd) rootDir() (http.FileSystem, error) {
+	if c.Dir != "" {
+		dir := filepath.Join(c.Dir, c.Root)
+		return http.Dir(dir), nil
+	}
+	dir := filepath.Join("out/embed", c.Root)
+	root, err := fs.Sub(content, dir)
+	if err != nil {
+		return nil, err
+	}
+	return http.FS(root), nil
+}
+
+func (c *exportCmd) Run() error {
+	if err := validateExportDir(c.Force, c.Dir); err != nil {
+		return err
+	}
+	fsys, err := fs.Sub(content, "out/embed")
+	if err != nil {
+		return err
+	}
+	return syncFS(c.Dir, fsys)
+}
+
+func validateExportDir(force bool, name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close() //nolint:errcheck // don't care about close failing on read-only files
+
+	_, err = f.ReadDir(1)
+	if errors.Is(err, io.EOF) { // empty
+		return nil
+	}
+	if err == nil { // not empty and not force
+		if force {
+			return nil
+		}
+		//nolint:goerr113 // dynamic errors in package main is ok
+		return fmt.Errorf("%q is not empty, use --force", name)
+	}
+	return err
+}
+
+// syncFS writes the contents of source to a directory on disk. It will
+// overwrite any files in the destination directory that have the same name in
+// the source filesystem. It will not touch any existing files in the
+// destination hierarchy that do not exist in the source filesystem.
+func syncFS(destDir string, source fs.FS) error {
+	return fs.WalkDir(source, ".", func(filename string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		dest := filepath.Join(destDir, filename)
+		if d.IsDir() {
+			return os.MkdirAll(dest, 0o777) //nolint:gosec
+		}
+		sf, err := source.Open(filename)
+		if err != nil {
+			return err
+		}
+		defer sf.Close() //nolint:errcheck // don't care about close failing on read-only files
+		df, err := os.Create(dest)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(df, sf)
+		if err != nil {
+			df.Close() //nolint:errcheck,gosec // we're returning the more important error
+			return err
+		}
+		return df.Close()
+	})
+}
+
 // Run implements the hidden `evy tokenize` CLI command, called by the
 // Kong API.
 func (c *tokenizeCmd) Run() error {
@@ -277,4 +405,28 @@ func truncateError(err error) error {
 		return parseErrors.Truncate(8)
 	}
 	return err
+}
+
+func listenAddr(port int, allInterfaces bool) string {
+	if allInterfaces {
+		return fmt.Sprintf(":%d", port)
+	}
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
+func listenAddrURL(address net.Addr) string {
+	addr, ok := address.(*net.TCPAddr)
+	if !ok {
+		return "<unknown address>"
+	}
+	if addr.IP.IsLoopback() {
+		return fmt.Sprintf("http://localhost:%d", addr.Port)
+	}
+	if addr.IP.IsUnspecified() {
+		if h, err := os.Hostname(); err == nil {
+			hostPort := net.JoinHostPort(h, strconv.Itoa(addr.Port))
+			return fmt.Sprintf("http://%s", hostPort)
+		}
+	}
+	return "http://" + addr.String()
 }

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ const description = `
 evy is a tool for managing evy source code.
 `
 
-type config struct {
+type app struct {
 	Version kong.VersionFlag `short:"V" help:"Print version information"`
 	Run     runCmd           `cmd:"" help:"Run Evy program."`
 	Fmt     fmtCmd           `cmd:"" help:"Format Evy files."`
@@ -119,7 +119,7 @@ func main() {
 		kong.Description(description),
 		kong.Vars{"version": version},
 	}
-	kctx := kong.Parse(&config{}, kopts...)
+	kctx := kong.Parse(&app{}, kopts...)
 	kctx.FatalIfErrorf(kctx.Run())
 }
 


### PR DESCRIPTION
Add `evy serve` command, starting a web server, serving the embedded evy website.
This command can also be used to serve the static content of any given directory
with `evy serve --dir`, and export the embedded contents with 
`evy serve export --dir`.

Co-authored-by: Cam Hutchison <camh@xdna.net>