### PR TITLE
docs: Fix various minor issues in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Evy
 
-[![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://evy.dev/discord)
+[![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://discord.evy.dev)
 [![GitHub Build](https://img.shields.io/github/actions/workflow/status/evylang/evy/prod.yaml?style=flat-square&branch=main&logo=github)](https://github.com/evylang/evy/actions/workflows/prod.yaml?query=branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/evylang.dev/evy.svg)](https://pkg.go.dev/evylang.dev/evy)
 [![GitHub Sponsorship](https://img.shields.io/badge/sponsor-%E2%99%A5-eb5c95?style=flat-square&logo=github&logoColor=white)](https://github.com/sponsors/evylang)
@@ -51,7 +51,7 @@ Here are some resources for learning more about Evy:
 
 For questions and discussions, join the [Evy community] on Discord.
 
-[Evy community]: https://evy.dev/discord
+[Evy community]: https://discord.evy.dev
 
 ## 📦 Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,19 @@
 # Documentation
 
-Learn more about Evy
-
-- [Syntax by Example](syntax_by_example.md): Learn the Evy syntax with a collection of examples.
-- [Built-in Documentation](builtins.md): Get details on built-in functions and events in Evy.
-- [Language Specification](spec.md): Read a formal definition of the Evy syntax and language.
-- [`evy` Usage](usage.md): Learn how to use the `evy` command line tool.
-
 Learn programming with Evy
 
 - Check out the [Learn and Practise] resources.
 - Explore the samples on the [Playground] or the [Gallery].
 - Ask questions or discuss Evy in the [Evy community] on Discord.
 
+Learn more about the Evy language and tools
+
+- [Syntax by Example](syntax_by_example.md): Learn the Evy syntax with a collection of examples.
+- [Built-in Documentation](builtins.md): Get details on built-in functions and events in Evy.
+- [Language Specification](spec.md): Read a formal definition of the Evy syntax and language.
+- [`evy` Usage](usage.md): Learn how to use the `evy` command line tool.
+
 [Learn and Practise]: https://github.com/evylang/evy/wiki
 [Playground]: https://play.evy.dev
 [Gallery]: https://github.com/evylang/evy/wiki/gallery
-[Evy community]: https://evy.dev/discord
+[Evy community]: https://discord.evy.dev

--- a/docs/release-notes/v0.1.0.md
+++ b/docs/release-notes/v0.1.0.md
@@ -7,9 +7,9 @@
 - **Documentation** for the Evy language and built-ins is now complete. For more information see:  
   [Overview] | [Language specification] | [Built-ins documentation]
 
-[Try It Out]: https://evy.dev/play
+[Try It Out]: https://play.evy.dev
 [design spec]: https://drive.google.com/file/d/1yFJlt38oykjPNTgRYgcO1YkO90fSsEuW/view?usp=sharing
 [Jason]: https://twitter.com/jasonstrachan
-[Overview]: https://evy.dev/docs
+[Overview]: https://docs.evy.dev
 [Language specification]: https://github.com/evylang/evy/blob/main/docs/spec.md
 [Built-ins documentation]: https://github.com/evylang/evy/blob/main/docs/builtins.md

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,4 +1,4 @@
-# Evy language specification
+# Language Specification
 
 Evy is a [statically typed], [garbage collected],
 [procedural] programming language. Its main design goal is to help

--- a/docs/syntax_by_example.md
+++ b/docs/syntax_by_example.md
@@ -1,4 +1,4 @@
-# Evy Syntax by Example
+# Syntax by Example
 
 The following examples will help you understand the syntax of Evy. For a
 more formal definition of the syntax, see the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,16 +1,17 @@
-# `evy` Usage
+# Command Line Usage
 
-The `evy` toolchain is a set of tools that can be used to parse, run,
-and format Evy source code. You can [install] the Evy toolchain locally
-and run it from your command line. The command-line interface for Evy
-supports all built-in functions except for graphics functions and event
-handlers. Only the web interface on [play.evy.dev] supports graphics and
-events.
+The `evy` toolchain is a set of tools that can be used to parse, run, and
+format Evy source code. It can also be used to serve the Evy web contents
+locally. You can [install] the Evy toolchain locally and run it from your
+command line. The command-line interface for Evy supports all built-in
+functions except for graphics functions and event handlers. Only the web
+interface on [play.evy.dev] supports graphics and events.
 
-The Evy toolchain has two subcommands:
+The Evy toolchain has three subcommands:
 
 - `evy run`: Parse and run Evy source code.
 - `evy fmt`: Format Evy source code.
+- `evy sever`: Format Evy source code.
 
 You can also get help for each subcommand by running it with the
 `--help` flag.
@@ -38,10 +39,10 @@ You can also get help for each subcommand by running it with the
         Format Evy files.
 
       serve export <dir>
-        Export embedded content
+        Export embedded content.
 
       serve start
-        Start server, default action, use as "evy serve"
+        Start web server, default for "evy serve".
 
     Run "evy <command> --help" for more information on a command.
 
@@ -83,5 +84,45 @@ You can also get help for each subcommand by running it with the
 
       -w, --write      update .evy file
       -c, --check      check if already formatted
+
+<!-- genend -->
+
+#### evy serve [start] --help
+
+<!-- gen:evy serve start --help -->
+
+    Usage: evy serve start
+
+    Start web server, default for "evy serve".
+
+    Flags:
+      -h, --help              Show context-sensitive help.
+      -V, --version           Print version information
+
+      -p, --port=8080         Port to listen on ($EVY_PORT)
+      -a, --all-interfaces    Listen only on all interfaces not just localhost
+                              ($EVY_ALL_INTERFACES)
+      -d, --dir=DIR           Directory to serve instead of embedded content
+          --root=DIR          Directory to use as root for serving, subdirectory of
+                              DIR if given, eg "play", "docs"
+
+<!-- genend -->
+
+#### evy serve export --help
+
+<!-- gen:evy serve export --help -->
+
+    Usage: evy serve export <dir>
+
+    Export embedded content.
+
+    Arguments:
+      <dir>    Directory to export embedded content to
+
+    Flags:
+      -h, --help       Show context-sensitive help.
+      -V, --version    Print version information
+
+      -f, --force      Use non-empty directory
 
 <!-- genend -->

--- a/main.go
+++ b/main.go
@@ -24,10 +24,10 @@
 //	    Format Evy files.
 //
 //	  serve export <dir>
-//	    Export embedded content
+//	    Export embedded content.
 //
 //	  serve start
-//	    Start server, default action, use as "evy serve"
+//	    Start web server, default for "evy serve".
 //
 //	Run "evy <command> --help" for more information on a command.
 //
@@ -151,8 +151,8 @@ type fmtCmd struct {
 }
 
 type serveCmd struct {
-	Export exportCmd `help:"Export embedded content" cmd:""`
-	Start  startCmd  `help:"Start server, default action, use as \"evy serve\"" cmd:"" default:"withargs"`
+	Export exportCmd `help:"Export embedded content." cmd:""`
+	Start  startCmd  `help:"Start web server, default for \"evy serve\"." cmd:"" default:"withargs"`
 }
 
 type exportCmd struct {


### PR DESCRIPTION
These issues came up as we were revisiting docs for md2html conversion for
https://docs.evy.dev proper. They include:

* Choose better titles as markdown titles will be used in HTML titles
* Use subdomain URLs, e.g. https://docs.evy.dev instead of https://evy.dev/docs
* Updating the `evy` CLI usage docs to include `evy serve`
* Re-arrange docs overview to be targeted at learners (main target group) and less at developers / experienced people