### PR TITLE
frontend: Fix ios / Safari 16.2 rendering issues

### DIFF
--- a/.hermit/node/.stylelintrc.json
+++ b/.hermit/node/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["stylelint-config-standard"]
+  "extends": ["stylelint-config-standard"],
+  "rules": {
+    "media-feature-range-notation": "prefix"
+  }
 }

--- a/build-tools/site-gen/main.go
+++ b/build-tools/site-gen/main.go
@@ -68,7 +68,7 @@ func (a *app) Run() error {
 // update any references to renamed files in them. Return the skipped files
 // (html) and a map of the files we renamed, or an error if something went
 // wrong.
-func (a *app) copyTree() ([]string, map[string]string, error) {
+func (a *app) copyTree() ([]string, map[string]string, error) { //nolint: gocognit
 	skippedFiles := []string{}
 	renamedFiles := make(map[string]string)
 
@@ -130,12 +130,18 @@ func (a *app) copyTree() ([]string, map[string]string, error) {
 			}
 			basename := strings.TrimSuffix(filepath.Base(filename), ext)
 			target := basename + "." + shortSha + ext
-			destfile = filepath.Join(filepath.Dir(destfile), target)
 			if _, ok := renamedFiles[filename]; ok {
 				//nolint:goerr113 // dynamic errors in package main is ok
 				return fmt.Errorf("duplicate filename: %s", srcfile)
 			}
 			renamedFiles[filename] = target
+			if ext == ".js" {
+				// also keep original JS filename for those who cannot use an `importmap` (e.g. ios 16.2)
+				if err := copyFile(srcfile, destfile); err != nil {
+					return err
+				}
+			}
+			destfile = filepath.Join(filepath.Dir(destfile), target)
 		}
 		return copyFile(srcfile, destfile)
 	})

--- a/frontend/css/index.css
+++ b/frontend/css/index.css
@@ -81,12 +81,12 @@ footer ul {
   gap: 20px;
   width: 100%;
   padding: 20px 0;
+}
 
-  @media (width <= 767px) {
-    & {
-      flex-direction: column;
-      gap: 10px;
-    }
+@media (max-width: 767px) {
+  footer ul {
+    flex-direction: column;
+    gap: 10px;
   }
 }
 

--- a/frontend/css/root.css
+++ b/frontend/css/root.css
@@ -15,9 +15,11 @@
   /* desktop */
   --display-desktop-only: initial;
   --display-mobile-only: none;
+}
 
-  /* mobile */
-  @media (width <= 767px) {
+/* mobile */
+@media (max-width: 767px) {
+  :root {
     --display-desktop-only: none;
     --display-mobile-only: initial;
   }

--- a/frontend/play/css/index.css
+++ b/frontend/play/css/index.css
@@ -47,7 +47,7 @@
   --dialog-width: min(100vw, 36rem);
 }
 
-@media (width <= 767px) {
+@media (max-width: 767px) {
   /* responsive mobile */
   :root {
     --header-img-top: 0.2em;
@@ -458,7 +458,7 @@ dialog .err,
   touch-action: pinch-zoom;
 }
 
-@media (height <= 500px) {
+@media (max-height: 500px) {
   .output .canvas canvas,
   .output .canvas {
     width: calc(100vh - 250px);


### PR DESCRIPTION
Fix ios / Safari 16.2 rendering issues that are related
to older browsers not supporting certain features:

* importmaps
* media queries with `width <= ...`
* nested media queries

---

Fixes https://github.com/evylang/evy/issues/275