### PR TITLE
bytecode: Implement string literals and operations

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -54,6 +54,21 @@ const (
 	// OpNumGreaterThanEqual represents a greater than or equal operator
 	// for numeric operands.
 	OpNumGreaterThanEqual
+	// OpStringLessThan represents a less than operator for string
+	// operands. Strings are compared using lexicographic order.
+	OpStringLessThan
+	// OpStringLessThanEqual represents a less than or equal operator for
+	// string operands. Strings are compared using lexicographic order.
+	OpStringLessThanEqual
+	// OpStringGreaterThan represents a greater than operator for string
+	// operands. Strings are compared using lexicographic order.
+	OpStringGreaterThan
+	// OpStringGreaterThanEqual represents a greater than or equal operator
+	// for string operands. Strings are compared using lexicographic order.
+	OpStringGreaterThanEqual
+	// OpStringConcatenate represents a + operator used to concatenate two
+	// strings.
+	OpStringConcatenate
 )
 
 var (
@@ -79,21 +94,26 @@ var definitions = map[Opcode]*OpDefinition{
 	// Operations like OpAdd have no operand width because the virtual
 	// machine is expected to pop the values from the stack when reading
 	// this instruction.
-	OpAdd:                 {"OpAdd", nil},
-	OpSubtract:            {"OpSubtract", nil},
-	OpMultiply:            {"OpMultiply", nil},
-	OpDivide:              {"OpDivide", nil},
-	OpModulo:              {"OpModulo", nil},
-	OpTrue:                {"OpTrue", nil},
-	OpFalse:               {"OpFalse", nil},
-	OpNot:                 {"OpNot", nil},
-	OpMinus:               {"OpMinus", nil},
-	OpEqual:               {"OpEqual", nil},
-	OpNotEqual:            {"OpNotEqual", nil},
-	OpNumLessThan:         {"OpNumLessThan", nil},
-	OpNumLessThanEqual:    {"OpNumLessThanEqual", nil},
-	OpNumGreaterThan:      {"OpNumGreaterThan", nil},
-	OpNumGreaterThanEqual: {"OpNumGreaterThanEqual", nil},
+	OpAdd:                    {"OpAdd", nil},
+	OpSubtract:               {"OpSubtract", nil},
+	OpMultiply:               {"OpMultiply", nil},
+	OpDivide:                 {"OpDivide", nil},
+	OpModulo:                 {"OpModulo", nil},
+	OpTrue:                   {"OpTrue", nil},
+	OpFalse:                  {"OpFalse", nil},
+	OpNot:                    {"OpNot", nil},
+	OpMinus:                  {"OpMinus", nil},
+	OpEqual:                  {"OpEqual", nil},
+	OpNotEqual:               {"OpNotEqual", nil},
+	OpNumLessThan:            {"OpNumLessThan", nil},
+	OpNumLessThanEqual:       {"OpNumLessThanEqual", nil},
+	OpNumGreaterThan:         {"OpNumGreaterThan", nil},
+	OpNumGreaterThanEqual:    {"OpNumGreaterThanEqual", nil},
+	OpStringLessThan:         {"OpStringLessThan", nil},
+	OpStringLessThanEqual:    {"OpStringLessThanEqual", nil},
+	OpStringGreaterThan:      {"OpStringGreaterThan", nil},
+	OpStringGreaterThanEqual: {"OpStringGreaterThanEqual", nil},
+	OpStringConcatenate:      {"OpStringConcatenate", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/value.go
+++ b/pkg/bytecode/value.go
@@ -43,3 +43,19 @@ func (b boolVal) Equals(v value) bool {
 	}
 	return b == b2
 }
+
+type stringVal string
+
+func (s stringVal) Type() *parser.Type { return parser.STRING_TYPE }
+
+func (s stringVal) String() string {
+	return string(s)
+}
+
+func (s stringVal) Equals(v value) bool {
+	s2, ok := v.(stringVal)
+	if !ok {
+		panic("internal error: String.Equals called with non-String value")
+	}
+	return s == s2
+}

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -117,6 +117,21 @@ func (vm *VM) Run() error {
 		case OpNumGreaterThanEqual:
 			right, left := vm.popBinaryNums()
 			err = vm.push(boolVal(left >= right))
+		case OpStringLessThan:
+			right, left := vm.popBinaryStrings()
+			err = vm.push(boolVal(left < right))
+		case OpStringLessThanEqual:
+			right, left := vm.popBinaryStrings()
+			err = vm.push(boolVal(left <= right))
+		case OpStringGreaterThan:
+			right, left := vm.popBinaryStrings()
+			err = vm.push(boolVal(left > right))
+		case OpStringGreaterThanEqual:
+			right, left := vm.popBinaryStrings()
+			err = vm.push(boolVal(left >= right))
+		case OpStringConcatenate:
+			right, left := vm.popBinaryStrings()
+			err = vm.push(stringVal(left + right))
 		}
 		if err != nil {
 			return err
@@ -161,8 +176,18 @@ func (vm *VM) popBinaryNums() (float64, float64) {
 	return float64(right), float64(left)
 }
 
+// popBinaryStrings pops the top two elements of the stack (the left
+// and right sides of the binary expressions) as strings and returns both.
+func (vm *VM) popBinaryStrings() (string, string) {
+	// the right was compiled last, so is higher on the stack
+	// than the left
+	right := vm.popStringVal()
+	left := vm.popStringVal()
+	return string(right), string(left)
+}
+
 // popNumVal pops an element from the stack and casts it to a num
-// before returning the value. If elem is not a num it will error.
+// before returning the value. If elem is not a num then it will error.
 func (vm *VM) popNumVal() numVal {
 	elem := vm.pop()
 	val, ok := elem.(numVal)
@@ -174,12 +199,24 @@ func (vm *VM) popNumVal() numVal {
 }
 
 // popBoolVal pops an element from the stack and casts it to a bool
-// before returning the value. If elem is not a bool it will error.
+// before returning the value. If elem is not a bool then it will error.
 func (vm *VM) popBoolVal() boolVal {
 	elem := vm.pop()
 	val, ok := elem.(boolVal)
 	if !ok {
 		panic(fmt.Errorf("%w: expected to pop boolVal but got %s",
+			ErrInternal, elem.Type()))
+	}
+	return val
+}
+
+// popNumVal pops an element from the stack and casts it to a string
+// before returning the value. If elem is not a string then it will error.
+func (vm *VM) popStringVal() stringVal {
+	elem := vm.pop()
+	val, ok := elem.(stringVal)
+	if !ok {
+		panic(fmt.Errorf("%w: expected to pop stringVal but got %s",
 			ErrInternal, elem.Type()))
 	}
 	return val


### PR DESCRIPTION
Add an internal representation for strings to the package and support
assigning strings. Add opcodes for concatenating and comparing strings.
The compiler takes the burden of type checking the arguments so that
the vm can run an optimised hot path.