### PR TITLE
bytecode: Implement boolean literals

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -28,6 +28,10 @@ const (
 	// Modulo returns the remainder of dividing the left side of an expression
 	// by the right.
 	OpModulo
+	// OpTrue represents the boolean literal true.
+	OpTrue
+	// OpFalse represents the boolean literal false.
+	OpFalse
 )
 
 var (
@@ -58,6 +62,8 @@ var definitions = map[Opcode]*OpDefinition{
 	OpMultiply: {"OpMultiply", nil},
 	OpDivide:   {"OpDivide", nil},
 	OpModulo:   {"OpModulo", nil},
+	OpTrue:     {"OpTrue", nil},
+	OpFalse:    {"OpFalse", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -58,6 +58,14 @@ func (c *Compiler) Compile(node parser.Node) error {
 		if err := c.emit(OpConstant, c.addConstant(num)); err != nil {
 			return err
 		}
+	case *parser.BoolLiteral:
+		opcode := OpFalse
+		if node.Value {
+			opcode = OpTrue
+		}
+		if err := c.emit(opcode); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/bytecode/value.go
+++ b/pkg/bytecode/value.go
@@ -27,3 +27,19 @@ func (n numVal) Equals(v value) bool {
 	}
 	return n == n2
 }
+
+type boolVal bool
+
+func (boolVal) Type() *parser.Type { return parser.BOOL_TYPE }
+
+func (b boolVal) String() string {
+	return strconv.FormatBool(bool(b))
+}
+
+func (b boolVal) Equals(v value) bool {
+	b2, ok := v.(boolVal)
+	if !ok {
+		panic("internal error: Bool.Equals called with non-Bool value")
+	}
+	return b == b2
+}


### PR DESCRIPTION
Add opcodes for the boolean literals true and false.
This change lays the groundwork for adding logical and
comparison operators. Cognitive complexity within the
Run function became a problem, so checking push errors
outside the switch statement became necessary for readability.


Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>