### PR TITLE
bytecode: Implement unary expressions

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -32,6 +32,12 @@ const (
 	OpTrue
 	// OpFalse represents the boolean literal false.
 	OpFalse
+	// OpNot represents the not unary operator, which performs logical
+	// negation on a boolean operand.
+	OpNot
+	// OpMinus represents the minus unary operator, which negates the
+	// value of a numeric operand.
+	OpMinus
 )
 
 var (
@@ -64,6 +70,8 @@ var definitions = map[Opcode]*OpDefinition{
 	OpModulo:   {"OpModulo", nil},
 	OpTrue:     {"OpTrue", nil},
 	OpFalse:    {"OpFalse", nil},
+	OpNot:      {"OpNot", nil},
+	OpMinus:    {"OpMinus", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -49,6 +49,8 @@ func (c *Compiler) Compile(node parser.Node) error {
 		return c.compileAssignment(node)
 	case *parser.BinaryExpression:
 		return c.compileBinaryExpression(node)
+	case *parser.UnaryExpression:
+		return c.compileUnaryExpression(node)
 	case *parser.GroupExpression:
 		return c.Compile(node.Expr)
 	case *parser.Var:
@@ -123,6 +125,19 @@ func (c *Compiler) compileBinaryExpression(expr *parser.BinaryExpression) error 
 	default:
 		return fmt.Errorf("%w %s", ErrUnknownOperator, expr.Op)
 	}
+}
+
+func (c *Compiler) compileUnaryExpression(expr *parser.UnaryExpression) error {
+	if err := c.Compile(expr.Right); err != nil {
+		return err
+	}
+	switch expr.Op {
+	case parser.OP_MINUS:
+		return c.emit(OpMinus)
+	case parser.OP_BANG:
+		return c.emit(OpNot)
+	}
+	return nil
 }
 
 func (c *Compiler) compileProgram(prog *parser.Program) error {

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -91,6 +91,12 @@ func (vm *VM) Run() error {
 			err = vm.push(boolVal(true))
 		case OpFalse:
 			err = vm.push(boolVal(false))
+		case OpNot:
+			val := vm.popBoolVal()
+			err = vm.push(!val)
+		case OpMinus:
+			val := vm.popNumVal()
+			err = vm.push(-val)
 		}
 		if err != nil {
 			return err
@@ -142,6 +148,18 @@ func (vm *VM) popNumVal() numVal {
 	val, ok := elem.(numVal)
 	if !ok {
 		panic(fmt.Errorf("%w: expected to pop numVal but got %s",
+			ErrInternal, elem.Type()))
+	}
+	return val
+}
+
+// popBoolVal pops an element from the stack and casts it to a bool
+// before returning the value. If elem is not a bool it will error.
+func (vm *VM) popBoolVal() boolVal {
+	elem := vm.pop()
+	val, ok := elem.(boolVal)
+	if !ok {
+		panic(fmt.Errorf("%w: expected to pop boolVal but got %s",
 			ErrInternal, elem.Type()))
 	}
 	return val

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -118,6 +118,22 @@ func TestBoolExpressions(t *testing.T) {
 				mustMake(t, OpSetGlobal, 0),
 			},
 		},
+		{
+			name: "not operator",
+			input: `
+			x := !true
+			x = x
+			`,
+			expectedStackTop:  false,
+			expectedConstants: []any{},
+			expectedInstructions: []Instructions{
+				mustMake(t, OpTrue),
+				mustMake(t, OpNot),
+				mustMake(t, OpSetGlobal, 0),
+				mustMake(t, OpGetGlobal, 0),
+				mustMake(t, OpSetGlobal, 0),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -234,6 +250,22 @@ func TestVMArithmetic(t *testing.T) {
 				mustMake(t, OpConstant, 0),
 				mustMake(t, OpConstant, 1),
 				mustMake(t, OpModulo),
+				mustMake(t, OpSetGlobal, 0),
+				mustMake(t, OpGetGlobal, 0),
+				mustMake(t, OpSetGlobal, 0),
+			},
+		},
+		{
+			name: "minus operator",
+			input: `
+			x := -1
+			x = x
+			`,
+			expectedStackTop:  -1,
+			expectedConstants: []any{1},
+			expectedInstructions: []Instructions{
+				mustMake(t, OpConstant, 0),
+				mustMake(t, OpMinus),
 				mustMake(t, OpSetGlobal, 0),
 				mustMake(t, OpGetGlobal, 0),
 				mustMake(t, OpSetGlobal, 0),


### PR DESCRIPTION
This change adds the 'not' and 'minus' unary operators
to the compiler and vm.

Co-authored-by: joshcarp joshcarp@users.noreply.github.com
Co-authored-by: pgmitche pgmitche@users.noreply.github.com