### PR TITLE
make: Generalise running playwright in docker

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -36,7 +36,7 @@ jobs:
       - run: ./bin/make deploy-prod
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
-      - run: ./bin/make e2e-docker
+      - run: ./bin/make e2e USE_DOCKER=1
         env:
           BASEURL: ${{ env.BASEURL_APEX }}
           BASEURL_PLAY: ${{ env.BASEURL_PLAY }}

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -33,7 +33,7 @@ jobs:
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./bin/make e2e-docker
+      - run: ./bin/make e2e USE_DOCKER=1
         env:
           BASEURL: ${{ env.BASEURL_APEX }}
           BASEURL_PLAY: ${{ env.BASEURL_PLAY }}


### PR DESCRIPTION
Change the way playwright is invoked in the Makefile so that specifying
whether to run it in docker is orthogonal to the Makefile target being
invoked.

`make e2e-docker` becomes `make USE_DOCKER=1 e2e`, and `make snaps`
becomes `make snaps USE_DOCKER=1` (note it does not matter where you put
`USE_DOCKER=1` as shown in those two examples).

Now, when a new Makefile target is added for a playwright command, a
second docker version does not need to be added.

Update the CI workflows to use this new method of specifying that
playwright should be run in docker.