### PR TITLE
parser: Fix formatting for multiline literals

### DIFF
--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -269,6 +269,7 @@ func (f *formatting) formatArrayLiteral(n *ArrayLiteral) {
 		return
 	}
 	f.write("[")
+	f.indentLevel++
 	if multi[0].isComment() {
 		f.write(" ")
 	}
@@ -287,12 +288,13 @@ func (f *formatting) formatArrayLiteral(n *ArrayLiteral) {
 		// newline or comment
 		f.write(string(m))
 
-		if i+1 == length || !multi[i+1].isNL() { // next is element, comment or `]`
+		if i+1 < length && !multi[i+1].isNL() { // next is element, comment or `]`
 			f.indent()
-			if i+1 < length {
-				f.write(indentStr) // one extra indent for element or comment
-			}
 		}
+	}
+	f.indentLevel--
+	if multi[length-1].isNL() {
+		f.indent()
 	}
 	f.write("]")
 }
@@ -304,6 +306,7 @@ func (f *formatting) formatMapLiteral(n *MapLiteral) {
 		return
 	}
 	f.write("{")
+	f.indentLevel++
 	if multi[0].isComment() {
 		f.write(" ")
 	}
@@ -321,12 +324,13 @@ func (f *formatting) formatMapLiteral(n *MapLiteral) {
 		}
 		// newline or comment
 		f.writes(string(m))
-		if i+1 == length || !multi[i+1].isNL() { // next is pair, comment or `}`
+		if i+1 < length && !multi[i+1].isNL() { // next is pair, comment or `}`
 			f.indent()
-			if i+1 < length {
-				f.write(indentStr) // one extra indent for pair or comment
-			}
 		}
+	}
+	f.indentLevel--
+	if multi[length-1].isNL() {
+		f.indent()
 	}
 	f.write("}")
 }

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -596,6 +596,70 @@ print x
 	assert.Equal(t, want, got)
 }
 
+func TestNestedArrayLiteralFormat(t *testing.T) {
+	input := `x := [
+[
+[1 2 3]
+[1 2 3]
+]
+[
+[1 2 3]
+[1 2 3]
+]
+]
+print x`
+	want := `
+x := [
+    [
+        [1 2 3]
+        [1 2 3]
+    ]
+    [
+        [1 2 3]
+        [1 2 3]
+    ]
+]
+print x
+`[1:]
+	parser := newParser(input, testBuiltins())
+	prog := parser.parse()
+	assertNoParseError(t, parser, input)
+	got := prog.Format()
+	assert.Equal(t, want, got)
+}
+
+func TestNestedMapLiteralFormat(t *testing.T) {
+	input := `x := {
+left:{
+black:[1]
+idx:[0]
+}
+right:{
+black:[1]
+idx:[0]
+}
+}
+print x`
+	want := `
+x := {
+    left:{
+        black:[1]
+        idx:[0]
+    }
+    right:{
+        black:[1]
+        idx:[0]
+    }
+}
+print x
+`[1:]
+	parser := newParser(input, testBuiltins())
+	prog := parser.parse()
+	assertNoParseError(t, parser, input)
+	got := prog.Format()
+	assert.Equal(t, want, got)
+}
+
 func TestNLStringLit(t *testing.T) {
 	input := `
 x := "a\nb"


### PR DESCRIPTION
Fix formatting for deeply nested multiline array and literals by tracking
indentation level for multiline literals and arrays.

Fixes: https://github.com/evylang/evy/issues/294