### PR TITLE
bytecode: Implement arrays

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -69,6 +69,12 @@ const (
 	// OpStringConcatenate represents a + operator used to concatenate two
 	// strings.
 	OpStringConcatenate
+	// OpArray represents an array literal, the operand N is the length of
+	// the array, and instructs the vm to pop N elements from the stack.
+	OpArray
+	// OpArrayConcatenate represents a + operator used to concatenate two
+	// arrays.
+	OpArrayConcatenate
 )
 
 var (
@@ -114,6 +120,9 @@ var definitions = map[Opcode]*OpDefinition{
 	OpStringGreaterThan:      {"OpStringGreaterThan", nil},
 	OpStringGreaterThanEqual: {"OpStringGreaterThanEqual", nil},
 	OpStringConcatenate:      {"OpStringConcatenate", nil},
+	// This operand width only allows arrays up to 65535 elements in length.
+	OpArray:            {"OpArray", []int{2}},
+	OpArrayConcatenate: {"OpArrayConcatenate", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -73,6 +73,15 @@ func (c *Compiler) Compile(node parser.Node) error {
 		if err := c.emit(OpConstant, c.addConstant(num)); err != nil {
 			return err
 		}
+	case *parser.ArrayLiteral:
+		for _, elem := range node.Elements {
+			if err := c.Compile(elem); err != nil {
+				return err
+			}
+		}
+		if err := c.emit(OpArray, len(node.Elements)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -129,6 +138,9 @@ func (c *Compiler) compileBinaryExpression(expr *parser.BinaryExpression) error 
 	}
 	if expr.Left.Type() == parser.STRING_TYPE && expr.Right.Type() == parser.STRING_TYPE {
 		return c.compileStringBinaryExpression(expr)
+	}
+	if expr.Left.Type().Name == parser.ARRAY && expr.Right.Type().Name == parser.ARRAY && expr.Op == parser.OP_PLUS {
+		return c.emit(OpArrayConcatenate)
 	}
 	return fmt.Errorf("%w: %s with types %s %s", ErrUnsupportedExpression,
 		expr, expr.Left.Type(), expr.Right.Type())

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -219,10 +219,10 @@ func (c *Compiler) compileDecl(decl *parser.Decl) error {
 }
 
 func (c *Compiler) compileAssignment(stmt *parser.AssignmentStmt) error {
-	if err := c.Compile(stmt.Target); err != nil {
+	if err := c.Compile(stmt.Value); err != nil {
 		return err
 	}
-	symbol := c.globals.Define(stmt.Value.String())
+	symbol := c.globals.Define(stmt.Target.String())
 	return c.emit(OpSetGlobal, symbol.Index)
 }
 

--- a/pkg/bytecode/value.go
+++ b/pkg/bytecode/value.go
@@ -2,6 +2,7 @@ package bytecode
 
 import (
 	"strconv"
+	"strings"
 
 	"evylang.dev/evy/pkg/parser"
 )
@@ -58,4 +59,39 @@ func (s stringVal) Equals(v value) bool {
 		panic("internal error: String.Equals called with non-String value")
 	}
 	return s == s2
+}
+
+type arrayVal struct {
+	Elements []value
+}
+
+func (a arrayVal) Type() *parser.Type {
+	// Revisit this when adding the typeof builtin: https://github.com/evylang/evy/pull/305#discussion_r1531149977
+	return parser.GENERIC_ARRAY
+}
+
+func (a arrayVal) String() string {
+	elements := make([]string, len(a.Elements))
+	for i, e := range a.Elements {
+		elements[i] = e.String()
+	}
+	return "[" + strings.Join(elements, " ") + "]"
+}
+
+func (a arrayVal) Equals(v value) bool {
+	a2, ok := v.(arrayVal)
+	if !ok {
+		panic("internal error: Array.Equals called with non-Array value")
+	}
+	if len(a.Elements) != len(a2.Elements) {
+		return false
+	}
+	elements2 := a2.Elements
+	for i, e := range a.Elements {
+		e2 := elements2[i]
+		if !e.Equals(e2) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -531,6 +531,33 @@ func TestArrays(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "concatenate preserve original",
+			input: `x := [1 2]
+			y := [3 4]
+			y = x + y
+			x = x`,
+			wantStackTop: makeValue(t, []any{1, 2}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 4),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpArray, 2),
+					mustMake(t, OpSetGlobal, 0),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpArray, 2),
+					mustMake(t, OpSetGlobal, 1),
+					mustMake(t, OpGetGlobal, 0),
+					mustMake(t, OpGetGlobal, 1),
+					mustMake(t, OpArrayConcatenate),
+					mustMake(t, OpSetGlobal, 1),
+					mustMake(t, OpGetGlobal, 0),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -461,6 +461,67 @@ func TestStringExpressions(t *testing.T) {
 	}
 }
 
+func TestArrays(t *testing.T) {
+	tests := []testCase{
+		{
+			name:         "empty assignment",
+			input:        "x := []",
+			wantStackTop: makeValue(t, []any{}),
+			wantBytecode: &Bytecode{
+				Constants: nil,
+				Instructions: makeInstructions(
+					mustMake(t, OpArray, 0),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "assignment",
+			input:        "x := [1 2 3]",
+			wantStackTop: makeValue(t, []any{1, 2, 3}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpArray, 3),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "concatenate",
+			input:        "x := [1 2] + [3 4]",
+			wantStackTop: makeValue(t, []any{1, 2, 3, 4}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 4),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpArray, 2),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpArray, 2),
+					mustMake(t, OpArrayConcatenate),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytecode := compileBytecode(t, tt.input)
+			assertBytecode(t, tt.wantBytecode, bytecode)
+			vm := NewVM(bytecode)
+			err := vm.Run()
+			assert.NoError(t, err, "runtime error")
+			got := vm.lastPoppedStackElem()
+			assert.Equal(t, tt.wantStackTop, got)
+		})
+	}
+}
+
 func compileBytecode(t *testing.T, input string) *Bytecode {
 	t.Helper()
 	// add x = x to the input so it parses correctly
@@ -479,6 +540,8 @@ func compileBytecode(t *testing.T, input string) *Bytecode {
 func makeValue(t *testing.T, a any) value {
 	t.Helper()
 	switch v := a.(type) {
+	case []any:
+		return arrayVal{Elements: makeValues(t, v...)}
 	case string:
 		return stringVal(v)
 	case int:

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -22,7 +22,7 @@ type testCase struct {
 func TestVMGlobals(t *testing.T) {
 	tests := []testCase{
 		{
-			name:         "global assignment",
+			name:         "inferred declaration",
 			input:        "x := 1",
 			wantStackTop: makeValue(t, 1),
 			wantBytecode: &Bytecode{
@@ -30,6 +30,29 @@ func TestVMGlobals(t *testing.T) {
 				Instructions: makeInstructions(
 					mustMake(t, OpConstant, 0),
 					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name: "assignment",
+			input: `x := 1
+			y := x
+			y = x + 1
+			y = y`,
+			wantStackTop: makeValue(t, 2),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 1),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpSetGlobal, 0),
+					mustMake(t, OpGetGlobal, 0),
+					mustMake(t, OpSetGlobal, 1),
+					mustMake(t, OpGetGlobal, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpAdd),
+					mustMake(t, OpSetGlobal, 1),
+					mustMake(t, OpGetGlobal, 1),
+					mustMake(t, OpSetGlobal, 1),
 				),
 			},
 		},


### PR DESCRIPTION
Adds support for array literals and array concatenation. Fixed an
issue with assignment where the target and value were swapped, which
would cause the result of any non-trivial assignment to fail. This had
gone unnoticed in the test suite due to the basic (e.g. x = x) usage of
assignments up until this point.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>