### PR TITLE
evaluator: Allow slice start index to be equal to length

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -726,7 +726,15 @@ The slice expression `arr[start:end]` copies a substring or subarray
 starting with the value at index `arr[start]`. The length of the slice
 is `end-start`. The end index `arr[end]` is not included in the slice.
 If `start` is left out, it defaults to `0`. If `end` is left out, it
-defaults to `len arr`. For example, the following code
+defaults to `len arr`.
+
+As with an **index**, the `start` or `end` value of a slice expression
+may be a negative `-i` as a shorthand for the normalized value
+`(len arr) - i`. After `start` and `end` are normalized, their values
+in the expression `arr[start:end]` must satisfy
+`0 <= start <= end <= (len arr)`.
+
+For example, the following code
 
 ```evy
 s := "abcd"

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -703,8 +703,16 @@ print 2 arr[-1]
         <code>arr[start]</code>. The length of the slice is <code>end-start</code>. The end index
         <code>arr[end]</code> is not included in the slice. If <code>start</code> is left out, it
         defaults to <code>0</code>. If <code>end</code> is left out, it defaults to
-        <code>len arr</code>. For example, the following code
+        <code>len arr</code>.
       </p>
+      <p>
+        As with an <strong>index</strong>, the <code>start</code> or <code>end</code> value of a
+        slice expression may be a negative <code>-i</code> as a shorthand for the normalized value
+        <code>(len arr) - i</code>. After <code>start</code> and <code>end</code> are normalized,
+        their values in the expression <code>arr[start:end]</code> must satisfy
+        <code>0 &lt;= start &lt;= end &lt;= (len arr)</code>.
+      </p>
+      <p>For example, the following code</p>
       <pre><code class="language-evy">s := &quot;abcd&quot;
 print 1 s[1:3]
 print 2 s[:2]

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -629,11 +629,13 @@ print "2" arr[1:]
 print "3" arr[1:2]
 print "4" arr[1:1]
 print "5" arr[:1]
+print "6" arr[3:]
+print "7" arr[3:3]
 print
 
 arr2 := arr[:]
 arr2[0] = 11
-print "6" arr arr2
+print "8" arr arr2
 `
 	out := run(prog)
 	want := []string{
@@ -642,8 +644,10 @@ print "6" arr arr2
 		"3 [2]",
 		"4 []",
 		"5 [1]",
+		"6 []",
+		"7 []",
 		"",
-		"6 [1 2 3] [11 2 3]",
+		"8 [1 2 3] [11 2 3]",
 		"",
 	}
 	got := strings.Split(out, "\n")
@@ -661,10 +665,12 @@ print "2" s[1:]
 print "3" s[1:2]
 print "4" s[1:1]
 print "5" s[:1]
+print "6" s[3:]
+print "7" s[3:3]
 print
 
 s2 := "A" + s[1:]
-print "6" s s2
+print "8" s s2
 `
 	out := run(prog)
 	want := []string{
@@ -673,8 +679,10 @@ print "6" s s2
 		"3 b",
 		"4 ",
 		"5 a",
+		"6 ",
+		"7 ",
 		"",
-		"6 abc Abc",
+		"8 abc Abc",
 		"",
 	}
 	got := strings.Split(out, "\n")

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -239,6 +239,10 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		`[1 2 3]["a"]`: "line 1 column 8: array index expects num, found string",
 		"{a:2}[2]":     "line 1 column 6: map index expects string, found num",
 
+		`"abc"["a":]`:    "line 1 column 6: string start index expects num, found string",
+		`"abc"["a":"b"]`: "line 1 column 6: string start index expects num, found string",
+		`"abc"[:"b"]`:    "line 1 column 6: string end index expects num, found string",
+
 		"{a:}": `line 1 column 4: unexpected "}"`,
 		"{:a}": `line 1 column 2: expected map key, found ":"`,
 


### PR DESCRIPTION
Fixes: #292 

Before:
```
print [1 2 3][1:] // [2 3]
print [1 2][1:] // [2]
print [1 2 3][2:2] // []
print [1][1:] // line 5: panic: index out of bounds: 1
```

After:
```
print [1 2 3][1:] // [2 3]
print [1 2][1:] // [2]
print [1 2 3][2:2] // []
print [1][1:] // []
```