### PR TITLE
parser: Fix assignability check by tracking type context

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1233,6 +1233,75 @@ fn []
 	}
 }
 
+func TestTypeofCombinedTypes(t *testing.T) {
+	tests := map[string]string{
+		// testcase //01
+		`//01
+n := 0
+na := [1]
+print
+print 1 (typeof [na [true]]) // []any
+print 2 (typeof [[] []]) // [][]any
+print 3 (typeof [[] [2]]) // [][]num
+print 4 (typeof [["string"] [2]]) // [][]any
+print 5 (typeof [[n] [2]]) // [][]num
+print 6 (typeof [na [2]]) // [][]num
+print 7 (typeof [na na]) // [][]num
+print 8 (typeof [[n] [true]]) // [][]any
+print 9 (typeof [na true]) // []any`: `
+1 []any
+2 [][]any
+3 [][]num
+4 [][]any
+5 [][]num
+6 [][]num
+7 [][]num
+8 [][]any
+9 []any
+`, // testcase //02
+		`//02
+arr := [1]
+print
+print 1 (typeof [[arr] [[true]]]) // [][]any
+print 2 (typeof [[[1]] [[true]]]) // [][][]any
+print 3 (typeof [[arr] [[1]]]) // [][][]num
+`: `
+1 [][]any
+2 [][][]any
+3 [][][]num
+`, // testcase //03
+		`//03
+a:[]any
+n := 2
+a = [1 2 n]
+print
+print 1 (typeof [1 2 n]) // []num
+print 2 (typeof a) // []any
+`: `
+1 []num
+2 []any
+`, // testcase //04
+		`//04
+bar:[]bool
+foo := [[1] bar]
+baz := [[true] bar]
+print
+print 1 (typeof foo) // []any
+print 2 (typeof baz) //  [][]bool
+`: `
+1 []any
+2 [][]bool
+`,
+	}
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in[:4], func(t *testing.T) {
+			got := run(in)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 func TestStr2BoolNum(t *testing.T) {
 	prog := `
 print 1 (str2bool "1") err

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -643,7 +643,7 @@ func (b *BinaryExpression) Type() *Type {
 
 func (b *BinaryExpression) infer() {
 	if b.T == EMPTY_ARRAY {
-		b.T = &Type{Name: ARRAY, Sub: ANY_TYPE}
+		b.T = &Type{Name: ARRAY, Sub: ANY_TYPE, Fixed: true}
 	}
 }
 
@@ -1149,44 +1149,6 @@ func wrapAny(val Node, targetType *Type) Node {
 		return mapLit
 	}
 	panic(fmt.Sprintf("internal error: %s incompatible types: target %v, value %v", val.Token().Location(), targetType, valType))
-}
-
-func isCompositeConst(n Node) bool {
-	if arrayLit, ok := n.(*ArrayLiteral); ok {
-		return isConst(arrayLit)
-	}
-	if mapLit, ok := n.(*MapLiteral); ok {
-		return isConst(mapLit)
-	}
-	return false
-}
-
-func isConst(node Node) bool {
-	switch n := node.(type) {
-	case *NumLiteral, *StringLiteral, *BoolLiteral:
-		return true
-	case *BinaryExpression:
-		return isConst(n.Left) && isConst(n.Right)
-	case *UnaryExpression:
-		return isConst(n.Right)
-	case *GroupExpression:
-		return isConst(n.Expr)
-	case *ArrayLiteral:
-		for _, el := range n.Elements {
-			if !isConst(el) {
-				return false
-			}
-		}
-		return true
-	case *MapLiteral:
-		for _, val := range n.Pairs {
-			if !isConst(val) {
-				return false
-			}
-		}
-		return true
-	}
-	return false
 }
 
 func alwaysTerms(n Node) bool {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1384,6 +1384,50 @@ end
 	}
 }
 
+func TestArrayTypeCombiningNoErr(t *testing.T) {
+	inputs := []string{
+		`
+n := 0
+na := [1]
+print [na [true]] // []any
+print [[] []] // [][]any
+print [[] [2]] // [][]num
+print [["string"] [2]] // [][]any
+print [[n] [2]] // [][]num
+print [na [2]] // [][]num
+print [na na] // [][]num
+print [[n] [true]] // [][]any
+print [na true] // []any
+`,
+		`
+arr := [1]
+print [[arr] [[true]]] // [][]any
+print [[[1]] [[true]]] // [][][]any
+print [[arr] [[1]]] // [][][]num
+`,
+		`
+a:[]any
+n := 2
+a = [1 2 n]
+print "[1 2 n]" [1 2 n] // [1 2 n] []num
+print a a // [1 2 2] []any
+`,
+		`
+ba:[]bool
+foo := [[1] ba]
+print foo
+foo2 := [[true] ba] // []any
+print foo2 // [][]bool
+		`,
+	}
+
+	for _, input := range inputs {
+		parser := newParser(input, testBuiltins())
+		parser.parse()
+		assertNoParseError(t, parser, input)
+	}
+}
+
 func TestLateCompositeLiteralTypingErr(t *testing.T) {
 	inputs := map[string]string{
 		`
@@ -1474,6 +1518,21 @@ print(any(arr))
 	want = "[]any"
 	got = arrayLit.Elements[0].Type().String()
 	assert.Equal(t, want, got)
+}
+
+func TestWrapArrayNoError(t *testing.T) {
+	inputs := []string{
+		`
+a:[]any
+n := 2
+a = [1 2 n]
+print "[1 2 n]" (typeof [1 2 n])
+print a (typeof a)`,
+	}
+	for _, input := range inputs {
+		parser := newParser(input, testBuiltins())
+		assertNoParseError(t, parser, input)
+	}
 }
 
 func TestAnyWrapArray(t *testing.T) {

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -67,6 +67,32 @@ func (t TypeName) name() string {
 type Type struct {
 	Name TypeName // string, num, bool, composite types array, map
 	Sub  *Type    // e.g.: `[]int` : Type{Name: "array", Sub: &Type{Name: "int"} }
+
+	// Fixed is a flag relevant only to composite types: arrays and maps. It
+	// determines if the composite type can be converted (or coerced) to a
+	// different composite type.
+	//
+	// *  Fixed is false: The composite type is flexible. It can be coerced
+	//    to other composite types (e.g., []num to []any) or directly to the
+	//    dynamic `any` type. This applies to composite literals and nested
+	//    composite literals.
+	// *  Fixed is true: The composite type is strict. It cannot be directly
+	//    coerced to other composite types, only to the dynamic `any` type.
+	//    This applies to variables and expressions (like array
+	//    concatenations and slices).
+	Fixed bool
+}
+
+func fixedType(t *Type) *Type {
+	if t.Name != ARRAY && t.Name != MAP {
+		return t
+	}
+	if t == GENERIC_ARRAY || t == GENERIC_MAP || t == EMPTY_ARRAY || t == EMPTY_MAP {
+		return t
+	}
+	t2 := *t
+	t2.Fixed = true
+	return &t2
 }
 
 // String returns a string representation of the Type.
@@ -95,25 +121,38 @@ func (t *Type) Equals(t2 *Type) bool {
 	return left == right
 }
 
-// accepts returns true if a variable v of Type t and a value v2 of Type t2
-// can form the valid assignment statement v = v2.
+// accepts reports whether a variable 'v' of Type 't' can be assigned a
+// value 'v2' of Type 't2'. accepts returns true if v = v2 is a valid
+// assignment.
 //
-// Assignability rules are stricter for composite variables than for composite
-// constants. Specifically, an any composite type, such as []any, can accept
-// a non-any composite type, such as []num, if the non-any composite type is
-// the type of a constant, such as [1 2].
+// Assignability of composite types (arrays, maps) is influenced by whether
+// the value is a literal or a variable. The internal Type.Fixed flag tracks
+// this distinction.
 //
-//	anyArr := &Type{Name ARRAY: Type: ANY} // []any
-//	numArr := &Type{Name ARRAY: Type: NUM} // []num
-//	fmt.Println(anyArray.accepts(numArray, true /* constant */)) // true
-//	fmt.Println(anyArray.accepts(numArray, false /* constant */)) // false
-func (t *Type) accepts(t2 *Type, constant bool) bool {
+// A composite literal with a specific element type (e.g. []num, {}bool) can
+// be assigned to a variable with a compatible 'any' element type (e.g.,
+// []any, {}any}).
+//
+// Composite variables have stricter typing. Assignment is generally only
+// allowed between variables of the same composite type, or from a composite
+// variable to an 'any' typed variable.
+//
+//	anyArr := &Type{Name ARRAY: Type: ANY} //  []any
+//	numArr := &Type{Name ARRAY: Type: NUM} // []num (literal)
+//	numArrVar := &Type{Name ARRAY: Type: NUM, Fixed: true} // []num (variable)
+//	fmt.Println(anyArray.accepts(numArray)) // true
+//	fmt.Println(anyArray.accepts(numArrayVar)) // false
+func (t *Type) accepts(t2 *Type) bool {
 	left, right := t, t2
+	var rightFixed bool
 	for (left != nil) && (right != nil) {
+		if right.Fixed {
+			rightFixed = true // cannot be coerced into different composite from here
+		}
 		switch {
 		case left == right:
 			return true
-		case left.Name == ANY && right.Name != NONE && (left == t || constant):
+		case left.Name == ANY && right.Name != NONE && (left == t || !rightFixed):
 			// left == t allows, e.g., any = num but not []any = []num
 			return true
 		case left.Name != right.Name:
@@ -173,16 +212,20 @@ func combineTypes(types []*Type) *Type {
 		if combinedT.Equals(t) {
 			continue
 		}
+		// types are not equal, ensure that composite types can be combined
+		if t.Fixed || combinedT.Fixed {
+			return ANY_TYPE
+		}
 		if (t.Name == ARRAY || t.Name == MAP) && t.Name == combinedT.Name {
 			switch {
-			case t == EMPTY_ARRAY, t == EMPTY_MAP:
+			case t == EMPTY_ARRAY, t == EMPTY_MAP: // do nothing
 			case combinedT == EMPTY_ARRAY, combinedT == EMPTY_MAP:
 				combinedT = t
-			case t.Name == ARRAY && combinedT.Name == ARRAY, t.Name == MAP && combinedT.Name == MAP:
+			default:
+				// Only literal composite types of the same kind (array or
+				// map) can be combined.
 				sub := combineTypes([]*Type{t.Sub, combinedT.Sub})
 				combinedT = &Type{Name: t.Name, Sub: sub}
-			default:
-				combinedT = &Type{Name: t.Name, Sub: ANY_TYPE}
 			}
 			continue
 		}


### PR DESCRIPTION
Fix assignability check by tracking type context in Type.Fixed flag: A
variable or expression of composite type has its type field Fixed set to
true. All other types, including literal composite Types have the Type.Fixed
field set to false.

This allows the Type.accept(otherType) method to work without the additional,
previously used `isConst` parameter, which was also imprecise. We can also
remove the `isCompositeConst` and `isConst` functions from the ast.go file.

Additionally rework the `combineTypes()` function to work with the new
Type.Fixed flag.

Add test cases to parser and evaluator package that cover all noted crashes on
nested types.

Issue: https://github.com/evylang/evy/issues/295

---

Fixes #295 