### PR TITLE
bytecode: Implement equality and inequality operators

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -38,6 +38,10 @@ const (
 	// OpMinus represents the minus unary operator, which negates the
 	// value of a numeric operand.
 	OpMinus
+	// OpEqual represents the equality operator.
+	OpEqual
+	// OpNotEqual represents the inequality operator.
+	OpNotEqual
 )
 
 var (
@@ -72,6 +76,8 @@ var definitions = map[Opcode]*OpDefinition{
 	OpFalse:    {"OpFalse", nil},
 	OpNot:      {"OpNot", nil},
 	OpMinus:    {"OpMinus", nil},
+	OpEqual:    {"OpEqual", nil},
+	OpNotEqual: {"OpNotEqual", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -122,6 +122,10 @@ func (c *Compiler) compileBinaryExpression(expr *parser.BinaryExpression) error 
 		return c.emit(OpDivide)
 	case parser.OP_PERCENT:
 		return c.emit(OpModulo)
+	case parser.OP_EQ:
+		return c.emit(OpEqual)
+	case parser.OP_NOT_EQ:
+		return c.emit(OpNotEqual)
 	default:
 		return fmt.Errorf("%w %s", ErrUnknownOperator, expr.Op)
 	}

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -97,6 +97,14 @@ func (vm *VM) Run() error {
 		case OpMinus:
 			val := vm.popNumVal()
 			err = vm.push(-val)
+		case OpEqual:
+			right := vm.pop()
+			left := vm.pop()
+			err = vm.push(boolVal(left.Equals(right)))
+		case OpNotEqual:
+			right := vm.pop()
+			left := vm.pop()
+			err = vm.push(boolVal(!left.Equals(right)))
 		}
 		if err != nil {
 			return err

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -134,6 +134,40 @@ func TestBoolExpressions(t *testing.T) {
 				mustMake(t, OpSetGlobal, 0),
 			},
 		},
+		{
+			name: "equal operator",
+			input: `
+			x := 1 == 1
+			x = x
+			`,
+			expectedStackTop:  true,
+			expectedConstants: []any{1, 1},
+			expectedInstructions: []Instructions{
+				mustMake(t, OpConstant, 0),
+				mustMake(t, OpConstant, 1),
+				mustMake(t, OpEqual),
+				mustMake(t, OpSetGlobal, 0),
+				mustMake(t, OpGetGlobal, 0),
+				mustMake(t, OpSetGlobal, 0),
+			},
+		},
+		{
+			name: "not operator",
+			input: `
+			x := 1 != 1
+			x = x
+			`,
+			expectedStackTop:  false,
+			expectedConstants: []any{1, 1},
+			expectedInstructions: []Instructions{
+				mustMake(t, OpConstant, 0),
+				mustMake(t, OpConstant, 1),
+				mustMake(t, OpNotEqual),
+				mustMake(t, OpSetGlobal, 0),
+				mustMake(t, OpGetGlobal, 0),
+				mustMake(t, OpSetGlobal, 0),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The equality operators are the only operators that can
operate across all evy types. Therefore it makes sense
to utilise the value interface and its Equals function
to generically handle this expression for all evy types.
The alternative is to create separate equality and
inequality opcodes for each evy type, which would
introduce many new opcodes and repeated code in this
package.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>