### PR TITLE
bytecode: Implement numeric comparison operators

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -42,6 +42,18 @@ const (
 	OpEqual
 	// OpNotEqual represents the inequality operator.
 	OpNotEqual
+	// OpNumLessThan represents a less than operator for numeric
+	// operands.
+	OpNumLessThan
+	// OpNumLessThanEqual represents a less than or equal operator for
+	// numeric operands.
+	OpNumLessThanEqual
+	// OpNumGreaterThan represents a greater than operator for numeric
+	// operands.
+	OpNumGreaterThan
+	// OpNumGreaterThanEqual represents a greater than or equal operator
+	// for numeric operands.
+	OpNumGreaterThanEqual
 )
 
 var (
@@ -67,17 +79,21 @@ var definitions = map[Opcode]*OpDefinition{
 	// Operations like OpAdd have no operand width because the virtual
 	// machine is expected to pop the values from the stack when reading
 	// this instruction.
-	OpAdd:      {"OpAdd", nil},
-	OpSubtract: {"OpSubtract", nil},
-	OpMultiply: {"OpMultiply", nil},
-	OpDivide:   {"OpDivide", nil},
-	OpModulo:   {"OpModulo", nil},
-	OpTrue:     {"OpTrue", nil},
-	OpFalse:    {"OpFalse", nil},
-	OpNot:      {"OpNot", nil},
-	OpMinus:    {"OpMinus", nil},
-	OpEqual:    {"OpEqual", nil},
-	OpNotEqual: {"OpNotEqual", nil},
+	OpAdd:                 {"OpAdd", nil},
+	OpSubtract:            {"OpSubtract", nil},
+	OpMultiply:            {"OpMultiply", nil},
+	OpDivide:              {"OpDivide", nil},
+	OpModulo:              {"OpModulo", nil},
+	OpTrue:                {"OpTrue", nil},
+	OpFalse:               {"OpFalse", nil},
+	OpNot:                 {"OpNot", nil},
+	OpMinus:               {"OpMinus", nil},
+	OpEqual:               {"OpEqual", nil},
+	OpNotEqual:            {"OpNotEqual", nil},
+	OpNumLessThan:         {"OpNumLessThan", nil},
+	OpNumLessThanEqual:    {"OpNumLessThanEqual", nil},
+	OpNumGreaterThan:      {"OpNumGreaterThan", nil},
+	OpNumGreaterThanEqual: {"OpNumGreaterThanEqual", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -105,6 +105,18 @@ func (vm *VM) Run() error {
 			right := vm.pop()
 			left := vm.pop()
 			err = vm.push(boolVal(!left.Equals(right)))
+		case OpNumLessThan:
+			right, left := vm.popBinaryNums()
+			err = vm.push(boolVal(left < right))
+		case OpNumLessThanEqual:
+			right, left := vm.popBinaryNums()
+			err = vm.push(boolVal(left <= right))
+		case OpNumGreaterThan:
+			right, left := vm.popBinaryNums()
+			err = vm.push(boolVal(left > right))
+		case OpNumGreaterThanEqual:
+			right, left := vm.popBinaryNums()
+			err = vm.push(boolVal(left >= right))
 		}
 		if err != nil {
 			return err

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -150,7 +150,7 @@ func TestBoolExpressions(t *testing.T) {
 	}
 }
 
-func TestVMArithmetic(t *testing.T) {
+func TestNumOperations(t *testing.T) {
 	tests := []testCase{
 		{
 			name:         "addition",
@@ -165,7 +165,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "subtraction",
 			input:        "x := 2 - 1",
 			wantStackTop: makeValue(t, 1),
@@ -178,7 +179,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "multiplication",
 			input:        "x := 2 * 1",
 			wantStackTop: makeValue(t, 2),
@@ -191,7 +193,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "division",
 			input:        "x := 2 / 1",
 			wantStackTop: makeValue(t, 2),
@@ -204,7 +207,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "modulo",
 			input:        "x := 2 % 1",
 			wantStackTop: makeValue(t, 0),
@@ -217,7 +221,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "float modulo",
 			input:        "x := 2.5 % 1.3",
 			wantStackTop: makeValue(t, 1.2),
@@ -230,7 +235,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "minus operator",
 			input:        "x := -1",
 			wantStackTop: makeValue(t, -1),
@@ -242,7 +248,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "all operators",
 			input:        "x := 1 + 2 - 3 * 4 / 5 % 6",
 			wantStackTop: makeValue(t, 1+2-math.Mod(3.0*4.0/5.0, 6.0)),
@@ -263,7 +270,8 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},
-		}, {
+		},
+		{
 			name:         "grouped expressions",
 			input:        "x := (1 + 2 - 3) * 4 / 5 % 6",
 			wantStackTop: makeValue(t, (1+2-3)*4/math.Mod(5.0, 6.0)),
@@ -281,6 +289,62 @@ func TestVMArithmetic(t *testing.T) {
 					mustMake(t, OpDivide),
 					mustMake(t, OpConstant, 5),
 					mustMake(t, OpModulo),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "less than",
+			input:        "x := 1 < 2",
+			wantStackTop: makeValue(t, true),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpNumLessThan),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "less than or equal",
+			input:        "x := 1 <= 2",
+			wantStackTop: makeValue(t, true),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpNumLessThanEqual),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "greater than",
+			input:        "x := 1 > 2",
+			wantStackTop: makeValue(t, false),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpNumGreaterThan),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "greater than or equal",
+			input:        "x := 1 >= 2",
+			wantStackTop: makeValue(t, false),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpNumGreaterThanEqual),
 					mustMake(t, OpSetGlobal, 0),
 				),
 			},


### PR DESCRIPTION
Adds comparison operators for numic operands, these will have
distinct opcodes from string comparison operands and avoids
verbose type checking code in the vm. Instead, the compiler
will perform type checks on operands to ensure that unique
opcodes are output depending on the types involved.