### PR TITLE
parser: Return early on wrong parameters count

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -296,6 +296,9 @@ func (p *parser) addEventParamsToScope(e *EventHandlerStmt) {
 		p.appendError(fmt.Sprintf("wrong number of parameters expected %d, got %d", len(expectedParams), len(e.Params)))
 	}
 	for i, param := range e.Params {
+		if i >= len(expectedParams) {
+			return
+		}
 		p.validateVarDecl(param, param.token, true /* allowUnderscore */)
 		exptectedType := expectedParams[i].Type()
 		if !param.Type().Equals(exptectedType) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1169,6 +1169,10 @@ end
 on down x:num
    print "pointer down:" x
 end`: `line 3 column 4: wrong number of parameters expected 2, got 1`,
+		`
+on down x:num y:num z:num
+    print x y z
+end`: `line 3 column 5: wrong number of parameters expected 2, got 3`,
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())


### PR DESCRIPTION
Return early on wrong event handler parameter count. We track the correct
error but still carry on parsing the parameters in further details which
causes an index out of range exception.

Issue: https://github.com/evylang/evy/issues/262

---

Fixes https://github.com/evylang/evy/issues/262