### PR TITLE
bytecode: Refactor tests

### DIFF
--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -31,11 +31,7 @@ type Bytecode struct {
 
 // NewCompiler returns a new compiler.
 func NewCompiler() *Compiler {
-	return &Compiler{
-		constants:    []value{},
-		instructions: Instructions{},
-		globals:      NewSymbolTable(),
-	}
+	return &Compiler{globals: NewSymbolTable()}
 }
 
 // Compile accepts an AST node and renders it to bytecode internally.


### PR DESCRIPTION
Add assumption that x = x at the end of every test,
this cuts down on duplicated assertions and makes
tests easier to read. Add some missing assertions
to TestVMGlobals.

Remove initialization to empty list as all tests
pass with nil rather than the empty slice. Rework
vm tests to not use custom asserts and avoid
linter error on duplicated lines. We can now do all
essential testing in vm_test.go via assert.Equal
and assert.NoError.