### PR TITLE
docsite: Add icons to sidebar footer

### DIFF
--- a/build-tools/md/tmpl/docs.html.tmpl
+++ b/build-tools/md/tmpl/docs.html.tmpl
@@ -46,6 +46,11 @@
           <button class="icon-close" id="sidebar-close"></button>
         </header>
         {{.Sidebar}}
+        <ul class="icons">
+          <li><a href="/discord" class="icon-discord"></a></li>
+          <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
+          <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+        </ul>
       </nav>
     {{end}}
 

--- a/frontend/preview/builtins.html
+++ b/frontend/preview/builtins.html
@@ -502,6 +502,12 @@
           </ul>
         </li>
       </ul>
+
+      <ul class="icons">
+        <li><a href="/discord" class="icon-discord"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+      </ul>
     </nav>
 
     <main>

--- a/frontend/preview/css/index.css
+++ b/frontend/preview/css/index.css
@@ -305,6 +305,30 @@ th {
   border-color: var(--color-primary);
 }
 
+#sidebar ul.icons {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+  padding: 32px 20px;
+  border-top: 1px solid var(--border-color);
+  margin: 40px 0;
+}
+
+#sidebar ul.icons li {
+  margin: 0;
+  padding: 0;
+}
+
+#sidebar ul.icons a {
+  color: var(--color);
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  padding: 0;
+}
+
 /* --- responsive -------------------------------------------------------- */
 #hamburger {
   cursor: pointer;

--- a/frontend/preview/css/index.css
+++ b/frontend/preview/css/index.css
@@ -97,9 +97,16 @@ li {
 
 a {
   color: var(--color-primary);
-  &:hover {
+  &:hover,
+  &:hover code {
     color: var(--color-primary-accent);
   }
+}
+
+a > code {
+  color: var(--color-primary);
+  padding-left: 0;
+  padding-right: 0;
 }
 
 pre {

--- a/frontend/preview/index.html
+++ b/frontend/preview/index.html
@@ -502,6 +502,12 @@
           </ul>
         </li>
       </ul>
+
+      <ul class="icons">
+        <li><a href="/discord" class="icon-discord"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+      </ul>
     </nav>
 
     <main>

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -502,6 +502,12 @@
           </ul>
         </li>
       </ul>
+
+      <ul class="icons">
+        <li><a href="/discord" class="icon-discord"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+      </ul>
     </nav>
 
     <main>

--- a/frontend/preview/syntax_by_example.html
+++ b/frontend/preview/syntax_by_example.html
@@ -502,6 +502,12 @@
           </ul>
         </li>
       </ul>
+
+      <ul class="icons">
+        <li><a href="/discord" class="icon-discord"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+      </ul>
     </nav>
 
     <main>

--- a/frontend/preview/usage.html
+++ b/frontend/preview/usage.html
@@ -502,6 +502,12 @@
           </ul>
         </li>
       </ul>
+
+      <ul class="icons">
+        <li><a href="/discord" class="icon-discord"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+      </ul>
     </nav>
 
     <main>


### PR DESCRIPTION
Add icons to sidebar footer to reflect to tie the design together with what
we had on the playground (Jason's recommendation).

Fix styling for links with code.

Fixes: https://github.com/evylang/todo/issues/72