### PR TITLE
evaluator: Fix `any` comparison

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1795,6 +1795,32 @@ func TestNestedTypeof(t *testing.T) {
 	}
 }
 
+func TestAnyEquals(t *testing.T) {
+	prog := `
+a:any
+b:any
+
+a = 1
+b = "hello"
+print 1 (a == b) (a != b)
+
+a = 1
+b = 2
+print 2 (a == b) (a != b)
+
+a = 1
+b = 1
+print 3 (a == b) (a != b)
+`
+	want := `
+1 false true
+2 false true
+3 true false
+`[1:]
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -144,7 +144,7 @@ func (a *anyVal) Equals(v value) bool {
 	if !ok {
 		panic("internal error: Any.Equals called with non-Any value")
 	}
-	return a.V.Equals(a2.V)
+	return a.V.Type().Equals(a2.V.Type()) && a.V.Equals(a2.V)
 }
 
 func (a *anyVal) Set(v value) {


### PR DESCRIPTION
Fix `any` comparison, ensuring that the underlying types are equal before
comparing the values.

Previously when comparing different underlying types in an `any` a panic occured:

    a:any
    a = 1
    b: any
    b = "hello"
    print (a == b)

yielded:

    evy run foo.evy
    panic: internal error: Num.Equals called with non-Num value

Fixes: https://github.com/evylang/evy/issues/298