### PR TITLE
bytecode: Implement math operators

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -20,6 +20,14 @@ const (
 	OpAdd
 	// OpSubtract instructs the virtual machine to perform a subtraction.
 	OpSubtract
+	// OpMultiply instructs the virtual machine to perform a multiplication.
+	OpMultiply
+	// OpDivide instructs the virtual machine to perform a division.
+	OpDivide
+	// OpModulo instructs the virtual machine to perform a modulo operation.
+	// Modulo returns the remainder of dividing the left side of an expression
+	// by the right.
+	OpModulo
 )
 
 var (
@@ -47,6 +55,9 @@ var definitions = map[Opcode]*OpDefinition{
 	// this instruction.
 	OpAdd:      {"OpAdd", nil},
 	OpSubtract: {"OpSubtract", nil},
+	OpMultiply: {"OpMultiply", nil},
+	OpDivide:   {"OpDivide", nil},
+	OpModulo:   {"OpModulo", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -49,6 +49,8 @@ func (c *Compiler) Compile(node parser.Node) error {
 		return c.compileAssignment(node)
 	case *parser.BinaryExpression:
 		return c.compileBinaryExpression(node)
+	case *parser.GroupExpression:
+		return c.Compile(node.Expr)
 	case *parser.Var:
 		return c.compileVar(node)
 	case *parser.NumLiteral:
@@ -104,7 +106,12 @@ func (c *Compiler) compileBinaryExpression(expr *parser.BinaryExpression) error 
 		return c.emit(OpAdd)
 	case parser.OP_MINUS:
 		return c.emit(OpSubtract)
-		// more operators to follow (*, /, %).
+	case parser.OP_ASTERISK:
+		return c.emit(OpMultiply)
+	case parser.OP_SLASH:
+		return c.emit(OpDivide)
+	case parser.OP_PERCENT:
+		return c.emit(OpModulo)
 	default:
 		return fmt.Errorf("%w %s", ErrUnknownOperator, expr.Op)
 	}


### PR DESCRIPTION
This change follows on from #274 by adding
compiler support for the remaining
mathematical operators in evy. The compiler
must also understand the `parser.GroupExpression`
to expand expressions inside parenthesis.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>