### PR TITLE
canvas: Fix Nan in move event

### DIFF
--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -768,7 +768,7 @@ function leaveXY(e) {
 }
 
 function clamp(val, min, max) {
-  return Math.min(Math.max(this, min), max)
+  return Math.min(Math.max(val, min), max)
 }
 
 function initEditor() {

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -394,9 +394,7 @@ async function handleHashChange() {
   crumbs && updateBreadcrumbs(crumbs)
   clearOutput()
   await format()
-  // Clear hash right away for the long ugly gzip/b64 content URL fragments,
-  // keep the fragment until the first edit for the rest.
-  opts.content ? clearHash() : editor.onUpdate(clearHash)
+  editor.onUpdate(clearHash)
 }
 
 // parseHash parses URL fragment into object e.g.:


### PR DESCRIPTION
We noticed an issue for the following evy example, where the program would
crash with last reporting a NaN for a the move x-coordinate. I have no idea
how this function ever worked, but now it does 😅.

While at it, remove Hash/fragment removal when accessing shared code snippets.
I've found myself wanting to copy that fragment several times now directly
from the address bar so I'm putting it back.

Issue: https://github.com/evylang/evy/issues/264 
Example:
https://play.evy.dev/#content=H4sIAAAAAAAAE3VRTWvDMAy9+1eI7JIuFJLuFug/6G2XjZCD6ziZmWNDPlb730+W0kAGM9iypaenJyvUTevWUcTNKqvlBNndSvWdCdH7CSbpBg2XUgCuAFfcBTRlS++I77i9teuEmPVw025YvqC+wpsQD9PhvRLKW+TKXnpa9xLJvYPR/2gINVaGmE7i7Cb5wCKRCfvVKXaNfp31B4Hp+rlnHFU/Od71MGq3QLllblkUT42ZJJG7y612EE7nioJ/CUxRQWhMCxEPQiRlR3U7lvQF47gptiwppHoYgTOxsTMmZyTnzo6SrE5+uUh3SZgu8O8nEU+OXPmZoSd4hf3feSwMZN58RvMPkAdw6M0ax64CFUeyPIpf+sznyiwCAAA=

---

Fixed at:

https://evy-lang-stage-play--267-gmiw5cd8.web.app/#content=H4sIAAAAAAAAE3VRTWvDMAy9+1eI7JIuFJLuFug/6G2XjZCD6ziZmWNDPlb730+W0kAGM9iypaenJyvUTevWUcTNKqvlBNndSvWdCdH7CSbpBg2XUgCuAFfcBTRlS++I77i9teuEmPVw025YvqC+wpsQD9PhvRLKW+TKXnpa9xLJvYPR/2gINVaGmE7i7Cb5wCKRCfvVKXaNfp31B4Hp+rlnHFU/Od71MGq3QLllblkUT42ZJJG7y612EE7nioJ/CUxRQWhMCxEPQiRlR3U7lvQF47gptiwppHoYgTOxsTMmZyTnzo6SrE5+uUh3SZgu8O8nEU+OXPmZoSd4hf3feSwMZN58RvMPkAdw6M0ax64CFUeyPIpf+sznyiwCAAA=

