### PR TITLE
parser: Allow keywords as map keys

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -622,16 +622,18 @@ outputs
 **Maps** are key-value stores, where the values can be looked up by their
 key, for example `map := { key1:"value1" key2:"value2" }`.
 
-Map values can be accessed with the dot expression, for example
-`map.key1`. If maps are accessed via the dot expression the key must
-match the grammars `ident` production. Map values can also be accessed
-with an index expression which allows for evaluation, non-ident keys
-and variable usage. For example the following code
+Map values can be accessed with the dot expression, for example `map.key1`. If
+maps are accessed via the dot expression the key must match the grammars
+`ident` production. Map keys in dot expression and map literals may be Evy
+keywords. Map values can also be accessed with an index expression which
+allows for evaluation, non-ident keys and variable usage.
+
+For example the following code
 
 ```evy
-m := {letters:"abc"}
-print 1 m.letters
-print 2 m["letters"]
+m := {letters:"abc" for:"u"}
+print 1 m.letters m.for
+print 2 m["letters"] m["for"]
 
 key := "German letters"
 m[key] = "äöü"
@@ -642,8 +644,8 @@ print 4 m["German letters"]
 outputs
 
 ```evy:output
-1 abc
-2 abc
+1 abc u
+2 abc u
 3 äöü
 4 äöü
 ```

--- a/frontend/module/editor.js
+++ b/frontend/module/editor.js
@@ -674,7 +674,7 @@ function readComment(s, i) {
 }
 
 function identType(val, prev, funcs) {
-  if (keywords.has(val)) {
+  if (keywords.has(val) && prev !== ".") {
     return "keyword"
   }
   if (builtins.has(val) && prev !== ".") {

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -621,13 +621,14 @@ print 3 arr
       <p>
         Map values can be accessed with the dot expression, for example <code>map.key1</code>. If
         maps are accessed via the dot expression the key must match the grammars
-        <code>ident</code> production. Map values can also be accessed with an index expression
-        which allows for evaluation, non-ident keys and variable usage. For example the following
-        code
+        <code>ident</code> production. Map keys in dot expression and map literals may be Evy
+        keywords. Map values can also be accessed with an index expression which allows for
+        evaluation, non-ident keys and variable usage.
       </p>
-      <pre><code class="language-evy">m := {letters:&quot;abc&quot;}
-print 1 m.letters
-print 2 m[&quot;letters&quot;]
+      <p>For example the following code</p>
+      <pre><code class="language-evy">m := {letters:&quot;abc&quot; for:&quot;u&quot;}
+print 1 m.letters m.for
+print 2 m[&quot;letters&quot;] m[&quot;for&quot;]
 
 key := &quot;German letters&quot;
 m[key] = &quot;äöü&quot;
@@ -635,8 +636,8 @@ print 3 m[key]
 print 4 m[&quot;German letters&quot;]
 </code></pre>
       <p>outputs</p>
-      <pre><code class="language-evy:output">1 abc
-2 abc
+      <pre><code class="language-evy:output">1 abc u
+2 abc u
 3 äöü
 4 äöü
 </code></pre>

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -520,6 +520,7 @@ func TestIndexErr(t *testing.T) {
 func TestMapLit(t *testing.T) {
 	tests := map[string]string{
 		"a := {n:1}":                 "{n:1}",
+		"a := {for:1}":               "{for:1}",
 		"a := {}":                    "{}",
 		`a := {name:"fox" age:42}`:   "{name:fox age:42}",
 		`a := {name:"fox" age:40+2}`: "{name:fox age:42}",
@@ -546,13 +547,17 @@ func TestDot(t *testing.T) {
 	tests := map[string]string{
 		// m := {name: "Greta"}
 		"print m.name":    "Greta",
+		"print m.for":     "FFF",
 		`print m["name"]`: "Greta",
+		`print m["for"]`:  "FFF",
 		`s := "name"
 		print m[s]`: "Greta",
+		`s := "for"
+		print m[s]`: "FFF",
 	}
 	for in, want := range tests {
 		in, want := in, want
-		input := `m := {name: "Greta"}` + "\n" + in
+		input := `m := {name: "Greta" for: "FFF"}` + "\n" + in
 		t.Run(input, func(t *testing.T) {
 			got := run(input)
 			assert.Equal(t, want+"\n", got)

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -119,6 +119,19 @@ var keywords = map[string]TokenType{
 	"end":    END,
 }
 
+// AsIdent returns t as an IDENT token if t is a keyword and valid as an
+// identifier, otherwise it returns t. This is to allow specific tokens that
+// are also valid identifiers to be used in certain contexts.
+func (t *Token) AsIdent() *Token {
+	tokstr := tokenStrings[t.TokenType()].format
+	if _, ok := keywords[tokstr]; !ok {
+		return t
+	}
+	ident := *t
+	ident.setLiteral(tokstr).setType(IDENT)
+	return &ident
+}
+
 type tokenString struct {
 	string string
 	format string

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -267,11 +267,12 @@ func (p *parser) parseDotExpr(left Node) Node {
 		p.appendErrorForToken(`field access with "." expects map type, found `+left.Type().String(), tok)
 		return nil
 	}
-	if p.cur.TokenType() != lexer.IDENT {
+	key := p.cur.AsIdent()
+	if key.TokenType() != lexer.IDENT {
 		p.appendErrorForToken(`expected map key, found `+p.cur.TokenType().String(), tok)
 		return nil
 	}
-	expr := &DotExpression{token: tok, Left: left, T: left.Type().Sub, Key: p.cur.Literal}
+	expr := &DotExpression{token: tok, Left: left, T: left.Type().Sub, Key: key.Literal}
 	p.advance() // advance past key IDENT
 	return expr
 }
@@ -490,10 +491,11 @@ func (p *parser) parseMapPairs(mapLit *MapLiteral) bool {
 	tt := p.cur.TokenType()
 
 	for tt != lexer.RCURLY && tt != lexer.EOF {
-		if tt != lexer.IDENT {
-			p.appendError("expected map key, found " + p.cur.Format())
+		keyTok := p.cur.AsIdent()
+		if keyTok.TokenType() != lexer.IDENT {
+			p.appendError("expected map key, found " + keyTok.Format())
 		}
-		key := p.cur.Literal
+		key := keyTok.Literal
 		p.advance() // advance past key IDENT
 		if _, ok := mapLit.Pairs[key]; ok {
 			p.appendError(fmt.Sprintf("duplicated map key %q", key))

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -86,6 +86,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 
 		// Map access - dot expressions
 		"map.key":          "(map.key)",
+		"map.end":          "(map.end)",
 		"map.key+3":        "((map.key)+3)",
 		"map2.a.b":         "((map2.a).b)",
 		"map.key+map2.a.b": "((map.key)+((map2.a).b))",
@@ -139,6 +140,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"{a: [1] b:2+n2 c: 1+2}": "{a:any([1]), b:any((2+n2)), c:any((1+2))}",
 		"{a: 1}.a":               "({a:1}.a)",
 		`{a: 1}["a"]`:            `({a:1}["a"])`,
+		`{end: 1}["end"]`:        `({end:1}["end"])`,
 
 		// Array concatenation
 		"[1] + [2]":            "([1]+[2])",


### PR DESCRIPTION
Allow keywords as map keys after dot expression and in literal initialization
so that the following now parses without error:

    m := { "for": "me" "end": "you" }
    print m.for m.end

Fixes: https://github.com/evylang/evy/issues/297