### PR TITLE
bytecode: Implement maps

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -75,6 +75,11 @@ const (
 	// OpArrayConcatenate represents a + operator used to concatenate two
 	// arrays.
 	OpArrayConcatenate
+	// OpMap represents a map literal, the operand N is the length of
+	// the map multiplied by 2. This length N represents the total length
+	// of the flattened map in the stack, where keys and values have been
+	// pushed sequentially (k1, v1, k2, v2...).
+	OpMap
 )
 
 var (
@@ -123,6 +128,9 @@ var definitions = map[Opcode]*OpDefinition{
 	// This operand width only allows arrays up to 65535 elements in length.
 	OpArray:            {"OpArray", []int{2}},
 	OpArrayConcatenate: {"OpArrayConcatenate", nil},
+	// This operand width only allows maps of up to 32767 pairs, as the map doubles in length
+	// to 65535 when it is flattened onto the stack.
+	OpMap: {"OpMap", []int{2}},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -82,6 +82,19 @@ func (c *Compiler) Compile(node parser.Node) error {
 		if err := c.emit(OpArray, len(node.Elements)); err != nil {
 			return err
 		}
+	case *parser.MapLiteral:
+		for _, k := range node.Order {
+			str := stringVal(k)
+			if err := c.emit(OpConstant, c.addConstant(str)); err != nil {
+				return err
+			}
+			if err := c.Compile(node.Pairs[k]); err != nil {
+				return err
+			}
+		}
+		if err := c.emit(OpMap, len(node.Pairs)*2); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/bytecode/value.go
+++ b/pkg/bytecode/value.go
@@ -1,6 +1,7 @@
 package bytecode
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -90,6 +91,37 @@ func (a arrayVal) Equals(v value) bool {
 	for i, e := range a.Elements {
 		e2 := elements2[i]
 		if !e.Equals(e2) {
+			return false
+		}
+	}
+	return true
+}
+
+type mapVal map[string]value
+
+func (m mapVal) Type() *parser.Type {
+	return parser.GENERIC_MAP
+}
+
+func (m mapVal) String() string {
+	pairs := []string{}
+	for k, v := range m {
+		pairs = append(pairs, fmt.Sprintf("%s: %s", k, v.String()))
+	}
+	return "{" + strings.Join(pairs, ", ") + "}"
+}
+
+func (m mapVal) Equals(v value) bool {
+	m2, ok := v.(mapVal)
+	if !ok {
+		panic("internal error: Map.Equals called with non-Map value")
+	}
+	if len(m) != len(m2) {
+		return false
+	}
+	for key, val := range m {
+		val2 := m2[key]
+		if val2 == nil || !val.Equals(val2) {
 			return false
 		}
 	}

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -150,6 +150,19 @@ func (vm *VM) Run() error {
 			concatenated.Elements = append(concatenated.Elements, left.Elements...)
 			concatenated.Elements = append(concatenated.Elements, right.Elements...)
 			err = vm.push(concatenated)
+		case OpMap:
+			mapLen := int(ReadUint16(vm.instructions[ip+1:]))
+			ip += 2
+
+			m := make(mapVal, 0)
+			for i := 0; i < mapLen; i += 2 {
+				val := vm.pop()
+				key := vm.popStringVal()
+				m[string(key)] = val
+			}
+			if err := vm.push(m); err != nil {
+				return err
+			}
 		}
 		if err != nil {
 			return err

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -1,0 +1,63 @@
+// Package cli provides a runtime to for Evy CLI execution in terminal.
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"evylang.dev/evy/pkg/evaluator"
+)
+
+// Runtime implements evaluator.Runtime.
+type Runtime struct {
+	evaluator.UnimplementedRuntime
+	reader    *bufio.Reader
+	SkipSleep bool
+}
+
+// NewRuntime returns an initialized cli runtime.
+func NewRuntime() *Runtime {
+	return &Runtime{reader: bufio.NewReader(os.Stdin)}
+}
+
+// Print prints s to stdout.
+func (*Runtime) Print(s string) {
+	fmt.Print(s)
+}
+
+// Cls clears the screen.
+func (*Runtime) Cls() {
+	cmd := exec.Command("clear")
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "cls")
+	}
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
+		fmt.Println("cannot clear screen", err)
+	}
+}
+
+// Read reads a line of input from stdin and strips trailing newline.
+func (rt *Runtime) Read() string {
+	s, err := rt.reader.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	return s[:len(s)-1] // strip trailing newline
+}
+
+// Sleep sleeps for dur. If the --skip-sleep flag is used, it does nothing.
+func (rt *Runtime) Sleep(dur time.Duration) {
+	if !rt.SkipSleep {
+		time.Sleep(dur)
+	}
+}
+
+// Yielder returns a no-op yielder for CLI evy as it is not needed. By
+// contrast, browser Evy needs to explicitly hand over control to JS
+// host with Yielder.
+func (*Runtime) Yielder() evaluator.Yielder { return nil }


### PR DESCRIPTION
Add support for maps to the compiler, the implementation is very
similar to arrays in https://github.com/evylang/evy/pull/305 but works in key/value pairs.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>