### PR TITLE
docsite: Fix various styling issues

### DIFF
--- a/build-tools/md/tmpl/docs.html.tmpl
+++ b/build-tools/md/tmpl/docs.html.tmpl
@@ -66,9 +66,9 @@
         </header>
         {{.Sidebar}}
         <ul class="icons">
-          <li><a href="/discord" class="icon-discord"></a></li>
-          <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
-          <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+          <li><a href="/discord" class="icon-discord" target="_blank"></a></li>
+          <li><a href="https://github.com/evylang/evy" class="icon-github" target="_blank"></a></li>
+          <li><a href="mailto:evy@evy.dev" class="icon-email" target="_blank"></a></li>
         </ul>
       </nav>
     {{end}}

--- a/build-tools/md/tmpl/docs.html.tmpl
+++ b/build-tools/md/tmpl/docs.html.tmpl
@@ -23,6 +23,7 @@
     <script src="{{.Root}}/index.js" type="module"></script>
   </head>
   <body>
+
     <header class="topnav docs">
       <div class="left">
         <button class="icon-hamburger mobile" id="hamburger"></button>
@@ -35,10 +36,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
           {{.Header}}
           <button>About</button>
           <label class="theme switch">
@@ -53,7 +50,6 @@
               }
             </script>
           </label>
-
         </nav>
         <a href="/" class="mobile logo-small"></a>
       </div>
@@ -78,5 +74,6 @@
         {{.Content}}
       </div>
     </main>
+
   </body>
 </html>

--- a/build-tools/md/tmpl/docs.html.tmpl
+++ b/build-tools/md/tmpl/docs.html.tmpl
@@ -73,6 +73,10 @@
       </nav>
     {{end}}
 
-    <main>{{.Content}}</main>
+    <main>
+      <div class="max-width-wrapper">
+        {{.Content}}
+      </div>
+    </main>
   </body>
 </html>

--- a/build-tools/md/tmpl/docs.html.tmpl
+++ b/build-tools/md/tmpl/docs.html.tmpl
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">{{.Title}}</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/docs/_header.md
+++ b/docs/_header.md
@@ -1,2 +1,2 @@
 [**Documentation**](README.md)
-[Contributing](contributing/README.md)
+[Playground](/play)

--- a/frontend/css/root.css
+++ b/frontend/css/root.css
@@ -19,6 +19,7 @@
   --background: hsl(210deg 5% 15%); /* main  */
   --background-dimmed: hsl(213deg 10% 23%); /* sidebar, header */
   --background-code: hsl(200deg 11% 18%); /* docs code blocks */
+  --background-inline-code: hsl(213deg 10% 23%); /* docs inline code */
   --color: hsl(0deg 0% 100%); /* text color, docs h1 */
   --color-hover: hsl(0deg 0% 100% / 70%);
   --color-slightly-dimmed: hsl(0deg 0% 90%); /* docs h5, th */
@@ -37,7 +38,8 @@
 :root:has(#dark-theme:not(:checked)) {
   --background: hsl(0deg 0% 96%); /* main  */
   --background-dimmed: hsl(0deg 0% 100% / 100%); /* sidebar, header */
-  --background-code: hsl(18deg 11% 82%); /* docs code blocks */
+  --background-code: hsl(200deg 13% 91%); /* docs code blocks */
+  --background-inline-code: hsl(200deg 13% 91%); /* docs inline code */
   --color: hsl(0deg 0% 0%); /* text color, docs h1 */
   --color-hover: hsl(0deg 0% 0% / 70%);
   --color-slightly-dimmed: hsl(0deg 0% 10%); /* docs h5, th */

--- a/frontend/play/index.html
+++ b/frontend/play/index.html
@@ -136,9 +136,9 @@
         <li class="mobile"><button id="sidebar-share">Share</button></li>
       </ul>
       <ul class="icons">
-        <li><a href="/discord" class="icon-discord"></a></li>
-        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
-        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+        <li><a href="/discord" class="icon-discord" target="_blank"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github" target="_blank"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email" target="_blank"></a></li>
         <li id="sidebar-icon-share" class="mobile"><button class="icon-share"></button></li>
       </ul>
     </nav>

--- a/frontend/preview/builtins.html
+++ b/frontend/preview/builtins.html
@@ -522,9 +522,9 @@
       </ul>
 
       <ul class="icons">
-        <li><a href="/discord" class="icon-discord"></a></li>
-        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
-        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+        <li><a href="/discord" class="icon-discord" target="_blank"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github" target="_blank"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email" target="_blank"></a></li>
       </ul>
     </nav>
 

--- a/frontend/preview/builtins.html
+++ b/frontend/preview/builtins.html
@@ -529,148 +529,150 @@
     </nav>
 
     <main>
-      <h1>Built-ins</h1>
-      <p>
-        <strong>Built-ins</strong> in Evy are pre-defined functions and events that allow for user
-        interaction, graphics, animation, mathematical operations, and more.
-      </p>
-      <p>
-        <strong>Functions</strong> are self-contained blocks of code that perform a specific task.
-        <strong>Events</strong> are notifications that are sent to a program when something happens,
-        such as when a user moves the mouse or presses a key.
-      </p>
-      <p>
-        For a more formal definition of the Evy syntax, see the
-        <a href="spec.html">Language Specification</a>, and for an intuitive understanding see
-        <a href="syntax_by_example.html">syntax by example</a>.
-      </p>
-      <h2>
-        <a id="input-and-output" href="#input-and-output" class="anchor">#</a>Input and Output
-      </h2>
-      <h3><a id="print" href="#print" class="anchor">#</a><code>print</code></h3>
-      <p>
-        <code>print</code> prints the arguments given to it to the output area. It separates them by
-        a single space and outputs a newline character at the end.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print &quot;Hello&quot;
+      <div class="max-width-wrapper">
+        <h1>Built-ins</h1>
+        <p>
+          <strong>Built-ins</strong> in Evy are pre-defined functions and events that allow for user
+          interaction, graphics, animation, mathematical operations, and more.
+        </p>
+        <p>
+          <strong>Functions</strong> are self-contained blocks of code that perform a specific task.
+          <strong>Events</strong> are notifications that are sent to a program when something
+          happens, such as when a user moves the mouse or presses a key.
+        </p>
+        <p>
+          For a more formal definition of the Evy syntax, see the
+          <a href="spec.html">Language Specification</a>, and for an intuitive understanding see
+          <a href="syntax_by_example.html">syntax by example</a>.
+        </p>
+        <h2>
+          <a id="input-and-output" href="#input-and-output" class="anchor">#</a>Input and Output
+        </h2>
+        <h3><a id="print" href="#print" class="anchor">#</a><code>print</code></h3>
+        <p>
+          <code>print</code> prints the arguments given to it to the output area. It separates them
+          by a single space and outputs a newline character at the end.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print &quot;Hello&quot;
 print 2 true &quot;blue&quot;
 print &quot;array:&quot; [1 2 3]
 print &quot;map:&quot; {name:&quot;Scholl&quot; age:21}
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">Hello
+        <p>Output</p>
+        <pre><code class="language-evy:output">Hello
 2 true blue
 array: [1 2 3]
 map: {name:Scholl age:21}
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>print a:any...
+        <h4>Reference</h4>
+        <pre><code>print a:any...
 </code></pre>
-      <p>
-        The <code>print</code> function prints its arguments to the output area, each separated by a
-        single space and terminated by a newline character. If no arguments are provided it only
-        prints the newline character.
-      </p>
-      <p>
-        The backslash character <code>\</code> can be used to represent special characters in
-        strings. For example, the <code>\t</code> escape sequence represents a tab character, and
-        the <code>\n</code> escape sequence represents a newline character. Quotes in string
-        literals must also be escaped with backslashes, otherwise they will be interpreted as the
-        end of the string literal. For example:
-      </p>
-      <pre><code class="language-evy">print &quot;Here's a tab: 👉\t👈\nShe said: \&quot;Thank you!\&quot;&quot;
+        <p>
+          The <code>print</code> function prints its arguments to the output area, each separated by
+          a single space and terminated by a newline character. If no arguments are provided it only
+          prints the newline character.
+        </p>
+        <p>
+          The backslash character <code>\</code> can be used to represent special characters in
+          strings. For example, the <code>\t</code> escape sequence represents a tab character, and
+          the <code>\n</code> escape sequence represents a newline character. Quotes in string
+          literals must also be escaped with backslashes, otherwise they will be interpreted as the
+          end of the string literal. For example:
+        </p>
+        <pre><code class="language-evy">print &quot;Here's a tab: 👉\t👈\nShe said: \&quot;Thank you!\&quot;&quot;
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">Here's a tab: 👉	👈
+        <p>Output</p>
+        <pre><code class="language-evy:output">Here's a tab: 👉	👈
 She said: &quot;Thank you!&quot;
 </code></pre>
-      <p>
-        In a browser environment <code>print</code> outputs to the output area. When running Evy
-        from the command line interface, <code>print</code> prints to standard out.
-      </p>
-      <h3><a id="read" href="#read" class="anchor">#</a><code>read</code></h3>
-      <p>
-        <code>read</code> reads a line of input from the user and returns it as a string. The
-        newline character is not included in the returned string.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">name := read
+        <p>
+          In a browser environment <code>print</code> outputs to the output area. When running Evy
+          from the command line interface, <code>print</code> prints to standard out.
+        </p>
+        <h3><a id="read" href="#read" class="anchor">#</a><code>read</code></h3>
+        <p>
+          <code>read</code> reads a line of input from the user and returns it as a string. The
+          newline character is not included in the returned string.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">name := read
 print &quot;Hello, &quot;+name+&quot;!&quot;
 </code></pre>
-      <p>Input</p>
-      <pre><code class="language-evy:input">Mary Jackson
+        <p>Input</p>
+        <pre><code class="language-evy:input">Mary Jackson
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">Hello, Mary Jackson!
+        <p>Output</p>
+        <pre><code class="language-evy:output">Hello, Mary Jackson!
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>read:string
+        <h4>Reference</h4>
+        <pre><code>read:string
 </code></pre>
-      <p>
-        The <code>read</code> function returns a string that contains the line of input that the
-        user entered up until, excluding the newline character. It is a blocking functions, which
-        means that it will not return until the user has entered a line of input and pressed the
-        Enter key.
-      </p>
-      <p>
-        In a browser environment <code>read</code> reads from the text input area. When running Evy
-        from the command line interface, <code>read</code> reads from standard in.
-      </p>
-      <h3><a id="cls" href="#cls" class="anchor">#</a><code>cls</code></h3>
-      <p><code>cls</code> clears the output area of all printed text.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print &quot;Hello&quot;
+        <p>
+          The <code>read</code> function returns a string that contains the line of input that the
+          user entered up until, excluding the newline character. It is a blocking functions, which
+          means that it will not return until the user has entered a line of input and pressed the
+          Enter key.
+        </p>
+        <p>
+          In a browser environment <code>read</code> reads from the text input area. When running
+          Evy from the command line interface, <code>read</code> reads from standard in.
+        </p>
+        <h3><a id="cls" href="#cls" class="anchor">#</a><code>cls</code></h3>
+        <p><code>cls</code> clears the output area of all printed text.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print &quot;Hello&quot;
 sleep 1
 cls
 print &quot;Bye&quot;
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">Bye
+        <p>Output</p>
+        <pre><code class="language-evy:output">Bye
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>cls
+        <h4>Reference</h4>
+        <pre><code>cls
 </code></pre>
-      <p>
-        The <code>cls</code> function clears all text output. In a browser environment
-        <code>cls</code> clears the output area. When running Evy from the command line interface,
-        <code>cls</code> clears the terminal, similar to the Unix <code>clear</code> or Windows
-        <code>cls</code> commands.
-      </p>
-      <h3><a id="printf" href="#printf" class="anchor">#</a><code>printf</code></h3>
-      <p><code>printf</code> stands for print formatted.</p>
-      <p>
-        <code>printf</code> prints its arguments to the output area according to a
-        <em>format</em> string. The format string is the first argument, and it contains
-        <strong>specifiers</strong>. Specifiers start with a percent sign <code>%</code>. They tell
-        the <code>printf</code> function how and where to print the remaining arguments inside the
-        format string. The rest of the format string is printed to the output area without changes.
-      </p>
-      <p>Here are some valid specifiers in Evy:</p>
-      <table>
-        <thead>
-          <tr>
-            <th>Specifier</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>%v</code></td>
-            <td>the argument in its default format</td>
-          </tr>
-          <tr>
-            <td><code>%q</code></td>
-            <td>a double-quoted string</td>
-          </tr>
-          <tr>
-            <td><code>%%</code></td>
-            <td>a percent sign <code>%</code></td>
-          </tr>
-        </tbody>
-      </table>
-      <h4>Example</h4>
-      <pre><code class="language-evy">printf &quot;The tank is 100%% full.\n\n&quot;
+        <p>
+          The <code>cls</code> function clears all text output. In a browser environment
+          <code>cls</code> clears the output area. When running Evy from the command line interface,
+          <code>cls</code> clears the terminal, similar to the Unix <code>clear</code> or Windows
+          <code>cls</code> commands.
+        </p>
+        <h3><a id="printf" href="#printf" class="anchor">#</a><code>printf</code></h3>
+        <p><code>printf</code> stands for print formatted.</p>
+        <p>
+          <code>printf</code> prints its arguments to the output area according to a
+          <em>format</em> string. The format string is the first argument, and it contains
+          <strong>specifiers</strong>. Specifiers start with a percent sign <code>%</code>. They
+          tell the <code>printf</code> function how and where to print the remaining arguments
+          inside the format string. The rest of the format string is printed to the output area
+          without changes.
+        </p>
+        <p>Here are some valid specifiers in Evy:</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Specifier</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>%v</code></td>
+              <td>the argument in its default format</td>
+            </tr>
+            <tr>
+              <td><code>%q</code></td>
+              <td>a double-quoted string</td>
+            </tr>
+            <tr>
+              <td><code>%%</code></td>
+              <td>a percent sign <code>%</code></td>
+            </tr>
+          </tbody>
+        </table>
+        <h4>Example</h4>
+        <pre><code class="language-evy">printf &quot;The tank is 100%% full.\n\n&quot;
 
 weather := &quot;rainy&quot;
 printf &quot;It is %v today.\n&quot; weather
@@ -684,8 +686,8 @@ printf &quot;They said: %q\n&quot; quote
 printf &quot;Array: %v\n&quot; [1 2 3]
 printf &quot;Map: %v\n&quot; {a:1 b:2}
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">The tank is 100% full.
+        <p>Output</p>
+        <pre><code class="language-evy:output">The tank is 100% full.
 
 It is rainy today.
 There will be 10mm of rainfall.
@@ -695,136 +697,137 @@ They said: &quot;Wow!&quot;
 Array: [1 2 3]
 Map: {a:1 b:2}
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>printf format:string a:any...
+        <h4>Reference</h4>
+        <pre><code>printf format:string a:any...
 </code></pre>
-      <p>
-        The <code>printf</code> function prints its arguments to the output area according to the
-        <strong>format</strong> string that is the first argument. The
-        <strong>specifiers</strong> that start with <code>%</code> and are contained in the format
-        string are replaced by the remaining arguments in the given order. For example, the
-        following code
-        <code>printf &quot;first: %s, second: %s&quot; &quot;A&quot; &quot;B&quot;</code> prints
-        <code>first: A, second: B</code>.
-      </p>
-      <p>Full list of valid specifiers in Evy:</p>
-      <table>
-        <thead>
-          <tr>
-            <th>Specifier</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>%v</code></td>
-            <td>the argument in a default format</td>
-          </tr>
-          <tr>
-            <td><code>%t</code></td>
-            <td>the word <code>true</code> or <code>false</code></td>
-          </tr>
-          <tr>
-            <td><code>%f</code></td>
-            <td>decimal point (floating-point) number, e.g. 123.456000</td>
-          </tr>
-          <tr>
-            <td><code>%e</code></td>
-            <td>scientific notation, e.g. -1.234456e+78</td>
-          </tr>
-          <tr>
-            <td><code>%s</code></td>
-            <td>string value</td>
-          </tr>
-          <tr>
-            <td><code>%q</code></td>
-            <td>a double-quoted string</td>
-          </tr>
-          <tr>
-            <td><code>%%</code></td>
-            <td>a literal percent sign <code>%</code>; consumes no value</td>
-          </tr>
-        </tbody>
-      </table>
-      <p>
-        If the arguments for the <code>%s</code>, <code>%q</code>, <code>%f</code>, <code>%e</code>,
-        and <code>%t</code> specifiers do not match the required type, a panic will occur.
-      </p>
-      <p>
-        The <strong>width</strong> and <strong>precision</strong> of a floating-point number can be
-        specified with the <code>%f</code> and <code>%v</code> format specifiers.
-      </p>
-      <ul>
-        <li>
-          Width is the number of characters that will be used to print the number. If the width is
-          not specified, it will be calculated based on the size of the number. It can be useful for
-          padding and aligned output.
-        </li>
-        <li>
-          Precision is the number of decimal places that will be displayed. If the precision is not
-          specified, it will be set to 6 for <code>%f</code>.
-        </li>
-      </ul>
-      <p>
-        Here is a table that shows the different ways to specify the width and precision of a
-        floating-point number:
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th>Verb</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>%f</code></td>
-            <td>default width, default precision</td>
-          </tr>
-          <tr>
-            <td><code>%7f</code></td>
-            <td>width 7, default precision</td>
-          </tr>
-          <tr>
-            <td><code>%.2f</code></td>
-            <td>default width, precision 2</td>
-          </tr>
-          <tr>
-            <td><code>%7.2f</code></td>
-            <td>width 7, precision 2</td>
-          </tr>
-          <tr>
-            <td><code>%7.f</code></td>
-            <td>width 7, precision 0</td>
-          </tr>
-        </tbody>
-      </table>
-      <p>
-        If the width/precision is preceded by a <code>-</code>, the value is padded with spaces on
-        the right rather than the left. If it is preceded by a 0, the value is padded with leading
-        zeros rather than spaces.
-      </p>
-      <p>
-        The width, precision and alignment prefix (<code>-</code> or <code>0</code>) can be used
-        with all valid specifiers. For example:
-      </p>
-      <pre><code class="language-evy">printf &quot;right:  |%7.2f|\n&quot; 1
+        <p>
+          The <code>printf</code> function prints its arguments to the output area according to the
+          <strong>format</strong> string that is the first argument. The
+          <strong>specifiers</strong> that start with <code>%</code> and are contained in the format
+          string are replaced by the remaining arguments in the given order. For example, the
+          following code
+          <code>printf &quot;first: %s, second: %s&quot; &quot;A&quot; &quot;B&quot;</code> prints
+          <code>first: A, second: B</code>.
+        </p>
+        <p>Full list of valid specifiers in Evy:</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Specifier</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>%v</code></td>
+              <td>the argument in a default format</td>
+            </tr>
+            <tr>
+              <td><code>%t</code></td>
+              <td>the word <code>true</code> or <code>false</code></td>
+            </tr>
+            <tr>
+              <td><code>%f</code></td>
+              <td>decimal point (floating-point) number, e.g. 123.456000</td>
+            </tr>
+            <tr>
+              <td><code>%e</code></td>
+              <td>scientific notation, e.g. -1.234456e+78</td>
+            </tr>
+            <tr>
+              <td><code>%s</code></td>
+              <td>string value</td>
+            </tr>
+            <tr>
+              <td><code>%q</code></td>
+              <td>a double-quoted string</td>
+            </tr>
+            <tr>
+              <td><code>%%</code></td>
+              <td>a literal percent sign <code>%</code>; consumes no value</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          If the arguments for the <code>%s</code>, <code>%q</code>, <code>%f</code>,
+          <code>%e</code>, and <code>%t</code> specifiers do not match the required type, a panic
+          will occur.
+        </p>
+        <p>
+          The <strong>width</strong> and <strong>precision</strong> of a floating-point number can
+          be specified with the <code>%f</code> and <code>%v</code> format specifiers.
+        </p>
+        <ul>
+          <li>
+            Width is the number of characters that will be used to print the number. If the width is
+            not specified, it will be calculated based on the size of the number. It can be useful
+            for padding and aligned output.
+          </li>
+          <li>
+            Precision is the number of decimal places that will be displayed. If the precision is
+            not specified, it will be set to 6 for <code>%f</code>.
+          </li>
+        </ul>
+        <p>
+          Here is a table that shows the different ways to specify the width and precision of a
+          floating-point number:
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Verb</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>%f</code></td>
+              <td>default width, default precision</td>
+            </tr>
+            <tr>
+              <td><code>%7f</code></td>
+              <td>width 7, default precision</td>
+            </tr>
+            <tr>
+              <td><code>%.2f</code></td>
+              <td>default width, precision 2</td>
+            </tr>
+            <tr>
+              <td><code>%7.2f</code></td>
+              <td>width 7, precision 2</td>
+            </tr>
+            <tr>
+              <td><code>%7.f</code></td>
+              <td>width 7, precision 0</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          If the width/precision is preceded by a <code>-</code>, the value is padded with spaces on
+          the right rather than the left. If it is preceded by a 0, the value is padded with leading
+          zeros rather than spaces.
+        </p>
+        <p>
+          The width, precision and alignment prefix (<code>-</code> or <code>0</code>) can be used
+          with all valid specifiers. For example:
+        </p>
+        <pre><code class="language-evy">printf &quot;right:  |%7.2f|\n&quot; 1
 printf &quot;left:   |%-7.2v|\n&quot; &quot;abcd&quot;
 printf &quot;zeropad:|%07.2f|\n&quot; 1.2345
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">right:  |   1.00|
+        <p>Output</p>
+        <pre><code class="language-evy:output">right:  |   1.00|
 left:   |ab     |
 zeropad:|0001.23|
 </code></pre>
-      <h2><a id="types" href="#types" class="anchor">#</a>Types</h2>
-      <h3><a id="len" href="#len" class="anchor">#</a><code>len</code></h3>
-      <p>
-        <code>len</code> returns the number of characters in a string, the number of elements in an
-        array or the number of key-value pairs in a map.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">l := len &quot;abcd&quot;
+        <h2><a id="types" href="#types" class="anchor">#</a>Types</h2>
+        <h3><a id="len" href="#len" class="anchor">#</a><code>len</code></h3>
+        <p>
+          <code>len</code> returns the number of characters in a string, the number of elements in
+          an array or the number of key-value pairs in a map.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">l := len &quot;abcd&quot;
 print &quot;len \&quot;abcd\&quot;:&quot; l
 
 l = len [1 2]
@@ -833,25 +836,25 @@ print &quot;len [1 2]:&quot; l
 l = len {a:3 b:4 c:5}
 print &quot;len {a:3 b:4 c:5}:&quot; l
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">len &quot;abcd&quot;: 4
+        <p>Output</p>
+        <pre><code class="language-evy:output">len &quot;abcd&quot;: 4
 len [1 2]: 2
 len {a:3 b:4 c:5}: 3
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>len:num a:any
+        <h4>Reference</h4>
+        <pre><code>len:num a:any
 </code></pre>
-      <p>
-        The <code>len</code> function takes a single argument, which can be a string, an array, or a
-        map. If the argument is a string, <code>len</code> returns the number of characters in the
-        string. If the argument is an array, <code>len</code> returns the number of elements in the
-        array. If the argument is a map, <code>len</code> returns the number of key-value pairs in
-        the map. If the argument is of any other type, a panic will occur.
-      </p>
-      <h3><a id="typeof" href="#typeof" class="anchor">#</a><code>typeof</code></h3>
-      <p><code>typeof</code> returns the type of the argument as string value.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">a:any
+        <p>
+          The <code>len</code> function takes a single argument, which can be a string, an array, or
+          a map. If the argument is a string, <code>len</code> returns the number of characters in
+          the string. If the argument is an array, <code>len</code> returns the number of elements
+          in the array. If the argument is a map, <code>len</code> returns the number of key-value
+          pairs in the map. If the argument is of any other type, a panic will occur.
+        </p>
+        <h3><a id="typeof" href="#typeof" class="anchor">#</a><code>typeof</code></h3>
+        <p><code>typeof</code> returns the type of the argument as string value.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">a:any
 a = &quot;abcd&quot;
 t := typeof a
 print &quot;typeof \&quot;abcd\&quot;:&quot; t
@@ -867,92 +870,94 @@ print &quot;typeof [1 2 true]:&quot; t
 
 print &quot;typeof []:&quot; (typeof [])
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">typeof &quot;abcd&quot;: string
+        <p>Output</p>
+        <pre><code class="language-evy:output">typeof &quot;abcd&quot;: string
 typeof {kind:true strong:true}: {}bool
 typeof [[1 2] [3 4]]: [][]num
 typeof [1 2 true]: []any
 typeof []: []any
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>typeof:string a:any
+        <h4>Reference</h4>
+        <pre><code>typeof:string a:any
 </code></pre>
-      <p>
-        The <code>typeof</code> function takes a single argument, which can be of any type. The
-        function returns a string that represents the type of the argument. The string returned by
-        <code>typeof</code> is the same as the type in an Evy program, for example <code>num</code>,
-        <code>bool</code>, <code>string</code>, <code>[]num</code>, <code>{}[]any</code>. For an
-        empty composite literal, <code>typeof</code> returns <code>[]</code> or <code>{}</code> as
-        it can be matched to any subtype, e.g. <code>[]</code> can be passed to a function that
-        takes an argument of <code>[]num</code>, or <code>[]string</code>.
-      </p>
-      <h2><a id="map" href="#map" class="anchor">#</a>Map</h2>
-      <h3><a id="has" href="#has" class="anchor">#</a><code>has</code></h3>
-      <p><code>has</code> returns whether a map has a given key or not.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">map := {a:1}
+        <p>
+          The <code>typeof</code> function takes a single argument, which can be of any type. The
+          function returns a string that represents the type of the argument. The string returned by
+          <code>typeof</code> is the same as the type in an Evy program, for example
+          <code>num</code>, <code>bool</code>, <code>string</code>, <code>[]num</code>,
+          <code>{}[]any</code>. For an empty composite literal, <code>typeof</code> returns
+          <code>[]</code> or <code>{}</code> as it can be matched to any subtype, e.g.
+          <code>[]</code> can be passed to a function that takes an argument of <code>[]num</code>,
+          or <code>[]string</code>.
+        </p>
+        <h2><a id="map" href="#map" class="anchor">#</a>Map</h2>
+        <h3><a id="has" href="#has" class="anchor">#</a><code>has</code></h3>
+        <p><code>has</code> returns whether a map has a given key or not.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">map := {a:1}
 printf &quot;has %v %q: %t\n&quot; map &quot;a&quot; (has map &quot;a&quot;)
 printf &quot;has %v %q: %t\n&quot; map &quot;X&quot; (has map &quot;X&quot;)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">has {a:1} &quot;a&quot;: true
+        <p>Output</p>
+        <pre><code class="language-evy:output">has {a:1} &quot;a&quot;: true
 has {a:1} &quot;X&quot;: false
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>has:bool map:{} key:string
+        <h4>Reference</h4>
+        <pre><code>has:bool map:{} key:string
 </code></pre>
-      <p>
-        The <code>has</code> function takes two arguments: a map and a key. It returns true if the
-        map has the key, and false if the map does not have the key. The map can be of any value
-        type, such as <code>{}num</code> or <code>{}[]any</code> and the key can be any string.
-      </p>
-      <h3><a id="del" href="#del" class="anchor">#</a><code>del</code></h3>
-      <p><code>del</code> deletes a key-value entry from a map.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">map := {a:1 b:2}
+        <p>
+          The <code>has</code> function takes two arguments: a map and a key. It returns true if the
+          map has the key, and false if the map does not have the key. The map can be of any value
+          type, such as <code>{}num</code> or <code>{}[]any</code> and the key can be any string.
+        </p>
+        <h3><a id="del" href="#del" class="anchor">#</a><code>del</code></h3>
+        <p><code>del</code> deletes a key-value entry from a map.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">map := {a:1 b:2}
 del map &quot;b&quot;
 print map
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">{a:1}
+        <p>Output</p>
+        <pre><code class="language-evy:output">{a:1}
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>del map:{} key:string
+        <h4>Reference</h4>
+        <pre><code>del map:{} key:string
 </code></pre>
-      <p>
-        The <code>del</code> function takes two arguments: a map and a key. It deletes the key-value
-        entry from the map if the key exists. If the key does not exist, the function does nothing.
-        The map can have any value type, and the key can be any string. It is safe to delete values
-        from the map with <code>del</code> while iterating with a <code>for … range</code> loop.
-      </p>
-      <h2><a id="program-control" href="#program-control" class="anchor">#</a>Program control</h2>
-      <h3><a id="sleep" href="#sleep" class="anchor">#</a><code>sleep</code></h3>
-      <p><code>sleep</code> pauses the program for the given number of seconds.</p>
-      <p>
-        <code>sleep</code> can be used to create delays in Evy programs. For example, you could use
-        sleep to create a countdown timer.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print &quot;2&quot;
+        <p>
+          The <code>del</code> function takes two arguments: a map and a key. It deletes the
+          key-value entry from the map if the key exists. If the key does not exist, the function
+          does nothing. The map can have any value type, and the key can be any string. It is safe
+          to delete values from the map with <code>del</code> while iterating with a
+          <code>for … range</code> loop.
+        </p>
+        <h2><a id="program-control" href="#program-control" class="anchor">#</a>Program control</h2>
+        <h3><a id="sleep" href="#sleep" class="anchor">#</a><code>sleep</code></h3>
+        <p><code>sleep</code> pauses the program for the given number of seconds.</p>
+        <p>
+          <code>sleep</code> can be used to create delays in Evy programs. For example, you could
+          use sleep to create a countdown timer.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print &quot;2&quot;
 sleep 1
 print &quot;1&quot;
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">2
+        <p>Output</p>
+        <pre><code class="language-evy:output">2
 1
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>sleep seconds:num
+        <h4>Reference</h4>
+        <pre><code>sleep seconds:num
 </code></pre>
-      <p>
-        The <code>sleep</code> function pauses the execution of the current Evy program for at least
-        the given number of seconds. Sleep may also pause for a fraction of a second, e.g.
-        <code>sleep 0.1</code>.
-      </p>
-      <h3><a id="exit" href="#exit" class="anchor">#</a><code>exit</code></h3>
-      <p><code>exit</code> terminates the program with the given status code.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy:err">input := &quot;not a number&quot;
+        <p>
+          The <code>sleep</code> function pauses the execution of the current Evy program for at
+          least the given number of seconds. Sleep may also pause for a fraction of a second, e.g.
+          <code>sleep 0.1</code>.
+        </p>
+        <h3><a id="exit" href="#exit" class="anchor">#</a><code>exit</code></h3>
+        <p><code>exit</code> terminates the program with the given status code.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy:err">input := &quot;not a number&quot;
 n := str2num input
 
 if err
@@ -962,105 +967,108 @@ end
 
 print n
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">str2num: cannot parse &quot;not a number&quot;
+        <p>Output</p>
+        <pre><code class="language-evy:output">str2num: cannot parse &quot;not a number&quot;
 </code></pre>
-      <h3><a id="panic" href="#panic" class="anchor">#</a><code>panic</code></h3>
-      <p>
-        <code>panic</code> prints the given error message and terminates the program immediately. It
-        is used to report unrecoverable errors.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy:err">scale := -5
+        <h3><a id="panic" href="#panic" class="anchor">#</a><code>panic</code></h3>
+        <p>
+          <code>panic</code> prints the given error message and terminates the program immediately.
+          It is used to report unrecoverable errors.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy:err">scale := -5
 
 if (scale) &lt;= 0
     panic &quot;scale must be positive&quot;
 end
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">line 4 column 5: scale must be positive
+        <p>Output</p>
+        <pre><code class="language-evy:output">line 4 column 5: scale must be positive
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>panic msg:string
+        <h4>Reference</h4>
+        <pre><code>panic msg:string
 </code></pre>
-      <p>
-        The <code>panic</code> function takes a single argument, which is the error message that the
-        program will print before it terminates with exit status 1.
-      </p>
-      <h2><a id="conversion" href="#conversion" class="anchor">#</a>Conversion</h2>
-      <h3><a id="str2num" href="#str2num" class="anchor">#</a><code>str2num</code></h3>
-      <p>
-        <code>str2num</code> converts a string to a number. If the string is not a valid number, it
-        returns <code>0</code> and sets the global <code>err</code> variable to <code>true</code>.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">n:num
+        <p>
+          The <code>panic</code> function takes a single argument, which is the error message that
+          the program will print before it terminates with exit status 1.
+        </p>
+        <h2><a id="conversion" href="#conversion" class="anchor">#</a>Conversion</h2>
+        <h3><a id="str2num" href="#str2num" class="anchor">#</a><code>str2num</code></h3>
+        <p>
+          <code>str2num</code> converts a string to a number. If the string is not a valid number,
+          it returns <code>0</code> and sets the global <code>err</code> variable to
+          <code>true</code>.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">n:num
 n = str2num &quot;1&quot;
 print &quot;n:&quot; n &quot;err:&quot; err
 n = str2num &quot;NOT-A-NUMBER&quot;
 print &quot;n:&quot; n &quot;err:&quot; err
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">n: 1 err: false
+        <p>Output</p>
+        <pre><code class="language-evy:output">n: 1 err: false
 n: 0 err: true
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>str2num:num s:string
+        <h4>Reference</h4>
+        <pre><code>str2num:num s:string
 </code></pre>
-      <p>
-        The <code>str2num</code> function converts a string to a number. It takes a single argument,
-        which is the string to convert. If the string is a valid number, the function returns the
-        number. Otherwise, the function returns 0 and sets the global <code>err</code> variable to
-        <code>true</code>. For more information on <code>err</code>, see the
-        <a href="#recoverable-errors">Recoverable Errors section</a>.
-      </p>
-      <h3><a id="str2bool" href="#str2bool" class="anchor">#</a><code>str2bool</code></h3>
-      <p>
-        <code>str2bool</code> converts a string to a boolean. If the string is not a valid boolean,
-        it returns <code>false</code> and sets the global <code>err</code> variable to
-        <code>true</code>.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">b:bool
+        <p>
+          The <code>str2num</code> function converts a string to a number. It takes a single
+          argument, which is the string to convert. If the string is a valid number, the function
+          returns the number. Otherwise, the function returns 0 and sets the global
+          <code>err</code> variable to <code>true</code>. For more information on <code>err</code>,
+          see the <a href="#recoverable-errors">Recoverable Errors section</a>.
+        </p>
+        <h3><a id="str2bool" href="#str2bool" class="anchor">#</a><code>str2bool</code></h3>
+        <p>
+          <code>str2bool</code> converts a string to a boolean. If the string is not a valid
+          boolean, it returns <code>false</code> and sets the global <code>err</code> variable to
+          <code>true</code>.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">b:bool
 b = str2bool &quot;true&quot;
 print &quot;b:&quot; b &quot;err:&quot; err
 b = str2bool &quot;NOT-A-BOOL&quot;
 print &quot;b:&quot; b &quot;err:&quot; err
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">b: true err: false
+        <p>Output</p>
+        <pre><code class="language-evy:output">b: true err: false
 b: false err: true
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>str2bool:bool s:string
+        <h4>Reference</h4>
+        <pre><code>str2bool:bool s:string
 </code></pre>
-      <p>
-        The <code>str2bool</code> function converts a string to a bool. It takes a single argument,
-        which is the string to convert. The function returns <code>true</code> if the string is
-        equal to <code>&quot;true&quot;</code>, <code>&quot;True&quot;</code>,
-        <code>&quot;TRUE&quot;</code>, or <code>&quot;1&quot;</code>, and <code>false</code> if the
-        string is equal to <code>&quot;false&quot;</code>, <code>&quot;False&quot;</code>,
-        <code>&quot;FALSE&quot;</code>, or <code>&quot;0&quot;</code>. The function returns
-        <code>false</code> and sets the global <code>err</code> variable to <code>true</code> if the
-        string is not a valid boolean. For more information on <code>err</code>, see the
-        <a href="#recoverable-errors">Recoverable Errors section</a>.
-      </p>
-      <h2><a id="errors" href="#errors" class="anchor">#</a>Errors</h2>
-      <p>Evy has two types of errors: parse errors and run-time errors.</p>
-      <ul>
-        <li>
-          <strong>parse errors</strong> are reported before the program is executed. They report
-          errors with the syntax, such as a missing closing quote for <code>print &quot;abc</code>,
-          an illegal character, such as <code>#</code>, or type errors, such as
-          <code>min &quot;a&quot; &quot;b&quot;</code>.
-        </li>
-        <li>
-          <strong>Run-time errors</strong> only occur if there are no parse errors and the code path
-          causing the error is executed.
-        </li>
-      </ul>
-      <p>For example, the following code will <strong>sometimes</strong> cause a run-time error:</p>
-      <pre><code class="language-evy">n:num
+        <p>
+          The <code>str2bool</code> function converts a string to a bool. It takes a single
+          argument, which is the string to convert. The function returns <code>true</code> if the
+          string is equal to <code>&quot;true&quot;</code>, <code>&quot;True&quot;</code>,
+          <code>&quot;TRUE&quot;</code>, or <code>&quot;1&quot;</code>, and <code>false</code> if
+          the string is equal to <code>&quot;false&quot;</code>, <code>&quot;False&quot;</code>,
+          <code>&quot;FALSE&quot;</code>, or <code>&quot;0&quot;</code>. The function returns
+          <code>false</code> and sets the global <code>err</code> variable to <code>true</code> if
+          the string is not a valid boolean. For more information on <code>err</code>, see the
+          <a href="#recoverable-errors">Recoverable Errors section</a>.
+        </p>
+        <h2><a id="errors" href="#errors" class="anchor">#</a>Errors</h2>
+        <p>Evy has two types of errors: parse errors and run-time errors.</p>
+        <ul>
+          <li>
+            <strong>parse errors</strong> are reported before the program is executed. They report
+            errors with the syntax, such as a missing closing quote for
+            <code>print &quot;abc</code>, an illegal character, such as <code>#</code>, or type
+            errors, such as <code>min &quot;a&quot; &quot;b&quot;</code>.
+          </li>
+          <li>
+            <strong>Run-time errors</strong> only occur if there are no parse errors and the code
+            path causing the error is executed.
+          </li>
+        </ul>
+        <p>
+          For example, the following code will <strong>sometimes</strong> cause a run-time error:
+        </p>
+        <pre><code class="language-evy">n:num
 if (rand1) &lt; 0.5
     n = str2num &quot;not-a-number&quot;
 else
@@ -1068,739 +1076,749 @@ else
 end
 print &quot;n:&quot; n &quot;error:&quot; err
 </code></pre>
-      <p>
-        Half the time, the program above will cause a run-time error and print
-        <code>n: 0 error: true</code>. The other half of the time, no error will occur and the
-        program will print <code>n:5 error:false</code>.
-      </p>
-      <p>Evy has two types of run-time errors: panic and error.</p>
-      <ul>
-        <li>
-          A <strong>panic</strong> is non-recoverable. It causes the program to exit immediately.
-        </li>
-        <li>
-          An <strong>error</strong> is recoverable. The program can continue running after the error
-          is handled.
-        </li>
-      </ul>
-      <h3><a id="panic-1" href="#panic-1" class="anchor">#</a>Panic</h3>
-      <p>
-        A panic causes the program to exit immediately and print an error message. Panics typically
-        occur when the program encounters a situation that it cannot handle, such as trying to
-        access an element of an array that is out of bounds. Panics cannot be intercepted by the
-        program, so it is important to take steps to prevent them from occurring in the first place.
-      </p>
-      <p>
-        One way to do this is to use <strong>guarding code</strong>, which is code that checks for
-        potential errors and takes steps to prevent them from occurring. For example, guarding code
-        could be used to check the length of an array before trying to access an element to avoid an
-        out of bounds error. If the access index is out of bounds, the guarding code could report
-        the error.
-      </p>
-      <p>Here is an example of a panic:</p>
-      <pre><code class="language-evy">arr := [0 1 2]
+        <p>
+          Half the time, the program above will cause a run-time error and print
+          <code>n: 0 error: true</code>. The other half of the time, no error will occur and the
+          program will print <code>n:5 error:false</code>.
+        </p>
+        <p>Evy has two types of run-time errors: panic and error.</p>
+        <ul>
+          <li>
+            A <strong>panic</strong> is non-recoverable. It causes the program to exit immediately.
+          </li>
+          <li>
+            An <strong>error</strong> is recoverable. The program can continue running after the
+            error is handled.
+          </li>
+        </ul>
+        <h3><a id="panic-1" href="#panic-1" class="anchor">#</a>Panic</h3>
+        <p>
+          A panic causes the program to exit immediately and print an error message. Panics
+          typically occur when the program encounters a situation that it cannot handle, such as
+          trying to access an element of an array that is out of bounds. Panics cannot be
+          intercepted by the program, so it is important to take steps to prevent them from
+          occurring in the first place.
+        </p>
+        <p>
+          One way to do this is to use <strong>guarding code</strong>, which is code that checks for
+          potential errors and takes steps to prevent them from occurring. For example, guarding
+          code could be used to check the length of an array before trying to access an element to
+          avoid an out of bounds error. If the access index is out of bounds, the guarding code
+          could report the error.
+        </p>
+        <p>Here is an example of a panic:</p>
+        <pre><code class="language-evy">arr := [0 1 2]
 i := 5 // e.g. user input
 print arr[i] // out of bounds
 print &quot;This line will not be executed&quot;
 </code></pre>
-      <p>
-        This code will cause a panic because the index 5 is out of bounds for the array
-        <code>arr</code>. The program will exit with the error message
-      </p>
-      <pre><code>line 3: panic: index out of bounds: 5
+        <p>
+          This code will cause a panic because the index 5 is out of bounds for the array
+          <code>arr</code>. The program will exit with the error message
+        </p>
+        <pre><code>line 3: panic: index out of bounds: 5
 </code></pre>
-      <p>
-        If you want your own code to panic, you can use the built-in <code>panic</code> function.
-        This is typically used to highlight mistakes or bugs in your program, such as invalid
-        function arguments or conditions that should never occur. The <code>panic</code> function
-        exits your program immediately, so it should only be used when it is clear that the program
-        cannot continue. For more information, see the <a href="#panic">Panic</a> section under
-        Program Control above.
-      </p>
-      <h3>
-        <a id="recoverable-errors" href="#recoverable-errors" class="anchor">#</a>Recoverable Errors
-      </h3>
-      <p>
-        The global <code>err</code> variable is used to indicate whether a recoverable error has
-        occurred. The global <code>errmsg</code> variable stores a detailed message about the error
-        that occurred.
-      </p>
-      <p>
-        Recoverable errors are caused by code that could not be prevented from running, such as
-        converting a user input string to a number if the string is not a number. This recoverable
-        error will set the global <code>err</code> variable to <code>true</code> and the program
-        will continue executing. If there is no error, <code>err</code> is set to
-        <code>false</code>.
-      </p>
-      <p>
-        The global <code>errmsg</code> variable stores a detailed message about the error which is
-        set alongside <code>err</code>. <code>errmsg</code> is set to the empty string
-        <code>&quot;&quot;</code> if no error has occurred. If an error does occur,
-        <code>errmsg</code> is set to a message that describes the error.
-      </p>
-      <p>
-        When a function that could potentially cause an error finishes executing without an error,
-        the <code>err</code> variable is reset to <code>false</code> and the
-        <code>errmsg</code> variable is set to the empty string. This is done even if the
-        <code>err</code> variable was previously set to <code>true</code> or the
-        <code>errmsg</code> variable was not empty. Therefore, it is up to the program to check the
-        <code>err</code> variable after any possible error occurrence.
-      </p>
-      <p>Here is an example of a recoverable error:</p>
-      <pre><code class="language-evy">n := str2num &quot;NOT A NUM&quot;
+        <p>
+          If you want your own code to panic, you can use the built-in <code>panic</code> function.
+          This is typically used to highlight mistakes or bugs in your program, such as invalid
+          function arguments or conditions that should never occur. The <code>panic</code> function
+          exits your program immediately, so it should only be used when it is clear that the
+          program cannot continue. For more information, see the <a href="#panic">Panic</a> section
+          under Program Control above.
+        </p>
+        <h3>
+          <a id="recoverable-errors" href="#recoverable-errors" class="anchor">#</a>Recoverable
+          Errors
+        </h3>
+        <p>
+          The global <code>err</code> variable is used to indicate whether a recoverable error has
+          occurred. The global <code>errmsg</code> variable stores a detailed message about the
+          error that occurred.
+        </p>
+        <p>
+          Recoverable errors are caused by code that could not be prevented from running, such as
+          converting a user input string to a number if the string is not a number. This recoverable
+          error will set the global <code>err</code> variable to <code>true</code> and the program
+          will continue executing. If there is no error, <code>err</code> is set to
+          <code>false</code>.
+        </p>
+        <p>
+          The global <code>errmsg</code> variable stores a detailed message about the error which is
+          set alongside <code>err</code>. <code>errmsg</code> is set to the empty string
+          <code>&quot;&quot;</code> if no error has occurred. If an error does occur,
+          <code>errmsg</code> is set to a message that describes the error.
+        </p>
+        <p>
+          When a function that could potentially cause an error finishes executing without an error,
+          the <code>err</code> variable is reset to <code>false</code> and the
+          <code>errmsg</code> variable is set to the empty string. This is done even if the
+          <code>err</code> variable was previously set to <code>true</code> or the
+          <code>errmsg</code> variable was not empty. Therefore, it is up to the program to check
+          the <code>err</code> variable after any possible error occurrence.
+        </p>
+        <p>Here is an example of a recoverable error:</p>
+        <pre><code class="language-evy">n := str2num &quot;NOT A NUM&quot;
 print &quot;num:&quot; n
 print &quot;err:&quot; err
 print &quot;errmsg:&quot; errmsg
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">num: 0
+        <p>Output</p>
+        <pre><code class="language-evy:output">num: 0
 err: true
 errmsg: str2num: cannot parse &quot;NOT A NUM&quot;
 </code></pre>
-      <p>
-        If you want your own code or function to cause a recoverable error, follow the convention of
-        setting the <code>err</code> variable to <code>true</code> and the
-        <code>errmsg</code> variable to a message describing the error in the error case. In the
-        non-error case, make sure to set the <code>err</code> variable to <code>false</code>.
-      </p>
-      <h2><a id="string" href="#string" class="anchor">#</a>String</h2>
-      <h3><a id="sprint" href="#sprint" class="anchor">#</a><code>sprint</code></h3>
-      <p><code>sprint</code> stands for print to string.</p>
-      <p>
-        It returns a string representation of the arguments given to it. It separates them by a
-        single space. Unlike <code>print</code>, there is no newline added to the end.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">s := sprint &quot;a&quot; [true] {a:1 b:2}
+        <p>
+          If you want your own code or function to cause a recoverable error, follow the convention
+          of setting the <code>err</code> variable to <code>true</code> and the
+          <code>errmsg</code> variable to a message describing the error in the error case. In the
+          non-error case, make sure to set the <code>err</code> variable to <code>false</code>.
+        </p>
+        <h2><a id="string" href="#string" class="anchor">#</a>String</h2>
+        <h3><a id="sprint" href="#sprint" class="anchor">#</a><code>sprint</code></h3>
+        <p><code>sprint</code> stands for print to string.</p>
+        <p>
+          It returns a string representation of the arguments given to it. It separates them by a
+          single space. Unlike <code>print</code>, there is no newline added to the end.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := sprint &quot;a&quot; [true] {a:1 b:2}
 printf &quot;%q\n&quot; s
 printf &quot;%q\n&quot; (sprint)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">&quot;a [true] {a:1 b:2}&quot;
+        <p>Output</p>
+        <pre><code class="language-evy:output">&quot;a [true] {a:1 b:2}&quot;
 &quot;&quot;
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>sprint:string a:any...
+        <h4>Reference</h4>
+        <pre><code>sprint:string a:any...
 </code></pre>
-      <p>
-        The <code>sprint</code> function takes any number of arguments and returns a string that
-        represents them, separated by a single space. The arguments can be of any type, including
-        strings, numbers, booleans, and maps. Unlike the <code>print</code> function, there is no
-        newline added to the end of the string.
-      </p>
-      <h3><a id="sprintf" href="#sprintf" class="anchor">#</a><code>sprintf</code></h3>
-      <p><code>sprintf</code> stands for print formatted to string.</p>
-      <p>
-        <code>sprintf</code> returns a string representation of its arguments according to a
-        <strong>format</strong> string. Formatting in <code>sprintf</code> and
-        <code>printf</code> work the same way, see <a href="#printf"><code>printf</code></a
-        >.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">s := sprintf &quot;%10q: %.f&quot; &quot;val&quot; 123.45
+        <p>
+          The <code>sprint</code> function takes any number of arguments and returns a string that
+          represents them, separated by a single space. The arguments can be of any type, including
+          strings, numbers, booleans, and maps. Unlike the <code>print</code> function, there is no
+          newline added to the end of the string.
+        </p>
+        <h3><a id="sprintf" href="#sprintf" class="anchor">#</a><code>sprintf</code></h3>
+        <p><code>sprintf</code> stands for print formatted to string.</p>
+        <p>
+          <code>sprintf</code> returns a string representation of its arguments according to a
+          <strong>format</strong> string. Formatting in <code>sprintf</code> and
+          <code>printf</code> work the same way, see <a href="#printf"><code>printf</code></a
+          >.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := sprintf &quot;%10q: %.f&quot; &quot;val&quot; 123.45
 print s
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">     &quot;val&quot;: 123
+        <p>Output</p>
+        <pre><code class="language-evy:output">     &quot;val&quot;: 123
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>sprintf:string format:string a:any...
+        <h4>Reference</h4>
+        <pre><code>sprintf:string format:string a:any...
 </code></pre>
-      <p>
-        The <code>sprintf</code> function returns a string representation of its arguments according
-        to a <strong>format</strong> string. The format string controls how the arguments are
-        formatted. The <code>sprintf</code> function works the same way as the
-        <code>printf</code> function, and the formatting syntax is the same, see
-        <a href="#printf"><code>printf</code></a
-        >.
-      </p>
-      <h3><a id="join" href="#join" class="anchor">#</a><code>join</code></h3>
-      <p>
-        <code>join</code> concatenates the elements of an array of strings into a single string,
-        with the given separator string placed between elements.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">s := join [&quot;a&quot; &quot;b&quot; &quot;c&quot;] &quot;, &quot;
+        <p>
+          The <code>sprintf</code> function returns a string representation of its arguments
+          according to a <strong>format</strong> string. The format string controls how the
+          arguments are formatted. The <code>sprintf</code> function works the same way as the
+          <code>printf</code> function, and the formatting syntax is the same, see
+          <a href="#printf"><code>printf</code></a
+          >.
+        </p>
+        <h3><a id="join" href="#join" class="anchor">#</a><code>join</code></h3>
+        <p>
+          <code>join</code> concatenates the elements of an array of strings into a single string,
+          with the given separator string placed between elements.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := join [&quot;a&quot; &quot;b&quot; &quot;c&quot;] &quot;, &quot;
 print s
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">a, b, c
+        <p>Output</p>
+        <pre><code class="language-evy:output">a, b, c
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>join:string elems:[]string sep:string
+        <h4>Reference</h4>
+        <pre><code>join:string elems:[]string sep:string
 </code></pre>
-      <p>
-        The <code>join</code> function takes two arguments: an array of strings and a separator
-        string. The array of strings is the list of elements to be concatenated. The separator
-        string is the string that will be placed between elements in the resulting string.
-      </p>
-      <p>
-        The <code>join</code> function returns a single string that is the concatenation of the
-        elements in the list of strings, with the separator string placed between elements.
-      </p>
-      <h3><a id="split" href="#split" class="anchor">#</a><code>split</code></h3>
-      <p>
-        <code>split</code> splits a string into a list of substrings separated by the given
-        separator. The separator can be any string, including the empty string.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (split &quot;a,b,c&quot; &quot;,&quot;)
+        <p>
+          The <code>join</code> function takes two arguments: an array of strings and a separator
+          string. The array of strings is the list of elements to be concatenated. The separator
+          string is the string that will be placed between elements in the resulting string.
+        </p>
+        <p>
+          The <code>join</code> function returns a single string that is the concatenation of the
+          elements in the list of strings, with the separator string placed between elements.
+        </p>
+        <h3><a id="split" href="#split" class="anchor">#</a><code>split</code></h3>
+        <p>
+          <code>split</code> splits a string into a list of substrings separated by the given
+          separator. The separator can be any string, including the empty string.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (split &quot;a,b,c&quot; &quot;,&quot;)
 print (split &quot;a,b,c&quot; &quot;.&quot;)
 print (split &quot;a,b,c&quot; &quot;&quot;)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">[a b c]
+        <p>Output</p>
+        <pre><code class="language-evy:output">[a b c]
 [a,b,c]
 [a , b , c]
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>split:[]string s:string sep:string
+        <h4>Reference</h4>
+        <pre><code>split:[]string s:string sep:string
 </code></pre>
-      <p>
-        The <code>split</code> function takes two arguments: the string to be split and the
-        separator string. The string to be split is the string that will be split into substrings.
-        The separator string is the string that will be used to split the string.
-      </p>
-      <p>
-        The <code>split</code> function returns a list of substrings. The list of substrings
-        contains all of the substrings of the original string that are separated by the separator
-        string.
-      </p>
-      <p>
-        If the string does not contain the separator, the <code>split</code> function returns an
-        array of length 1 containing the original string.
-      </p>
-      <p>
-        If the separator is the empty string, the <code>split</code> function splits the string
-        after each character (UTF-8 sequence).
-      </p>
-      <p>
-        If both the string and the separator are empty, the <code>split</code> function returns an
-        empty list.
-      </p>
-      <h3><a id="upper" href="#upper" class="anchor">#</a><code>upper</code></h3>
-      <p><code>upper</code> returns a string with all lowercase letters converted to uppercase.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">s := upper &quot;abc D e ü&quot;
+        <p>
+          The <code>split</code> function takes two arguments: the string to be split and the
+          separator string. The string to be split is the string that will be split into substrings.
+          The separator string is the string that will be used to split the string.
+        </p>
+        <p>
+          The <code>split</code> function returns a list of substrings. The list of substrings
+          contains all of the substrings of the original string that are separated by the separator
+          string.
+        </p>
+        <p>
+          If the string does not contain the separator, the <code>split</code> function returns an
+          array of length 1 containing the original string.
+        </p>
+        <p>
+          If the separator is the empty string, the <code>split</code> function splits the string
+          after each character (UTF-8 sequence).
+        </p>
+        <p>
+          If both the string and the separator are empty, the <code>split</code> function returns an
+          empty list.
+        </p>
+        <h3><a id="upper" href="#upper" class="anchor">#</a><code>upper</code></h3>
+        <p>
+          <code>upper</code> returns a string with all lowercase letters converted to uppercase.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := upper &quot;abc D e ü&quot;
 print s
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">ABC D E Ü
+        <p>Output</p>
+        <pre><code class="language-evy:output">ABC D E Ü
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>upper:string s:string
+        <h4>Reference</h4>
+        <pre><code>upper:string s:string
 </code></pre>
-      <p>
-        The <code>upper</code> function takes a single argument: the string to be converted to
-        uppercase. The function returns a new string with all lowercase letters converted to
-        uppercase. All other characters are left unchanged.
-      </p>
-      <p>
-        The <code>upper</code> function uses the Unicode character database to determine which
-        characters are lowercase and their equivalent uppercase form.
-      </p>
-      <h3><a id="lower" href="#lower" class="anchor">#</a><code>lower</code></h3>
-      <p><code>lower</code> returns a string with all uppercase letters converted to lowercase.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">s := lower &quot;abc D e ü&quot;
+        <p>
+          The <code>upper</code> function takes a single argument: the string to be converted to
+          uppercase. The function returns a new string with all lowercase letters converted to
+          uppercase. All other characters are left unchanged.
+        </p>
+        <p>
+          The <code>upper</code> function uses the Unicode character database to determine which
+          characters are lowercase and their equivalent uppercase form.
+        </p>
+        <h3><a id="lower" href="#lower" class="anchor">#</a><code>lower</code></h3>
+        <p>
+          <code>lower</code> returns a string with all uppercase letters converted to lowercase.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := lower &quot;abc D e ü&quot;
 print s
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">abc d e ü
+        <p>Output</p>
+        <pre><code class="language-evy:output">abc d e ü
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>lower:string s:string
+        <h4>Reference</h4>
+        <pre><code>lower:string s:string
 </code></pre>
-      <p>
-        The <code>lower</code> function takes a single argument: the string to be converted to
-        lowercase. The function returns a new string with all uppercase letters converted to
-        lowercase. All other characters are left unchanged.
-      </p>
-      <p>
-        The <code>lower</code> function uses the Unicode character database to determine which
-        characters are uppercase and their equivalent lowercase form.
-      </p>
-      <h3><a id="index" href="#index" class="anchor">#</a><code>index</code></h3>
-      <p>
-        <code>index</code> returns the position of a substring in a string, or -1 if the substring
-        is not present.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">n := index &quot;abcde&quot; &quot;de&quot;
+        <p>
+          The <code>lower</code> function takes a single argument: the string to be converted to
+          lowercase. The function returns a new string with all uppercase letters converted to
+          lowercase. All other characters are left unchanged.
+        </p>
+        <p>
+          The <code>lower</code> function uses the Unicode character database to determine which
+          characters are uppercase and their equivalent lowercase form.
+        </p>
+        <h3><a id="index" href="#index" class="anchor">#</a><code>index</code></h3>
+        <p>
+          <code>index</code> returns the position of a substring in a string, or -1 if the substring
+          is not present.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">n := index &quot;abcde&quot; &quot;de&quot;
 print n
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">3
+        <p>Output</p>
+        <pre><code class="language-evy:output">3
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>index:num s:string sub:string
+        <h4>Reference</h4>
+        <pre><code>index:num s:string sub:string
 </code></pre>
-      <p>
-        The <code>index</code> function finds the index of a substring <code>sub</code> in a string
-        <code>s</code>. It returns the index of the first occurrence of a <code>sub</code> within
-        <code>s</code>, or -1 if the substring is not present.
-      </p>
-      <h3><a id="startswith" href="#startswith" class="anchor">#</a><code>startswith</code></h3>
-      <p><code>startswith</code> tests whether a string begins with a given prefix.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">b := startswith &quot;abcde&quot; &quot;ab&quot;
+        <p>
+          The <code>index</code> function finds the index of a substring <code>sub</code> in a
+          string <code>s</code>. It returns the index of the first occurrence of a
+          <code>sub</code> within <code>s</code>, or -1 if the substring is not present.
+        </p>
+        <h3><a id="startswith" href="#startswith" class="anchor">#</a><code>startswith</code></h3>
+        <p><code>startswith</code> tests whether a string begins with a given prefix.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">b := startswith &quot;abcde&quot; &quot;ab&quot;
 print b
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">true
+        <p>Output</p>
+        <pre><code class="language-evy:output">true
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>startswith:bool s:string prefix:string
+        <h4>Reference</h4>
+        <pre><code>startswith:bool s:string prefix:string
 </code></pre>
-      <p>
-        The <code>startswith</code> function tests whether the string <code>s</code> begins with
-        <code>prefix</code> and returns <code>true</code> if <code>s</code> starts with
-        <code>prefix</code>, <code>false</code> otherwise.
-      </p>
-      <h3><a id="endswith" href="#endswith" class="anchor">#</a><code>endswith</code></h3>
-      <p><code>endswith</code> tests whether a string ends with a given suffix.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">b := endswith &quot;abcde&quot; &quot;ab&quot;
+        <p>
+          The <code>startswith</code> function tests whether the string <code>s</code> begins with
+          <code>prefix</code> and returns <code>true</code> if <code>s</code> starts with
+          <code>prefix</code>, <code>false</code> otherwise.
+        </p>
+        <h3><a id="endswith" href="#endswith" class="anchor">#</a><code>endswith</code></h3>
+        <p><code>endswith</code> tests whether a string ends with a given suffix.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">b := endswith &quot;abcde&quot; &quot;ab&quot;
 print b
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">false
+        <p>Output</p>
+        <pre><code class="language-evy:output">false
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>endswith:bool s:string suffix:string
+        <h4>Reference</h4>
+        <pre><code>endswith:bool s:string suffix:string
 </code></pre>
-      <p>
-        The <code>endswith</code> function tests whether the string <code>s</code> ends with
-        <code>suffix</code> and returns <code>true</code> if <code>s</code> ends with
-        <code>suffix</code>, <code>false</code> otherwise.
-      </p>
-      <h3><a id="trim" href="#trim" class="anchor">#</a><code>trim</code></h3>
-      <p><code>trim</code> removes leading and trailing characters from a string.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">s := trim &quot;.,..abc.de.&quot; &quot;.,&quot;
+        <p>
+          The <code>endswith</code> function tests whether the string <code>s</code> ends with
+          <code>suffix</code> and returns <code>true</code> if <code>s</code> ends with
+          <code>suffix</code>, <code>false</code> otherwise.
+        </p>
+        <h3><a id="trim" href="#trim" class="anchor">#</a><code>trim</code></h3>
+        <p><code>trim</code> removes leading and trailing characters from a string.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := trim &quot;.,..abc.de.&quot; &quot;.,&quot;
 print s
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">abc.de
+        <p>Output</p>
+        <pre><code class="language-evy:output">abc.de
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>trim:string s:string cutset:string
+        <h4>Reference</h4>
+        <pre><code>trim:string s:string cutset:string
 </code></pre>
-      <p>
-        The <code>trim</code> function removes any characters in <code>cutset</code> from the
-        beginning and end of string <code>s</code>. It returns a copy of the resulting string.
-      </p>
-      <h3><a id="replace" href="#replace" class="anchor">#</a><code>replace</code></h3>
-      <p>
-        <code>replace</code> replaces all occurrences of a substring with another substring in a
-        string.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">s := replace &quot;abc123xyzabc abc&quot; &quot;abc&quot; &quot;ABC&quot;
+        <p>
+          The <code>trim</code> function removes any characters in <code>cutset</code> from the
+          beginning and end of string <code>s</code>. It returns a copy of the resulting string.
+        </p>
+        <h3><a id="replace" href="#replace" class="anchor">#</a><code>replace</code></h3>
+        <p>
+          <code>replace</code> replaces all occurrences of a substring with another substring in a
+          string.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := replace &quot;abc123xyzabc abc&quot; &quot;abc&quot; &quot;ABC&quot;
 print s
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">ABC123xyzABC ABC
+        <p>Output</p>
+        <pre><code class="language-evy:output">ABC123xyzABC ABC
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>replace:string s:string old:string new:string
+        <h4>Reference</h4>
+        <pre><code>replace:string s:string old:string new:string
 </code></pre>
-      <p>
-        The <code>replace</code> function replaces all occurrences of the substring
-        <code>old</code> in the string <code>s</code> with the substring <code>new</code>.
-      </p>
-      <h2><a id="random" href="#random" class="anchor">#</a>Random</h2>
-      <h3><a id="rand" href="#rand" class="anchor">#</a><code>rand</code></h3>
-      <p><code>rand</code> returns a random, non-negative integer less than the argument.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (rand 3)
+        <p>
+          The <code>replace</code> function replaces all occurrences of the substring
+          <code>old</code> in the string <code>s</code> with the substring <code>new</code>.
+        </p>
+        <h2><a id="random" href="#random" class="anchor">#</a>Random</h2>
+        <h3><a id="rand" href="#rand" class="anchor">#</a><code>rand</code></h3>
+        <p><code>rand</code> returns a random, non-negative integer less than the argument.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (rand 3)
 print (rand 3)
 </code></pre>
-      <p>Sample output</p>
-      <pre><code>2
+        <p>Sample output</p>
+        <pre><code>2
 0
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>rand:num n:num
+        <h4>Reference</h4>
+        <pre><code>rand:num n:num
 </code></pre>
-      <p>
-        The <code>rand</code> functions returns, a non-negative pseudo-random integer number in the
-        half-open interval <code>[0,n)</code>. A panic occurs for <code>n &lt;= 0</code>.
-      </p>
-      <h3><a id="rand1" href="#rand1" class="anchor">#</a><code>rand1</code></h3>
-      <p><code>rand1</code> returns a random, non-negative floating point number less than 1.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (rand1)
+        <p>
+          The <code>rand</code> functions returns, a non-negative pseudo-random integer number in
+          the half-open interval <code>[0,n)</code>. A panic occurs for <code>n &lt;= 0</code>.
+        </p>
+        <h3><a id="rand1" href="#rand1" class="anchor">#</a><code>rand1</code></h3>
+        <p><code>rand1</code> returns a random, non-negative floating point number less than 1.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (rand1)
 print (rand1)
 </code></pre>
-      <p>Sample output</p>
-      <pre><code>0.7679753163102002
+        <p>Sample output</p>
+        <pre><code>0.7679753163102002
 0.6349044894123325
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>rand1:num
+        <h4>Reference</h4>
+        <pre><code>rand1:num
 </code></pre>
-      <p>
-        The <code>rand1</code> function returns a pseudo-random floating point number in the
-        half-open interval <code>[0.0,1.0)</code>.
-      </p>
-      <h2><a id="math" href="#math" class="anchor">#</a>Math</h2>
-      <h3><a id="min" href="#min" class="anchor">#</a><code>min</code></h3>
-      <p><code>min</code> returns the smaller of the two given numbers.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (min 3 1)
+        <p>
+          The <code>rand1</code> function returns a pseudo-random floating point number in the
+          half-open interval <code>[0.0,1.0)</code>.
+        </p>
+        <h2><a id="math" href="#math" class="anchor">#</a>Math</h2>
+        <h3><a id="min" href="#min" class="anchor">#</a><code>min</code></h3>
+        <p><code>min</code> returns the smaller of the two given numbers.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (min 3 1)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">1
+        <p>Output</p>
+        <pre><code class="language-evy:output">1
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>min:num n1:num n2:num
+        <h4>Reference</h4>
+        <pre><code>min:num n1:num n2:num
 </code></pre>
-      <p>The <code>min</code> function returns the smaller of the two given number arguments.</p>
-      <h3><a id="max" href="#max" class="anchor">#</a><code>max</code></h3>
-      <p><code>max</code> returns the greater of the two given numbers.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (min 3 1)
+        <p>The <code>min</code> function returns the smaller of the two given number arguments.</p>
+        <h3><a id="max" href="#max" class="anchor">#</a><code>max</code></h3>
+        <p><code>max</code> returns the greater of the two given numbers.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (min 3 1)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">1
+        <p>Output</p>
+        <pre><code class="language-evy:output">1
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>max:num n1:num n2:num
+        <h4>Reference</h4>
+        <pre><code>max:num n1:num n2:num
 </code></pre>
-      <p>The <code>max</code> function returns the greater of the two given number arguments.</p>
-      <h3><a id="floor" href="#floor" class="anchor">#</a><code>floor</code></h3>
-      <p>
-        <code>floor</code> returns the greatest integer value less than or equal to the given
-        number.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (floor 2.7)
+        <p>The <code>max</code> function returns the greater of the two given number arguments.</p>
+        <h3><a id="floor" href="#floor" class="anchor">#</a><code>floor</code></h3>
+        <p>
+          <code>floor</code> returns the greatest integer value less than or equal to the given
+          number.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (floor 2.7)
 print (floor 3)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">2
+        <p>Output</p>
+        <pre><code class="language-evy:output">2
 3
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>floor:num n:num
+        <h4>Reference</h4>
+        <pre><code>floor:num n:num
 </code></pre>
-      <p>
-        The <code>floor</code> function returns the greatest integer value less than or equal to its
-        number argument <code>n</code>.
-      </p>
-      <h3><a id="ceil" href="#ceil" class="anchor">#</a><code>ceil</code></h3>
-      <p>
-        <code>ceil</code> returns the smallest integer greater than or equal to the given number.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (ceil 2.1)
+        <p>
+          The <code>floor</code> function returns the greatest integer value less than or equal to
+          its number argument <code>n</code>.
+        </p>
+        <h3><a id="ceil" href="#ceil" class="anchor">#</a><code>ceil</code></h3>
+        <p>
+          <code>ceil</code> returns the smallest integer greater than or equal to the given number.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (ceil 2.1)
 print (ceil 4)
 </code></pre>
-      <p>Sample output</p>
-      <pre><code>3
+        <p>Sample output</p>
+        <pre><code>3
 4
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>ceil:num n:num
+        <h4>Reference</h4>
+        <pre><code>ceil:num n:num
 </code></pre>
-      <p>
-        The <code>ceil</code> function returns the smallest integer greater than or equal to its
-        number argument <code>n</code>.
-      </p>
-      <h3><a id="round" href="#round" class="anchor">#</a><code>round</code></h3>
-      <p>
-        <code>round</code> returns the nearest integer to the given number, rounding half away from
-        0.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (round 2.4)
+        <p>
+          The <code>ceil</code> function returns the smallest integer greater than or equal to its
+          number argument <code>n</code>.
+        </p>
+        <h3><a id="round" href="#round" class="anchor">#</a><code>round</code></h3>
+        <p>
+          <code>round</code> returns the nearest integer to the given number, rounding half away
+          from 0.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (round 2.4)
 print (round 2.5)
 </code></pre>
-      <p>Sample output</p>
-      <pre><code>2
+        <p>Sample output</p>
+        <pre><code>2
 3
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>round:num n:num
+        <h4>Reference</h4>
+        <pre><code>round:num n:num
 </code></pre>
-      <p>
-        The <code>round</code> function returns the nearest integer to the given number argument
-        <code>n</code>, rounding half away from 0.
-      </p>
-      <h3><a id="pow" href="#pow" class="anchor">#</a><code>pow</code></h3>
-      <p>
-        <code>pow</code> returns the value of the first number raised to the power of the second
-        number.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (pow 2 3)
+        <p>
+          The <code>round</code> function returns the nearest integer to the given number argument
+          <code>n</code>, rounding half away from 0.
+        </p>
+        <h3><a id="pow" href="#pow" class="anchor">#</a><code>pow</code></h3>
+        <p>
+          <code>pow</code> returns the value of the first number raised to the power of the second
+          number.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (pow 2 3)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">8
+        <p>Output</p>
+        <pre><code class="language-evy:output">8
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>pow:num b:num exp:num
+        <h4>Reference</h4>
+        <pre><code>pow:num b:num exp:num
 </code></pre>
-      <p>
-        The <code>pow</code> function returns <code>b</code> to the power of <code>exp</code>. The
-        first number argument <code>b</code> is the base. The second number argument
-        <code>exp</code> is the exponent.
-      </p>
-      <h3><a id="log" href="#log" class="anchor">#</a><code>log</code></h3>
-      <p><code>log</code> returns the logarithm of the given number, to the base of e.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">printf &quot;%.2f\n&quot; (log 1)
+        <p>
+          The <code>pow</code> function returns <code>b</code> to the power of <code>exp</code>. The
+          first number argument <code>b</code> is the base. The second number argument
+          <code>exp</code> is the exponent.
+        </p>
+        <h3><a id="log" href="#log" class="anchor">#</a><code>log</code></h3>
+        <p><code>log</code> returns the logarithm of the given number, to the base of e.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">printf &quot;%.2f\n&quot; (log 1)
 printf &quot;%.2f\n&quot; (log 2.7183) // e
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">0.00
+        <p>Output</p>
+        <pre><code class="language-evy:output">0.00
 1.00
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>log:num n:num
+        <h4>Reference</h4>
+        <pre><code>log:num n:num
 </code></pre>
-      <p>
-        The <code>log</code> function returns the <strong>natural logarithm</strong>, the logarithm
-        of the given number argument <code>n</code>, to the base of <code>e</code>.
-      </p>
-      <h3><a id="sqrt" href="#sqrt" class="anchor">#</a><code>sqrt</code></h3>
-      <p><code>sqrt</code> returns the square root of the given number.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">print (sqrt 9)
+        <p>
+          The <code>log</code> function returns the <strong>natural logarithm</strong>, the
+          logarithm of the given number argument <code>n</code>, to the base of <code>e</code>.
+        </p>
+        <h3><a id="sqrt" href="#sqrt" class="anchor">#</a><code>sqrt</code></h3>
+        <p><code>sqrt</code> returns the square root of the given number.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (sqrt 9)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">3
+        <p>Output</p>
+        <pre><code class="language-evy:output">3
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>sqrt:num n:num
+        <h4>Reference</h4>
+        <pre><code>sqrt:num n:num
 </code></pre>
-      <p>
-        The <code>sqrt</code> function returns the positive square root of the number argument
-        <code>n</code>.
-      </p>
-      <h3><a id="sin" href="#sin" class="anchor">#</a><code>sin</code></h3>
-      <p><code>sin</code> returns the sine of the given angle in radians.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">pi := 3.14159265
+        <p>
+          The <code>sqrt</code> function returns the positive square root of the number argument
+          <code>n</code>.
+        </p>
+        <h3><a id="sin" href="#sin" class="anchor">#</a><code>sin</code></h3>
+        <p><code>sin</code> returns the sine of the given angle in radians.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">pi := 3.14159265
 print (sin 0.5*pi)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">1
+        <p>Output</p>
+        <pre><code class="language-evy:output">1
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>sin:num n:num
+        <h4>Reference</h4>
+        <pre><code>sin:num n:num
 </code></pre>
-      <p>
-        The <code>sin</code> function returns the sine of the given angle <code>n</code> in radians.
-      </p>
-      <h3><a id="cos" href="#cos" class="anchor">#</a><code>cos</code></h3>
-      <p><code>cos</code> returns the cosine of the given angle in radians.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">pi := 3.14159265
+        <p>
+          The <code>sin</code> function returns the sine of the given angle <code>n</code> in
+          radians.
+        </p>
+        <h3><a id="cos" href="#cos" class="anchor">#</a><code>cos</code></h3>
+        <p><code>cos</code> returns the cosine of the given angle in radians.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">pi := 3.14159265
 print (cos pi)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">-1
+        <p>Output</p>
+        <pre><code class="language-evy:output">-1
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>cos:num n:num
+        <h4>Reference</h4>
+        <pre><code>cos:num n:num
 </code></pre>
-      <p>
-        The <code>cos</code> function returns the cosine of the given angle <code>n</code> in
-        radians.
-      </p>
-      <h3><a id="atan2" href="#atan2" class="anchor">#</a><code>atan2</code></h3>
-      <p>
-        <code>atan2</code> returns the angle in radians between the positive x-axis and the ray from
-        the origin to the point <code>x y</code>.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">pi := 3.14159265
+        <p>
+          The <code>cos</code> function returns the cosine of the given angle <code>n</code> in
+          radians.
+        </p>
+        <h3><a id="atan2" href="#atan2" class="anchor">#</a><code>atan2</code></h3>
+        <p>
+          <code>atan2</code> returns the angle in radians between the positive x-axis and the ray
+          from the origin to the point <code>x y</code>.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">pi := 3.14159265
 rad := atan2 1 1
 degrees := rad * 180 / pi
 printf &quot;rad: %.2f degrees: %.2f&quot; rad degrees
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">rad: 0.79 degrees: 45.00
+        <p>Output</p>
+        <pre><code class="language-evy:output">rad: 0.79 degrees: 45.00
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>atan2:num y:num x:num
+        <h4>Reference</h4>
+        <pre><code>atan2:num y:num x:num
 </code></pre>
-      <p>
-        The <code>atan2</code> function returns the angle in radians between the positive x-axis and
-        the ray from the origin to the point <code>x y</code>. More formally, it returns the arc
-        tangent of <code>y/x</code> for given arguments <code>y</code> and <code>x</code>, using the
-        signs of the two to determine the quadrant of the return value.
-      </p>
-      <h2><a id="graphics" href="#graphics" class="anchor">#</a>Graphics</h2>
-      <p>
-        Evy on the web outputs drawing commands to a drawing area called the
-        <strong>canvas</strong>.
-      </p>
-      <p>
-        Positions on the canvas are defined by a coordinate system, similar to the Cartesian
-        coordinate system used in mathematics. The horizontal dimension is called the
-        <strong>x-axis</strong>, and the vertical dimension is called the <strong>y-axis</strong>.
-      </p>
-      <p>
-        A point on the canvas is defined by its <strong>x</strong> and
-        <strong>y coordinates</strong>, which are written as <code>x y</code>. For example, the
-        point <code>30 60</code> has an x-coordinate of 30 and a y-coordinate of 60. It is located
-        30 units from the left edge of the canvas and 60 units from the bottom edge.
-      </p>
-      <img
-        width="300"
-        alt="Cartesian coordinates with x and y axes and point (30, 60)"
-        src="img/coords.png"
-      />
-      <p>
-        <a
-          href="/play#content=H4sIAAAAAAAAE0WRwW6EIBCG7/MUE86NAV1w8dqkL7HxYJFtSVE2rmnXNn33DgL2NDMfA///h7fFjWCCDwuyVz+YDwZfblzfkVcnAO9mixwF5zCFz9jyxIhQC7fgN7zsQ48XfUZRydTEOfG8tL8SYSVRn/sIcokc4BrmFX/u7tt2J7wOk/Nbx17cMuBzGO0TTmEO99tgLPtNXrREAat9rMgeLCFBMKPtQGWJM0ioOVJQp3gJqY48hKUma7VG2VJtRK47z0t0qGKeus3LLSrRF56laomqzvq72OFBYK2L1e6fC5JQJVXXRJ4/Z7EjO/yTV+MW4+kC/AGSFdVbwgEAAA=="
-          >Evy source: coordinates</a
-        >.
-      </p>
-      <p>
-        The canvas ranges from coordinates <code>0 0</code> to <code>100 100</code>. The center of
-        the canvas has the coordinates <code>50 50</code>.
-      </p>
-      <p>
-        Shapes are drawn on the canvas using a <strong>pen</strong>. The pen has an
-        <code>x y</code> position and a style. The position of the pen is also known as the current
-        <strong>cursor position</strong>.
-      </p>
-      <p>
-        Some graphics functions, like <code>line</code>, <code>rect</code>, <code>circle</code>, and
-        <code>text</code>, create shapes on the canvas. Other graphics functions such as
-        <code>color</code>, <code>width</code>, and <code>font</code> set the style of the pen for
-        subsequent drawing commands.
-      </p>
-      <h3><a id="move" href="#move" class="anchor">#</a><code>move</code></h3>
-      <p><code>move</code> sets the position of the pen to the given coordinates.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">grid
+        <p>
+          The <code>atan2</code> function returns the angle in radians between the positive x-axis
+          and the ray from the origin to the point <code>x y</code>. More formally, it returns the
+          arc tangent of <code>y/x</code> for given arguments <code>y</code> and <code>x</code>,
+          using the signs of the two to determine the quadrant of the return value.
+        </p>
+        <h2><a id="graphics" href="#graphics" class="anchor">#</a>Graphics</h2>
+        <p>
+          Evy on the web outputs drawing commands to a drawing area called the
+          <strong>canvas</strong>.
+        </p>
+        <p>
+          Positions on the canvas are defined by a coordinate system, similar to the Cartesian
+          coordinate system used in mathematics. The horizontal dimension is called the
+          <strong>x-axis</strong>, and the vertical dimension is called the <strong>y-axis</strong>.
+        </p>
+        <p>
+          A point on the canvas is defined by its <strong>x</strong> and
+          <strong>y coordinates</strong>, which are written as <code>x y</code>. For example, the
+          point <code>30 60</code> has an x-coordinate of 30 and a y-coordinate of 60. It is located
+          30 units from the left edge of the canvas and 60 units from the bottom edge.
+        </p>
+        <img
+          width="300"
+          alt="Cartesian coordinates with x and y axes and point (30, 60)"
+          src="img/coords.png"
+        />
+        <p>
+          <a
+            href="/play#content=H4sIAAAAAAAAE0WRwW6EIBCG7/MUE86NAV1w8dqkL7HxYJFtSVE2rmnXNn33DgL2NDMfA///h7fFjWCCDwuyVz+YDwZfblzfkVcnAO9mixwF5zCFz9jyxIhQC7fgN7zsQ48XfUZRydTEOfG8tL8SYSVRn/sIcokc4BrmFX/u7tt2J7wOk/Nbx17cMuBzGO0TTmEO99tgLPtNXrREAat9rMgeLCFBMKPtQGWJM0ioOVJQp3gJqY48hKUma7VG2VJtRK47z0t0qGKeus3LLSrRF56laomqzvq72OFBYK2L1e6fC5JQJVXXRJ4/Z7EjO/yTV+MW4+kC/AGSFdVbwgEAAA=="
+            >Evy source: coordinates</a
+          >.
+        </p>
+        <p>
+          The canvas ranges from coordinates <code>0 0</code> to <code>100 100</code>. The center of
+          the canvas has the coordinates <code>50 50</code>.
+        </p>
+        <p>
+          Shapes are drawn on the canvas using a <strong>pen</strong>. The pen has an
+          <code>x y</code> position and a style. The position of the pen is also known as the
+          current <strong>cursor position</strong>.
+        </p>
+        <p>
+          Some graphics functions, like <code>line</code>, <code>rect</code>, <code>circle</code>,
+          and <code>text</code>, create shapes on the canvas. Other graphics functions such as
+          <code>color</code>, <code>width</code>, and <code>font</code> set the style of the pen for
+          subsequent drawing commands.
+        </p>
+        <h3><a id="move" href="#move" class="anchor">#</a><code>move</code></h3>
+        <p><code>move</code> sets the position of the pen to the given coordinates.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">grid
 move 30 60
 circle 1
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="small black dot at coords 30 60" src="img/move-30-60.png" />
-      <h4>Reference</h4>
-      <pre><code>move x:num y:num
+        <p>Output</p>
+        <img width="300" alt="small black dot at coords 30 60" src="img/move-30-60.png" />
+        <h4>Reference</h4>
+        <pre><code>move x:num y:num
 </code></pre>
-      <p>
-        The <code>move</code> function sets the position of the cursor to the given
-        <code>x</code> and <code>y</code> coordinates. The initial cursor position is
-        <code>0 0</code>.
-      </p>
-      <h3><a id="line" href="#line" class="anchor">#</a><code>line</code></h3>
-      <p>
-        <code>line</code> draws a line from the current position of the pen to the given
-        coordinates.
-      </p>
-      <h4>Example</h4>
-      <p>The following example draws a triangle.</p>
-      <pre><code class="language-evy">move 30 20
+        <p>
+          The <code>move</code> function sets the position of the cursor to the given
+          <code>x</code> and <code>y</code> coordinates. The initial cursor position is
+          <code>0 0</code>.
+        </p>
+        <h3><a id="line" href="#line" class="anchor">#</a><code>line</code></h3>
+        <p>
+          <code>line</code> draws a line from the current position of the pen to the given
+          coordinates.
+        </p>
+        <h4>Example</h4>
+        <p>The following example draws a triangle.</p>
+        <pre><code class="language-evy">move 30 20
 line 70 20
 line 50 50
 line 30 20
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="triangle in bottom half of canvas" src="img/triangle.png" />
-      <h4>Reference</h4>
-      <pre><code>line x:num y:num
+        <p>Output</p>
+        <img width="300" alt="triangle in bottom half of canvas" src="img/triangle.png" />
+        <h4>Reference</h4>
+        <pre><code>line x:num y:num
 </code></pre>
-      <p>
-        The <code>line</code> function draws a line from the current cursor position to the given
-        <code>x</code> and <code>y</code> coordinates. The cursor position is then updated to the
-        given coordinates, which allows for easy polygon drawing.
-      </p>
-      <h3><a id="rect" href="#rect" class="anchor">#</a><code>rect</code></h3>
-      <p>
-        <code>rect</code> draws a rectangle with the given width and height at the pen's current
-        position.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">grid
+        <p>
+          The <code>line</code> function draws a line from the current cursor position to the given
+          <code>x</code> and <code>y</code> coordinates. The cursor position is then updated to the
+          given coordinates, which allows for easy polygon drawing.
+        </p>
+        <h3><a id="rect" href="#rect" class="anchor">#</a><code>rect</code></h3>
+        <p>
+          <code>rect</code> draws a rectangle with the given width and height at the pen's current
+          position.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">grid
 move 40 20
 rect 10 30
 rect 40 20
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="two black rectangles with touching vertices" src="img/rects.png" />
-      <h4>Reference</h4>
-      <pre><code>rect width:num height:num
+        <p>Output</p>
+        <img width="300" alt="two black rectangles with touching vertices" src="img/rects.png" />
+        <h4>Reference</h4>
+        <pre><code>rect width:num height:num
 </code></pre>
-      <p>
-        The <code>rect</code> function draws a rectangle with the given <code>width</code> and
-        <code>height</code> at the current cursor position. The cursor position is then updated to
-        the position that is the width and height away from the current position. In other words,
-        the opposite corner of the rectangle is at the new cursor position.
-      </p>
-      <h3><a id="circle" href="#circle" class="anchor">#</a><code>circle</code></h3>
-      <p><code>circle</code> draws a circle with given radius at the pen's current position.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">grid
+        <p>
+          The <code>rect</code> function draws a rectangle with the given <code>width</code> and
+          <code>height</code> at the current cursor position. The cursor position is then updated to
+          the position that is the width and height away from the current position. In other words,
+          the opposite corner of the rectangle is at the new cursor position.
+        </p>
+        <h3><a id="circle" href="#circle" class="anchor">#</a><code>circle</code></h3>
+        <p><code>circle</code> draws a circle with given radius at the pen's current position.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">grid
 move 50 50
 circle 10
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="black circle in the canvas center" src="img/circle.png" />
-      <h4>Reference</h4>
-      <pre><code>circle radius:num
+        <p>Output</p>
+        <img width="300" alt="black circle in the canvas center" src="img/circle.png" />
+        <h4>Reference</h4>
+        <pre><code>circle radius:num
 </code></pre>
-      <p>
-        The <code>circle</code> function draws a circle with the given <code>radius</code> centered
-        at the current cursor position. The cursor position does not change after drawing a circle.
-      </p>
-      <h3><a id="color" href="#color" class="anchor">#</a><code>color</code></h3>
-      <p>
-        <code>color</code> changes the color of the pen. All
-        <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value"
-          >CSS (Cascading Style Sheets) color values</a
-        >
-        are supported. You can start by using the simpler
-        <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/named-color">named CSS colors</a>
-        , such as <code>&quot;red&quot;</code>, <code>&quot;darkmagenta&quot;</code>, and
-        <code>&quot;springgreen&quot;</code>.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">color &quot;darkmagenta&quot;
+        <p>
+          The <code>circle</code> function draws a circle with the given
+          <code>radius</code> centered at the current cursor position. The cursor position does not
+          change after drawing a circle.
+        </p>
+        <h3><a id="color" href="#color" class="anchor">#</a><code>color</code></h3>
+        <p>
+          <code>color</code> changes the color of the pen. All
+          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value"
+            >CSS (Cascading Style Sheets) color values</a
+          >
+          are supported. You can start by using the simpler
+          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/named-color"
+            >named CSS colors</a
+          >
+          , such as <code>&quot;red&quot;</code>, <code>&quot;darkmagenta&quot;</code>, and
+          <code>&quot;springgreen&quot;</code>.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">color &quot;darkmagenta&quot;
 rect 20 20
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="dark magenta square in bottom left corner" src="img/magenta.png" />
-      <h4>Reference</h4>
-      <pre><code>color c:string
+        <p>Output</p>
+        <img width="300" alt="dark magenta square in bottom left corner" src="img/magenta.png" />
+        <h4>Reference</h4>
+        <pre><code>color c:string
 </code></pre>
-      <p>
-        The <code>color</code> function changes the color of the <strong>stroke</strong> and the
-        <strong>fill</strong> to the given CSS color string <code>c</code>. Evy supports all
-        <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value">CSS color values</a>,
-        including semi-transparent ones. For example, the following code changes the color to a
-        shade of red that is 60% opaque: <code>color &quot;hsl (0deg 100% 50% / 60%)&quot;</code>.
-      </p>
-      <p>
-        <strong>Named CSS colors</strong>, such as <code>&quot;red&quot;</code>,
-        <code>&quot;darkmagenta&quot;</code>, and <code>&quot;springgreen&quot;</code>, are a
-        simpler way of specifying common colors. For a complete list of named CSS colors, see the
-        <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/named-color"
-          >Mozilla Developer documentation</a
-        >.
-      </p>
-      <p>
-        If the color string <code>c</code> is not recognized as a valid CSS color, the color does
-        not change. The initial color is <code>&quot;black&quot;</code>.
-      </p>
-      <h3><a id="colour" href="#colour" class="anchor">#</a><code>colour</code></h3>
-      <p>
-        <code>colour</code> is an alternate spelling of <code>color</code>. See
-        <a href="#color"><code>color</code></a
-        >.
-      </p>
-      <h3><a id="width" href="#width" class="anchor">#</a><code>width</code></h3>
-      <p><code>width</code> sets the thickness of the lines drawn by the pen.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">width 10
+        <p>
+          The <code>color</code> function changes the color of the <strong>stroke</strong> and the
+          <strong>fill</strong> to the given CSS color string <code>c</code>. Evy supports all
+          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value">CSS color values</a
+          >, including semi-transparent ones. For example, the following code changes the color to a
+          shade of red that is 60% opaque: <code>color &quot;hsl (0deg 100% 50% / 60%)&quot;</code>.
+        </p>
+        <p>
+          <strong>Named CSS colors</strong>, such as <code>&quot;red&quot;</code>,
+          <code>&quot;darkmagenta&quot;</code>, and <code>&quot;springgreen&quot;</code>, are a
+          simpler way of specifying common colors. For a complete list of named CSS colors, see the
+          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/named-color"
+            >Mozilla Developer documentation</a
+          >.
+        </p>
+        <p>
+          If the color string <code>c</code> is not recognized as a valid CSS color, the color does
+          not change. The initial color is <code>&quot;black&quot;</code>.
+        </p>
+        <h3><a id="colour" href="#colour" class="anchor">#</a><code>colour</code></h3>
+        <p>
+          <code>colour</code> is an alternate spelling of <code>color</code>. See
+          <a href="#color"><code>color</code></a
+          >.
+        </p>
+        <h3><a id="width" href="#width" class="anchor">#</a><code>width</code></h3>
+        <p><code>width</code> sets the thickness of the lines drawn by the pen.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">width 10
 line 30 30
 width 1
 line 60 60
@@ -1808,79 +1826,79 @@ width 0.1
 line 90 90
 grid
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="diagonal lines of different width" src="img/width.png" />
-      <h4>Reference</h4>
-      <pre><code>width n:num
+        <p>Output</p>
+        <img width="300" alt="diagonal lines of different width" src="img/width.png" />
+        <h4>Reference</h4>
+        <pre><code>width n:num
 </code></pre>
-      <p>
-        The <code>width</code> function sets the thickness of the <strong>stroke</strong> to the
-        given <code>n</code>
-        units. The stroke is the visible line that is drawn when using the
-        <code>line</code> function or any other shape function after setting
-        <code>fill &quot;none&quot;</code>. The initial stroke width it 0.1 units.
-      </p>
-      <h3><a id="clear" href="#clear" class="anchor">#</a><code>clear</code></h3>
-      <p>
-        <code>clear</code> clears the canvas. Optionally, it can take a color argument to clear the
-        canvas to.
-      </p>
-      <h4>Example</h4>
-      <p>
-        The following example code shows how to draw a magenta square, clear the canvas, and then
-        draw a blue circle. The final result is a canvas with a blue circle centered at
-        <code>20 20</code>. The magenta square is not visible because it has been removed by the
-        <code>clear</code> function.
-      </p>
-      <pre><code class="language-evy">color &quot;darkmagenta&quot;
+        <p>
+          The <code>width</code> function sets the thickness of the <strong>stroke</strong> to the
+          given <code>n</code>
+          units. The stroke is the visible line that is drawn when using the
+          <code>line</code> function or any other shape function after setting
+          <code>fill &quot;none&quot;</code>. The initial stroke width it 0.1 units.
+        </p>
+        <h3><a id="clear" href="#clear" class="anchor">#</a><code>clear</code></h3>
+        <p>
+          <code>clear</code> clears the canvas. Optionally, it can take a color argument to clear
+          the canvas to.
+        </p>
+        <h4>Example</h4>
+        <p>
+          The following example code shows how to draw a magenta square, clear the canvas, and then
+          draw a blue circle. The final result is a canvas with a blue circle centered at
+          <code>20 20</code>. The magenta square is not visible because it has been removed by the
+          <code>clear</code> function.
+        </p>
+        <pre><code class="language-evy">color &quot;darkmagenta&quot;
 rect 20 20
 clear
 color &quot;blue&quot;
 circle 5
 grid
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="blue circle in bottom left corner" src="img/blue-circle.png" />
-      <h4>Reference</h4>
-      <pre><code>clear [c:string]
+        <p>Output</p>
+        <img width="300" alt="blue circle in bottom left corner" src="img/blue-circle.png" />
+        <h4>Reference</h4>
+        <pre><code>clear [c:string]
 </code></pre>
-      <p>
-        The <code>clear</code> function clears the canvas. It can optionally take a color as a
-        string argument, in which case the canvas will be cleared to that color. If no color is
-        specified, the canvas will be cleared to <code>&quot;white&quot;</code>. Initially the
-        canvas is cleared to <code>&quot;white&quot;</code>, not
-        <code>&quot;transparent&quot;</code>.
-      </p>
-      <h3><a id="grid" href="#grid" class="anchor">#</a><code>grid</code></h3>
-      <p>
-        <code>grid</code> draws a grid on the canvas. The grid is parallel to the x and y axes, and
-        each grid line is spaced 10 units apart.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">grid
+        <p>
+          The <code>clear</code> function clears the canvas. It can optionally take a color as a
+          string argument, in which case the canvas will be cleared to that color. If no color is
+          specified, the canvas will be cleared to <code>&quot;white&quot;</code>. Initially the
+          canvas is cleared to <code>&quot;white&quot;</code>, not
+          <code>&quot;transparent&quot;</code>.
+        </p>
+        <h3><a id="grid" href="#grid" class="anchor">#</a><code>grid</code></h3>
+        <p>
+          <code>grid</code> draws a grid on the canvas. The grid is parallel to the x and y axes,
+          and each grid line is spaced 10 units apart.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">grid
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="10x10 grid lines" src="img/grid.png" />
-      <h4>Reference</h4>
-      <pre><code>grid
+        <p>Output</p>
+        <img width="300" alt="10x10 grid lines" src="img/grid.png" />
+        <h4>Reference</h4>
+        <pre><code>grid
 </code></pre>
-      <p>
-        The <code>grid</code> function draws a grid on the canvas. The grid lines are parallel to
-        the x and y axes, and each grid line is spaced 10 units apart. The grid lines are 0.1 units
-        thin and have a semi-transparent gray color, with an opacity of 50%. This makes the grid
-        lines faint enough to be drawn on top of other shapes. The grid lines that go through the
-        point <code>50 50</code>, which is the center of the canvas, are slightly thicker. The
-        thickness of these grid lines is 0.2 units, which makes it easier to see the center of the
-        canvas.
-      </p>
-      <p>
-        The <code>grid</code> function is a shorthand of the <code>gridn</code> function with the
-        arguments <code>10</code> and <code>&quot;hsl(0deg 100% 0% / 50%)&quot;</code>, see
-        <a href="#gridn"><code>gridn</code></a
-        >. It is roughly equivalent to the following Evy code. However, the current color, cursor
-        position, and line width are not affected by the built-in <code>grid</code> function.
-      </p>
-      <pre><code class="language-evy">color &quot;hsl(0deg 100% 0% / 50%)&quot;
+        <p>
+          The <code>grid</code> function draws a grid on the canvas. The grid lines are parallel to
+          the x and y axes, and each grid line is spaced 10 units apart. The grid lines are 0.1
+          units thin and have a semi-transparent gray color, with an opacity of 50%. This makes the
+          grid lines faint enough to be drawn on top of other shapes. The grid lines that go through
+          the point <code>50 50</code>, which is the center of the canvas, are slightly thicker. The
+          thickness of these grid lines is 0.2 units, which makes it easier to see the center of the
+          canvas.
+        </p>
+        <p>
+          The <code>grid</code> function is a shorthand of the <code>gridn</code> function with the
+          arguments <code>10</code> and <code>&quot;hsl(0deg 100% 0% / 50%)&quot;</code>, see
+          <a href="#gridn"><code>gridn</code></a
+          >. It is roughly equivalent to the following Evy code. However, the current color, cursor
+          position, and line width are not affected by the built-in <code>grid</code> function.
+        </p>
+        <pre><code class="language-evy">color &quot;hsl(0deg 100% 0% / 50%)&quot;
 for i := range 0 101 10
     width 0.1
     if i == 50
@@ -1892,33 +1910,33 @@ for i := range 0 101 10
     line 100 i
 end
 </code></pre>
-      <h3><a id="gridn" href="#gridn" class="anchor">#</a><code>gridn</code></h3>
-      <p>
-        <code>gridn</code> draws a grid on the canvas. The grid is parallel to the x and y axes, and
-        each grid line is spaced the given number of units apart. The color of the grid is set to
-        the given color.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">gridn 2 &quot;red&quot;
+        <h3><a id="gridn" href="#gridn" class="anchor">#</a><code>gridn</code></h3>
+        <p>
+          <code>gridn</code> draws a grid on the canvas. The grid is parallel to the x and y axes,
+          and each grid line is spaced the given number of units apart. The color of the grid is set
+          to the given color.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">gridn 2 &quot;red&quot;
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="50x50 red grid lines" src="img/gridn.png" />
-      <h4>Reference</h4>
-      <pre><code>gridn n:num c:string
+        <p>Output</p>
+        <img width="300" alt="50x50 red grid lines" src="img/gridn.png" />
+        <h4>Reference</h4>
+        <pre><code>gridn n:num c:string
 </code></pre>
-      <p>
-        The <code>gridn</code> function draws a grid on the canvas. The grid lines are parallel to
-        the x and y axes, and each grid line is spaced <code>n</code> units apart. The color of the
-        grid is set to the color specified by the string argument <code>c</code>. The default line
-        width is 0.1 units. Every fifth grid line is slightly thicker, with a line width of 0.2
-        units.
-      </p>
-      <p>
-        The <code>gridn</code> function is roughly equivalent to the following Evy code, but the
-        current color, cursor position, and line width are not affected by the built-in
-        <code>gridn</code> function.
-      </p>
-      <pre><code class="language-evy">c := &quot;red&quot;
+        <p>
+          The <code>gridn</code> function draws a grid on the canvas. The grid lines are parallel to
+          the x and y axes, and each grid line is spaced <code>n</code> units apart. The color of
+          the grid is set to the color specified by the string argument <code>c</code>. The default
+          line width is 0.1 units. Every fifth grid line is slightly thicker, with a line width of
+          0.2 units.
+        </p>
+        <p>
+          The <code>gridn</code> function is roughly equivalent to the following Evy code, but the
+          current color, cursor position, and line width are not affected by the built-in
+          <code>gridn</code> function.
+        </p>
+        <pre><code class="language-evy">c := &quot;red&quot;
 n := 2
 
 color c
@@ -1935,11 +1953,11 @@ for i := range 0 101 n
     line 100 i
 end
 </code></pre>
-      <h3><a id="poly" href="#poly" class="anchor">#</a><code>poly</code></h3>
-      <p><code>poly</code> draws polylines and polygons for the given coordinates.</p>
-      <h4>Example</h4>
-      <p>The following code draws a w-shaped red polyline and a yellow triangle.</p>
-      <pre><code class="language-evy">width 1
+        <h3><a id="poly" href="#poly" class="anchor">#</a><code>poly</code></h3>
+        <p><code>poly</code> draws polylines and polygons for the given coordinates.</p>
+        <h4>Example</h4>
+        <p>The following code draws a w-shaped red polyline and a yellow triangle.</p>
+        <pre><code class="language-evy">width 1
 color &quot;red&quot;
 
 fill &quot;none&quot;
@@ -1948,36 +1966,37 @@ poly [10 80] [30 60] [50 80] [70 60] [90 80]
 fill &quot;gold&quot;
 poly [10 20] [50 50] [20 10] [10 20]
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="w-shaped red polyline, yellow triangle" src="img/poly.png" />
-      <h4>Reference</h4>
-      <pre><code>poly xy:[]num...
+        <p>Output</p>
+        <img width="300" alt="w-shaped red polyline, yellow triangle" src="img/poly.png" />
+        <h4>Reference</h4>
+        <pre><code>poly xy:[]num...
 </code></pre>
-      <p>
-        The <code>poly</code> function draws polylines and polygons for the given coordinates. A
-        polyline is a sequence of connected line segments, and a polygon is a closed polyline.
-      </p>
-      <p>
-        The <code>poly</code> function takes a variadic number of arguments of type
-        <code>[]num</code>. Each argument has to be a number array with two elements
-        <code>[x y]</code>. The first element representing the x coordinate and the second the y
-        coordinate of a vertex in the polyline or polygon. If the array does not have two elements,
-        a panic occurs. For example, the <code>poly</code> function can be called as follows:
-      </p>
-      <pre><code>poly [x1 y1] [x2 y2] [x3 y3]
+        <p>
+          The <code>poly</code> function draws polylines and polygons for the given coordinates. A
+          polyline is a sequence of connected line segments, and a polygon is a closed polyline.
+        </p>
+        <p>
+          The <code>poly</code> function takes a variadic number of arguments of type
+          <code>[]num</code>. Each argument has to be a number array with two elements
+          <code>[x y]</code>. The first element representing the x coordinate and the second the y
+          coordinate of a vertex in the polyline or polygon. If the array does not have two
+          elements, a panic occurs. For example, the <code>poly</code> function can be called as
+          follows:
+        </p>
+        <pre><code>poly [x1 y1] [x2 y2] [x3 y3]
 </code></pre>
-      <p>
-        Use <code>fill &quot;none&quot;</code> to draw a line without filling. To draw a closed
-        polygon, make sure that the first and last coordinates are the same. The
-        <code>poly</code> function does not use or change the cursor position.
-      </p>
-      <h3><a id="ellipse" href="#ellipse" class="anchor">#</a><code>ellipse</code></h3>
-      <p>
-        <code>ellipse</code> draws an ellipse for given center, radii and optional tilt, start and
-        end angles.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">// red circle
+        <p>
+          Use <code>fill &quot;none&quot;</code> to draw a line without filling. To draw a closed
+          polygon, make sure that the first and last coordinates are the same. The
+          <code>poly</code> function does not use or change the cursor position.
+        </p>
+        <h3><a id="ellipse" href="#ellipse" class="anchor">#</a><code>ellipse</code></h3>
+        <p>
+          <code>ellipse</code> draws an ellipse for given center, radii and optional tilt, start and
+          end angles.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">// red circle
 color &quot;red&quot;
 ellipse 50 50 40
 
@@ -1993,75 +2012,79 @@ ellipse 50 50 40 10 45
 color &quot;white&quot;
 ellipse 50 50 40 10 135 0 180
 </code></pre>
-      <p>Output</p>
-      <img
-        width="300"
-        alt="red circle with yellow ellilpse, tilted blue ellipse and whit half-ellipse"
-        src="img/ellipse.png"
-      />
-      <h4>Reference</h4>
-      <pre><code>ellipse x:num y:num rx:num [ry:num [tilt:num [start:num end:num]]]
+        <p>Output</p>
+        <img
+          width="300"
+          alt="red circle with yellow ellilpse, tilted blue ellipse and whit half-ellipse"
+          src="img/ellipse.png"
+        />
+        <h4>Reference</h4>
+        <pre><code>ellipse x:num y:num rx:num [ry:num [tilt:num [start:num end:num]]]
 </code></pre>
-      <p>
-        The <code>ellipse</code> function draws an ellipse with the given center, radii, tilt, and
-        start and end angles. It can take 3, 4, 5, or 7 arguments. Default values are used for
-        omitted arguments.
-      </p>
-      <p>
-        The first two arguments are the coordinates of the center of the ellipse. The third argument
-        is the radius of the ellipse in the x direction. The fourth argument is the radius of the
-        ellipse in the y direction. If the fourth argument is omitted, the ellipse is drawn as a
-        circle. The fifth argument is the tilt of the ellipse in degrees, with a default value of 0.
-        The sixth and seventh arguments are the start and end angles of the ellipse in degrees, with
-        default values of 0 and 360, respectively.
-      </p>
-      <h3><a id="stroke" href="#stroke" class="anchor">#</a><code>stroke</code></h3>
-      <p><code>stroke</code> sets the color of the outline of shapes.</p>
-      <h4>Example</h4>
-      <p>The following code draws two red squares, one with a blue outline.</p>
-      <pre><code class="language-evy">width 1
+        <p>
+          The <code>ellipse</code> function draws an ellipse with the given center, radii, tilt, and
+          start and end angles. It can take 3, 4, 5, or 7 arguments. Default values are used for
+          omitted arguments.
+        </p>
+        <p>
+          The first two arguments are the coordinates of the center of the ellipse. The third
+          argument is the radius of the ellipse in the x direction. The fourth argument is the
+          radius of the ellipse in the y direction. If the fourth argument is omitted, the ellipse
+          is drawn as a circle. The fifth argument is the tilt of the ellipse in degrees, with a
+          default value of 0. The sixth and seventh arguments are the start and end angles of the
+          ellipse in degrees, with default values of 0 and 360, respectively.
+        </p>
+        <h3><a id="stroke" href="#stroke" class="anchor">#</a><code>stroke</code></h3>
+        <p><code>stroke</code> sets the color of the outline of shapes.</p>
+        <h4>Example</h4>
+        <p>The following code draws two red squares, one with a blue outline.</p>
+        <pre><code class="language-evy">width 1
 color &quot;red&quot;
 rect 30 30
 
 stroke &quot;blue&quot;
 rect 30 30
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="two red sqaures one with blue outline" src="img/stroke.png" />
-      <h4>Reference</h4>
-      <pre><code>stroke c:string
+        <p>Output</p>
+        <img width="300" alt="two red sqaures one with blue outline" src="img/stroke.png" />
+        <h4>Reference</h4>
+        <pre><code>stroke c:string
 </code></pre>
-      <p>
-        The <code>stroke</code> function sets the color of the <strong>stroke</strong> to the given
-        string argument <code>c</code>. The stroke is the visible line that is drawn when you use
-        the line function or any other shape function after calling fill &quot;none&quot;. The
-        initial stroke color is <code>&quot;black&quot;</code>.
-      </p>
-      <h3><a id="fill" href="#fill" class="anchor">#</a><code>fill</code></h3>
-      <p><code>fill</code> sets the color of the interior of shapes.</p>
-      <h4>Example</h4>
-      <p>The following code draws a red square and a blue square with a red outline.</p>
-      <pre><code class="language-evy">width 1
+        <p>
+          The <code>stroke</code> function sets the color of the <strong>stroke</strong> to the
+          given string argument <code>c</code>. The stroke is the visible line that is drawn when
+          you use the line function or any other shape function after calling fill &quot;none&quot;.
+          The initial stroke color is <code>&quot;black&quot;</code>.
+        </p>
+        <h3><a id="fill" href="#fill" class="anchor">#</a><code>fill</code></h3>
+        <p><code>fill</code> sets the color of the interior of shapes.</p>
+        <h4>Example</h4>
+        <p>The following code draws a red square and a blue square with a red outline.</p>
+        <pre><code class="language-evy">width 1
 color &quot;red&quot;
 rect 30 30
 
 fill &quot;blue&quot;
 rect 30 30
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="a red sqaures and a blue square with red outline" src="img/fill.png" />
-      <h4>Reference</h4>
-      <pre><code>fill c:string
+        <p>Output</p>
+        <img
+          width="300"
+          alt="a red sqaures and a blue square with red outline"
+          src="img/fill.png"
+        />
+        <h4>Reference</h4>
+        <pre><code>fill c:string
 </code></pre>
-      <p>
-        The <code>fill</code> function sets the color of the <strong>fill</strong> to the given
-        string argument <code>c</code>. The fill is the interior of a shape. The initial fill color
-        is <code>&quot;black&quot;</code>.
-      </p>
-      <h3><a id="dash" href="#dash" class="anchor">#</a><code>dash</code></h3>
-      <p><code>dash</code> sets the line dash pattern.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">width 2
+        <p>
+          The <code>fill</code> function sets the color of the <strong>fill</strong> to the given
+          string argument <code>c</code>. The fill is the interior of a shape. The initial fill
+          color is <code>&quot;black&quot;</code>.
+        </p>
+        <h3><a id="dash" href="#dash" class="anchor">#</a><code>dash</code></h3>
+        <p><code>dash</code> sets the line dash pattern.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">width 2
 
 dash 5 // same as: dash 5 5, dash 5 5 5
 hline 85 &quot;red&quot;
@@ -2083,27 +2106,27 @@ func hline y:num c:string
     line 100 y
 end
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="dash patterns" src="img/dashes.png" />
-      <h4>Reference</h4>
-      <pre><code>dash segments:num...
+        <p>Output</p>
+        <img width="300" alt="dash patterns" src="img/dashes.png" />
+        <h4>Reference</h4>
+        <pre><code>dash segments:num...
 </code></pre>
-      <p>
-        The <code>dash</code> function sets the line dash pattern used when stroking lines. The dash
-        pattern is specified as a variadic number of arguments, where each argument represents the
-        length of a dash or gap. For example, the arguments <code>5 10</code> would create a line
-        with 5-unit long dashes and 10-unit long gaps.
-      </p>
-      <p>
-        If the number of arguments is odd, they are copied and concatenated. For example, the
-        arguments <code>10 5 10</code> would become <code>10 5 10 10 5 10</code>. If no arguments
-        are given, the line returns to being solid.
-      </p>
-      <p>The initial dash pattern is a solid line.</p>
-      <h3><a id="linecap" href="#linecap" class="anchor">#</a><code>linecap</code></h3>
-      <p><code>linecap</code> sets the shape of the ends of lines.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">width 5
+        <p>
+          The <code>dash</code> function sets the line dash pattern used when stroking lines. The
+          dash pattern is specified as a variadic number of arguments, where each argument
+          represents the length of a dash or gap. For example, the arguments <code>5 10</code> would
+          create a line with 5-unit long dashes and 10-unit long gaps.
+        </p>
+        <p>
+          If the number of arguments is odd, they are copied and concatenated. For example, the
+          arguments <code>10 5 10</code> would become <code>10 5 10 10 5 10</code>. If no arguments
+          are given, the line returns to being solid.
+        </p>
+        <p>The initial dash pattern is a solid line.</p>
+        <h3><a id="linecap" href="#linecap" class="anchor">#</a><code>linecap</code></h3>
+        <p><code>linecap</code> sets the shape of the ends of lines.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">width 5
 grid
 
 linecap &quot;round&quot;
@@ -2120,74 +2143,75 @@ func hline y:num
     line 90 y
 end
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="round and square line caps" src="img/linecaps.png" />
-      <h4>Reference</h4>
-      <pre><code>linecap style:string
+        <p>Output</p>
+        <img width="300" alt="round and square line caps" src="img/linecaps.png" />
+        <h4>Reference</h4>
+        <pre><code>linecap style:string
 </code></pre>
-      <p>
-        The <code>linecap</code> function sets the shape of the ends of lines to the
-        <code>style</code> string argument. Valid styles are <code>&quot;round&quot;</code>,
-        <code>&quot;butt&quot;</code> or <code>&quot;square&quot;</code>. An invalid style takes no
-        effect.
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th>Style</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>&quot;round&quot;</code></td>
-            <td>The ends of the line are rounded.</td>
-          </tr>
-          <tr>
-            <td><code>&quot;butt&quot;</code></td>
-            <td>The ends of the line are squared off at the endpoints.</td>
-          </tr>
-          <tr>
-            <td><code>&quot;square&quot;</code></td>
-            <td>
-              The ends of the line are squared off by adding a box with an equal width and half the
-              height of the line's thickness.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p>The initial linecap style is <code>&quot;round&quot;</code>.</p>
-      <h3><a id="text" href="#text" class="anchor">#</a><code>text</code></h3>
-      <p><code>text</code> prints text to the canvas at the current cursor position.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">move 20 70
+        <p>
+          The <code>linecap</code> function sets the shape of the ends of lines to the
+          <code>style</code> string argument. Valid styles are <code>&quot;round&quot;</code>,
+          <code>&quot;butt&quot;</code> or <code>&quot;square&quot;</code>. An invalid style takes
+          no effect.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Style</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>&quot;round&quot;</code></td>
+              <td>The ends of the line are rounded.</td>
+            </tr>
+            <tr>
+              <td><code>&quot;butt&quot;</code></td>
+              <td>The ends of the line are squared off at the endpoints.</td>
+            </tr>
+            <tr>
+              <td><code>&quot;square&quot;</code></td>
+              <td>
+                The ends of the line are squared off by adding a box with an equal width and half
+                the height of the line's thickness.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p>The initial linecap style is <code>&quot;round&quot;</code>.</p>
+        <h3><a id="text" href="#text" class="anchor">#</a><code>text</code></h3>
+        <p><code>text</code> prints text to the canvas at the current cursor position.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">move 20 70
 text &quot;“Time is an illusion.&quot;
 move 20 63
 text &quot;Lunchtime doubly so.”&quot;
 move 35 48
 text &quot;― Douglas Adams&quot;
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="text sample" src="img/text.png" />
-      <h4>Reference</h4>
-      <pre><code>text s:string
+        <p>Output</p>
+        <img width="300" alt="text sample" src="img/text.png" />
+        <h4>Reference</h4>
+        <pre><code>text s:string
 </code></pre>
-      <p>
-        The <code>text</code> function prints the string argument <code>s</code> to the canvas at
-        the current cursor position. The cursor position is not updated after writing text. Only
-        <code>fill</code> and <code>color</code> have an effect on the text; <code>stroke</code> has
-        no effect. For more text styling, such as setting <strong>font size</strong> or
-        <strong>font family</strong>, see <a href="#font"><code>font</code></a
-        >.
-      </p>
-      <h3><a id="font" href="#font" class="anchor">#</a><code>font</code></h3>
-      <p>
-        <code>font</code> sets the font properties for text. The font properties are
-        <code>family</code>,<code>size</code>, <code>weight</code>, <code>style</code>,
-        <code>letterspacing</code>, <code>baseline</code>, and <code>align</code>.
-      </p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">font {family:&quot;Bradley Hand, cursive&quot; size:4}
+        <p>
+          The <code>text</code> function prints the string argument <code>s</code> to the canvas at
+          the current cursor position. The cursor position is not updated after writing text. Only
+          <code>fill</code> and <code>color</code> have an effect on the text;
+          <code>stroke</code> has no effect. For more text styling, such as setting
+          <strong>font size</strong> or <strong>font family</strong>, see
+          <a href="#font"><code>font</code></a
+          >.
+        </p>
+        <h3><a id="font" href="#font" class="anchor">#</a><code>font</code></h3>
+        <p>
+          <code>font</code> sets the font properties for text. The font properties are
+          <code>family</code>,<code>size</code>, <code>weight</code>, <code>style</code>,
+          <code>letterspacing</code>, <code>baseline</code>, and <code>align</code>.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">font {family:&quot;Bradley Hand, cursive&quot; size:4}
 
 move 10 65
 text &quot;“The wonderful thing about programming&quot;
@@ -2219,13 +2243,13 @@ font {size:4 letterspacing:0 weight:100 style:&quot;normal&quot;}
 move 90 25
 text &quot;computer scientist, compiler builder&quot;
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="styled text sample" src="img/font.png" />
-      <p>
-        The following example shows the effect of the <code>align</code> and
-        <code>baseline</code> properties:
-      </p>
-      <pre><code class="language-evy">font {size:6 family:&quot;Fira Code, monospace&quot;}
+        <p>Output</p>
+        <img width="300" alt="styled text sample" src="img/font.png" />
+        <p>
+          The following example shows the effect of the <code>align</code> and
+          <code>baseline</code> properties:
+        </p>
+        <pre><code class="language-evy">font {size:6 family:&quot;Fira Code, monospace&quot;}
 
 move 25 78
 line 25 86
@@ -2269,57 +2293,57 @@ move 55 35
 font {baseline:&quot;alphabetic&quot;}
 text &quot;alphabetic&quot;
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="styled text sample" src="img/align.png" />
-      <h4>Reference</h4>
-      <pre><code>font props:{}any
+        <p>Output</p>
+        <img width="300" alt="styled text sample" src="img/align.png" />
+        <h4>Reference</h4>
+        <pre><code>font props:{}any
 </code></pre>
-      <p>
-        The <code>font</code> function sets the font properties for text. The font properties are
-        <code>family</code>, <code>size</code>, <code>weight</code>, <code>style</code>,
-        <code>letterspacing</code>, <code>align</code>, and <code>baseline</code>.
-      </p>
-      <p>
-        The <code>family</code> property specifies a prioritized list of one or more font family
-        names. Values are separated by commas to indicate that they are alternatives. The browser
-        will select the first available font. For example, the value
-        <code>&quot;Fira Code, monospace&quot;</code> would specify that the browser should try to
-        use the Fira Code font, but if that font is not available, it should use a monospace font.
-        The default font family is the browser default.
-      </p>
-      <p>
-        The <code>size</code> property specifies the height of a letter in canvas units. The default
-        size is 6.
-      </p>
-      <p>
-        The <code>weight</code> property specifies the boldness of the font. The values 100, 200,
-        ..., 900 can be used to specify the weight of the font. The value 400 is normal, 700 is
-        bold. The default weight is 400.
-      </p>
-      <p>
-        The <code>style</code> property specifies the sloping of the font. The values
-        <code>&quot;normal&quot;</code> and <code>&quot;italic&quot;</code> can be used to specify
-        the style of the font. The default style is &quot;normal&quot;.
-      </p>
-      <p>
-        The <code>letterspacing</code> property specifies the additional horizontal space between
-        text characters in canvas units. The default value is 0.
-      </p>
-      <p>
-        The <code>align</code> property specifies the horizontal alignment of the text. The values
-        <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code>, and
-        <code>&quot;center&quot;</code> can be used to specify the alignment. The default value is
-        <code>&quot;left&quot;</code>.
-      </p>
-      <p>
-        The <code>baseline</code> property specifies the vertical cursor position relative to the
-        vertical text position. The values <code>&quot;top&quot;</code>,
-        <code>&quot;bottom&quot;</code>, <code>&quot;middle&quot;</code>, and
-        <code>&quot;alphabetic&quot;</code> can be used to specify the baseline. The default value
-        is <code>&quot;alphabetic&quot;</code>.
-      </p>
-      <p>Here is an example of how to use the font function:</p>
-      <pre><code class="language-evy">font {
+        <p>
+          The <code>font</code> function sets the font properties for text. The font properties are
+          <code>family</code>, <code>size</code>, <code>weight</code>, <code>style</code>,
+          <code>letterspacing</code>, <code>align</code>, and <code>baseline</code>.
+        </p>
+        <p>
+          The <code>family</code> property specifies a prioritized list of one or more font family
+          names. Values are separated by commas to indicate that they are alternatives. The browser
+          will select the first available font. For example, the value
+          <code>&quot;Fira Code, monospace&quot;</code> would specify that the browser should try to
+          use the Fira Code font, but if that font is not available, it should use a monospace font.
+          The default font family is the browser default.
+        </p>
+        <p>
+          The <code>size</code> property specifies the height of a letter in canvas units. The
+          default size is 6.
+        </p>
+        <p>
+          The <code>weight</code> property specifies the boldness of the font. The values 100, 200,
+          ..., 900 can be used to specify the weight of the font. The value 400 is normal, 700 is
+          bold. The default weight is 400.
+        </p>
+        <p>
+          The <code>style</code> property specifies the sloping of the font. The values
+          <code>&quot;normal&quot;</code> and <code>&quot;italic&quot;</code> can be used to specify
+          the style of the font. The default style is &quot;normal&quot;.
+        </p>
+        <p>
+          The <code>letterspacing</code> property specifies the additional horizontal space between
+          text characters in canvas units. The default value is 0.
+        </p>
+        <p>
+          The <code>align</code> property specifies the horizontal alignment of the text. The values
+          <code>&quot;left&quot;</code>, <code>&quot;right&quot;</code>, and
+          <code>&quot;center&quot;</code> can be used to specify the alignment. The default value is
+          <code>&quot;left&quot;</code>.
+        </p>
+        <p>
+          The <code>baseline</code> property specifies the vertical cursor position relative to the
+          vertical text position. The values <code>&quot;top&quot;</code>,
+          <code>&quot;bottom&quot;</code>, <code>&quot;middle&quot;</code>, and
+          <code>&quot;alphabetic&quot;</code> can be used to specify the baseline. The default value
+          is <code>&quot;alphabetic&quot;</code>.
+        </p>
+        <p>Here is an example of how to use the font function:</p>
+        <pre><code class="language-evy">font {
     family:&quot;Fira Code, monospace&quot;
     size:9
     weight:700
@@ -2329,125 +2353,125 @@ text &quot;alphabetic&quot;
     align:&quot;center&quot;
 }
 </code></pre>
-      <p>
-        This code sets the font properties to use the Fira Code font, a size of 9, a weight of 700,
-        an italic style, a letterspacing of 0.5, a top baseline, and a center alignment.
-      </p>
-      <h2><a id="event-handlers" href="#event-handlers" class="anchor">#</a>Event Handlers</h2>
-      <p>
-        Evy first executes all top-level code in the order it appears in the source code. If there
-        is at least one event handler, Evy then enters an event loop. In the event loop, Evy waits
-        for external events, such as a key press or a pointer down event. When an event occurs, Evy
-        calls the corresponding event handler function if it has been implemented. The event handler
-        function can optionally receive arguments, such as the key character or the pointer
-        coordinates. Once the event handler function has finished, Evy returns to the event loop and
-        waits for the next event.
-      </p>
-      <p>
-        Event handlers are declared using the <code>on</code> keyword. Only predefined events can be
-        handled: <code>key</code>, <code>down</code>, <code>up</code>, <code>move</code>,
-        <code>animate</code>, and <code>input</code>. For example, the following code defines an
-        event handler for the key press event:
-      </p>
-      <pre><code class="language-evy">on key k:string
+        <p>
+          This code sets the font properties to use the Fira Code font, a size of 9, a weight of
+          700, an italic style, a letterspacing of 0.5, a top baseline, and a center alignment.
+        </p>
+        <h2><a id="event-handlers" href="#event-handlers" class="anchor">#</a>Event Handlers</h2>
+        <p>
+          Evy first executes all top-level code in the order it appears in the source code. If there
+          is at least one event handler, Evy then enters an event loop. In the event loop, Evy waits
+          for external events, such as a key press or a pointer down event. When an event occurs,
+          Evy calls the corresponding event handler function if it has been implemented. The event
+          handler function can optionally receive arguments, such as the key character or the
+          pointer coordinates. Once the event handler function has finished, Evy returns to the
+          event loop and waits for the next event.
+        </p>
+        <p>
+          Event handlers are declared using the <code>on</code> keyword. Only predefined events can
+          be handled: <code>key</code>, <code>down</code>, <code>up</code>, <code>move</code>,
+          <code>animate</code>, and <code>input</code>. For example, the following code defines an
+          event handler for the key press event:
+        </p>
+        <pre><code class="language-evy">on key k:string
     print k
 end
 </code></pre>
-      <p>
-        The parameters to the event handlers must match the expected signature. The
-        <code>key</code> event handler expects a single parameter of type string, which is the
-        character that was pressed. The parameters can be fully omitted or fully specified. If only
-        some parameters are needed, use the anonymous <code>_</code> parameter. The
-        <code>down</code> event handler, for instance, expects two parameters, the x and y
-        coordinates of the pointer. If you only need the x coordinate, you can use
-        <code>on down x:num _:num</code>.
-      </p>
-      <p>
-        Pointer events, such as <code>down</code>, <code>up</code>, and <code>move</code>, occur
-        when a pointing input device, such as a mouse, a pen or stylus, or a finger, is used to
-        interact with the canvas.
-      </p>
-      <h3><a id="key" href="#key" class="anchor">#</a><code>key</code></h3>
-      <p><code>key</code> is called when a key on the keyboard is pressed.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">on key k:string
+        <p>
+          The parameters to the event handlers must match the expected signature. The
+          <code>key</code> event handler expects a single parameter of type string, which is the
+          character that was pressed. The parameters can be fully omitted or fully specified. If
+          only some parameters are needed, use the anonymous <code>_</code> parameter. The
+          <code>down</code> event handler, for instance, expects two parameters, the x and y
+          coordinates of the pointer. If you only need the x coordinate, you can use
+          <code>on down x:num _:num</code>.
+        </p>
+        <p>
+          Pointer events, such as <code>down</code>, <code>up</code>, and <code>move</code>, occur
+          when a pointing input device, such as a mouse, a pen or stylus, or a finger, is used to
+          interact with the canvas.
+        </p>
+        <h3><a id="key" href="#key" class="anchor">#</a><code>key</code></h3>
+        <p><code>key</code> is called when a key on the keyboard is pressed.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">on key k:string
     print k
 end
 </code></pre>
-      <p>Sample output</p>
-      <pre><code>Escape
+        <p>Sample output</p>
+        <pre><code>Escape
 Shift
 R
 o
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>key k:string
+        <h4>Reference</h4>
+        <pre><code>key k:string
 </code></pre>
-      <p>
-        The <code>key</code> event handler is called when a <strong>keydown</strong> event occurs.
-        The handler is passed a string argument which is the character of the key that was pressed.
-        For example, if the user presses the <code>a</code> key, the argument would be the string
-        <code>&quot;a&quot;</code>.
-      </p>
-      <p>
-        Some keys do not have a character representation, such as the arrow keys or the shift key.
-        For these keys, the argument is a special string, such as
-        <code>&quot;ArrowRight&quot;</code>, <code>&quot;ArrowUp&quot;</code>,
-        <code>&quot;Shift&quot;</code>, <code>&quot;Enter&quot;</code>,
-        <code>&quot;Control&quot;</code>, <code>&quot;Alt&quot;</code>,
-        <code>&quot;Backspace&quot;</code>, or <code>&quot;Escape&quot;</code>.
-      </p>
-      <p>
-        When the shift key is pressed and then another key is pressed, the argument is the uppercase
-        or special character representation of the key that was pressed. For example, if the user
-        presses <code>shift</code>+<code>a</code>, the argument is the string
-        <code>&quot;A&quot;</code>.
-      </p>
-      <h3><a id="down" href="#down" class="anchor">#</a><code>down</code></h3>
-      <p><code>down</code> is called when the pointer is pressed down.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">on down x:num y:num
+        <p>
+          The <code>key</code> event handler is called when a <strong>keydown</strong> event occurs.
+          The handler is passed a string argument which is the character of the key that was
+          pressed. For example, if the user presses the <code>a</code> key, the argument would be
+          the string <code>&quot;a&quot;</code>.
+        </p>
+        <p>
+          Some keys do not have a character representation, such as the arrow keys or the shift key.
+          For these keys, the argument is a special string, such as
+          <code>&quot;ArrowRight&quot;</code>, <code>&quot;ArrowUp&quot;</code>,
+          <code>&quot;Shift&quot;</code>, <code>&quot;Enter&quot;</code>,
+          <code>&quot;Control&quot;</code>, <code>&quot;Alt&quot;</code>,
+          <code>&quot;Backspace&quot;</code>, or <code>&quot;Escape&quot;</code>.
+        </p>
+        <p>
+          When the shift key is pressed and then another key is pressed, the argument is the
+          uppercase or special character representation of the key that was pressed. For example, if
+          the user presses <code>shift</code>+<code>a</code>, the argument is the string
+          <code>&quot;A&quot;</code>.
+        </p>
+        <h3><a id="down" href="#down" class="anchor">#</a><code>down</code></h3>
+        <p><code>down</code> is called when the pointer is pressed down.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">on down x:num y:num
     printf &quot;x: %2.0f y: %2.0f\n&quot; x y
 end
 </code></pre>
-      <p>Sample output</p>
-      <pre><code>x: 42 y: 85
+        <p>Sample output</p>
+        <pre><code>x: 42 y: 85
 x:  7 y:  6
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>down x:num y:num
+        <h4>Reference</h4>
+        <pre><code>down x:num y:num
 </code></pre>
-      <p>
-        The <code>down</code> event handler is called when a <strong>pointerdown</strong> event
-        occurs on the canvas. The handler is passed two number arguments, <code>x</code> and
-        <code>y</code>, which are the coordinates of the pointer location when the pointer was
-        pressed down. The pointer is typically a mouse, stylus or finger.
-      </p>
-      <h3><a id="up" href="#up" class="anchor">#</a><code>up</code></h3>
-      <p><code>up</code> is called when the pointer is lifted up.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">on up x:num y:num
+        <p>
+          The <code>down</code> event handler is called when a <strong>pointerdown</strong> event
+          occurs on the canvas. The handler is passed two number arguments, <code>x</code> and
+          <code>y</code>, which are the coordinates of the pointer location when the pointer was
+          pressed down. The pointer is typically a mouse, stylus or finger.
+        </p>
+        <h3><a id="up" href="#up" class="anchor">#</a><code>up</code></h3>
+        <p><code>up</code> is called when the pointer is lifted up.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">on up x:num y:num
     move x y
     color &quot;red&quot;
     circle 1
 end
 </code></pre>
-      <p>Sample output</p>
-      <img width="300" alt="red dots" src="img/up.png" />
-      <h4>Reference</h4>
-      <pre><code>up x:num y:num
+        <p>Sample output</p>
+        <img width="300" alt="red dots" src="img/up.png" />
+        <h4>Reference</h4>
+        <pre><code>up x:num y:num
 </code></pre>
-      <p>
-        The <code>up</code> event handler is called when a <strong>pointerup</strong> event occurs
-        on the canvas. The handler is passed two number arguments, <code>x</code> and
-        <code>y</code>, which are the coordinates of the pointer location when the pointer was
-        lifted up. The pointer is typically a mouse, stylus or finger.
-      </p>
-      <h3><a id="move-1" href="#move-1" class="anchor">#</a><code>move</code></h3>
-      <p><code>move</code> is called when the pointer is moved.</p>
-      <h4>Example</h4>
-      <p>The following sample draws a line following the pointer's movement.</p>
-      <pre><code class="language-evy">down := false
+        <p>
+          The <code>up</code> event handler is called when a <strong>pointerup</strong> event occurs
+          on the canvas. The handler is passed two number arguments, <code>x</code> and
+          <code>y</code>, which are the coordinates of the pointer location when the pointer was
+          lifted up. The pointer is typically a mouse, stylus or finger.
+        </p>
+        <h3><a id="move-1" href="#move-1" class="anchor">#</a><code>move</code></h3>
+        <p><code>move</code> is called when the pointer is moved.</p>
+        <h4>Example</h4>
+        <p>The following sample draws a line following the pointer's movement.</p>
+        <pre><code class="language-evy">down := false
 width 1
 
 on down x:num y:num
@@ -2465,21 +2489,25 @@ on up
     down = false
 end
 </code></pre>
-      <p>Sample output</p>
-      <img width="300" alt="black line tracking short and fast mouse movement" src="img/move.png" />
-      <h4>Reference</h4>
-      <pre><code>move x:num y:num
+        <p>Sample output</p>
+        <img
+          width="300"
+          alt="black line tracking short and fast mouse movement"
+          src="img/move.png"
+        />
+        <h4>Reference</h4>
+        <pre><code>move x:num y:num
 </code></pre>
-      <p>
-        The <code>move</code> event handler is called when a <strong>pointermove</strong> event
-        occurs on the canvas. The handler is passed two number arguments, <code>x</code> and
-        <code>y</code>, which are the coordinates of the position that the pointer has moved to. The
-        pointer is typically a mouse, stylus or finger.
-      </p>
-      <h3><a id="animate" href="#animate" class="anchor">#</a><code>animate</code></h3>
-      <p><code>animate</code> gets called periodically around 60 times per second.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">semiblack := &quot;hsl(0deg 0% 0% / 10%)&quot;
+        <p>
+          The <code>move</code> event handler is called when a <strong>pointermove</strong> event
+          occurs on the canvas. The handler is passed two number arguments, <code>x</code> and
+          <code>y</code>, which are the coordinates of the position that the pointer has moved to.
+          The pointer is typically a mouse, stylus or finger.
+        </p>
+        <h3><a id="animate" href="#animate" class="anchor">#</a><code>animate</code></h3>
+        <p><code>animate</code> gets called periodically around 60 times per second.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">semiblack := &quot;hsl(0deg 0% 0% / 10%)&quot;
 width 1
 fill semiblack
 stroke &quot;red&quot;
@@ -2491,52 +2519,53 @@ on animate ms:num
     circle 10
 end
 </code></pre>
-      <p>Output</p>
-      <img width="300" alt="red circle reapeated falling" src="img/animate.gif" />
-      <h4>Reference</h4>
-      <pre><code>animate elapsed:num
+        <p>Output</p>
+        <img width="300" alt="red circle reapeated falling" src="img/animate.gif" />
+        <h4>Reference</h4>
+        <pre><code>animate elapsed:num
 </code></pre>
-      <p>
-        The <code>animate</code> event handler is called when an animation frame is available. This
-        means that the handler will be called typically 60 times in a second, but it will generally
-        match the display refresh rate. If the computations within a single animate call take too
-        long, the frame rate will drop.
-      </p>
-      <p>
-        The animate event handler is passed a single numeric argument which is the number of elapsed
-        milliseconds since the start of the animation. This allows you to track the progress of the
-        animation and to update the animation accordingly.
-      </p>
-      <h3><a id="input" href="#input" class="anchor">#</a><code>input</code></h3>
-      <p><code>input</code> is called when the value of an input element changes.</p>
-      <h4>Example</h4>
-      <pre><code class="language-evy">on input id:string val:string
+        <p>
+          The <code>animate</code> event handler is called when an animation frame is available.
+          This means that the handler will be called typically 60 times in a second, but it will
+          generally match the display refresh rate. If the computations within a single animate call
+          take too long, the frame rate will drop.
+        </p>
+        <p>
+          The animate event handler is passed a single numeric argument which is the number of
+          elapsed milliseconds since the start of the animation. This allows you to track the
+          progress of the animation and to update the animation accordingly.
+        </p>
+        <h3><a id="input" href="#input" class="anchor">#</a><code>input</code></h3>
+        <p><code>input</code> is called when the value of an input element changes.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">on input id:string val:string
     print &quot;id:&quot; id &quot;val:&quot; val
 end
 </code></pre>
-      <p>Sample Output from the Evy website</p>
-      <pre><code>id: sliderx val: 15
+        <p>Sample Output from the Evy website</p>
+        <pre><code>id: sliderx val: 15
 id: slidery val: 0
 id: slidery val: 100
 </code></pre>
-      <h4>Reference</h4>
-      <pre><code>input id:string val:id
+        <h4>Reference</h4>
+        <pre><code>input id:string val:id
 </code></pre>
-      <p>
-        The <code>input</code> event handler is called when the value of an input element changes.
-        The handler is passed two string arguments: the id of the input element and its new value.
-      </p>
-      <p>
-        For example, if you have an input element with the id <code>sliderx</code> and the user
-        changes the value of the slider to <code>15</code>, the input event handler will be called
-        with the arguments <code>sliderx</code> and <code>15</code>.
-      </p>
-      <p>
-        The Evy web interface has two sliders that are used as input elements. The sliders range
-        from 0 to 100, and their ids are <code>sliderx</code> and <code>slidery</code>. When you
-        change the position of the sliders the <code>input</code> event handler is called with the
-        new position value of the slider.
-      </p>
+        <p>
+          The <code>input</code> event handler is called when the value of an input element changes.
+          The handler is passed two string arguments: the id of the input element and its new value.
+        </p>
+        <p>
+          For example, if you have an input element with the id <code>sliderx</code> and the user
+          changes the value of the slider to <code>15</code>, the input event handler will be called
+          with the arguments <code>sliderx</code> and <code>15</code>.
+        </p>
+        <p>
+          The Evy web interface has two sliders that are used as input elements. The sliders range
+          from 0 to 100, and their ids are <code>sliderx</code> and <code>slidery</code>. When you
+          change the position of the sliders the <code>input</code> event handler is called with the
+          new position value of the slider.
+        </p>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/builtins.html
+++ b/frontend/preview/builtins.html
@@ -40,7 +40,7 @@
             <input type="text" placeholder="Search..." />
           </div>
           <a href="index.html"><strong>Documentation</strong></a>
-          <a href="contributing/index.html">Contributing</a>
+          <a href="/play">Playground</a>
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/builtins.html
+++ b/frontend/preview/builtins.html
@@ -35,10 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
           <a href="index.html"><strong>Documentation</strong></a>
           <a href="/play">Playground</a>
           <button>About</button>

--- a/frontend/preview/builtins.html
+++ b/frontend/preview/builtins.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Built-ins</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/css/index.css
+++ b/frontend/preview/css/index.css
@@ -22,12 +22,18 @@ main {
   grid-area: main;
   height: 100%;
   overflow: auto;
-  padding-left: 120px;
   background-color: var(--background);
-  padding-bottom: 40px;
 }
-main > * {
+
+/* max-width-wrapper is responsible for centering content in main area.
+   If we applied the same rules to main, the scrollbar would show up offset from the
+   right edge, at `margin-right:auto` distance. */
+main .max-width-wrapper {
   max-width: 60rem;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 40px 32px;
 }
 
 li::marker {
@@ -57,7 +63,6 @@ li::marker {
 
 h1 {
   font-size: 1.875rem;
-  margin-top: 40px;
 }
 
 h2 {
@@ -343,24 +348,7 @@ th {
   }
 }
 
-@media (max-width: 1600px) {
-  main {
-    padding-left: 88px;
-    padding-right: 88px;
-  }
-  main > * {
-    max-width: 52rem;
-  }
-}
-
 @media (max-width: 1280px) {
-  main {
-    padding-left: 40px;
-    padding-right: 40px;
-  }
-  main > * {
-    max-width: 48rem;
-  }
   #sidebar {
     width: 270px;
   }
@@ -370,12 +358,9 @@ th {
 }
 
 @media (max-width: 1024px) {
-  main {
+  main .max-width-wrapper {
     padding-left: 16px;
     padding-right: 16px;
-  }
-  main > * {
-    max-width: 100%;
   }
   #sidebar {
     width: 250px;
@@ -383,9 +368,6 @@ th {
 }
 
 @media (max-width: 767px) {
-  main {
-    width: 100vw;
-  }
   #sidebar {
     width: 312px;
     position: absolute;

--- a/frontend/preview/css/index.css
+++ b/frontend/preview/css/index.css
@@ -125,7 +125,7 @@ pre {
 code {
   padding: 0.25em;
   font-size: 0.85rem;
-  background-color: var(--background-dimmed);
+  background-color: var(--background-inline-code);
   border-radius: 4px;
   color: var(--color);
 }
@@ -249,6 +249,7 @@ th {
 }
 #sidebar a code {
   color: var(--color-hover);
+  background: none;
 }
 #sidebar a:hover,
 #sidebar a:hover code {

--- a/frontend/preview/css/index.css
+++ b/frontend/preview/css/index.css
@@ -90,6 +90,10 @@ p {
   color: var(--color-dimmed);
   margin-bottom: 24px;
 }
+/* Reduce margin bottom if code block follows */
+p:has(+ pre) {
+  margin-bottom: 8px;
+}
 
 ul,
 ol {
@@ -115,7 +119,7 @@ a > code {
 }
 
 pre {
-  margin: 16px 0;
+  margin: 16px 0 24px;
   padding: 16px;
   border-left: 6px solid var(--border-color);
   overflow-x: auto;

--- a/frontend/preview/css/index.css
+++ b/frontend/preview/css/index.css
@@ -202,36 +202,6 @@ th {
   color: var(--color-accent);
 }
 
-.search {
-  display: flex;
-  align-items: center;
-  border: 1px solid var(--border-color-strong);
-  border-radius: 6px;
-}
-
-.search > .icon-search {
-  height: 0.9em;
-  width: 0.9em;
-  margin-left: 8px;
-  margin-right: 8px;
-  color: var(--color);
-}
-
-.search > input {
-  height: 2.05rem;
-  border: none;
-  background: none;
-  color: var(--color);
-  padding-left: 4px;
-  max-width: 224px;
-  outline: none;
-}
-
-.search > input::placeholder {
-  opacity: 1;
-  color: var(--color);
-}
-
 /* --- Sidebar -------------------------------------------------------- */
 #sidebar {
   width: 320px;

--- a/frontend/preview/development/releasing.html
+++ b/frontend/preview/development/releasing.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Releasing</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/development/releasing.html
+++ b/frontend/preview/development/releasing.html
@@ -59,40 +59,43 @@
     </header>
 
     <main>
-      <h1>Releasing</h1>
-      <p>
-        Evy automatically releases with every new merge to the <code>main</code> branch on GitHub.
-        This process publishes artifacts for all major operating systems and architectures under
-        <a href="https://github.com/evylang/evy/releases">releases</a> as part of a successful CI
-        run. Additionally, the <code>evylang/tap/evy</code> brew formula is updated to the latest
-        version.
-      </p>
-      <p>
-        By default, each release receives a semantic <strong>patch</strong> bump. For example, if
-        the latest version is <code>v0.2.4</code>, the next one will be <code>v0.2.5</code> by
-        default.
-      </p>
-      <p>
-        To trigger a minor version bump, add a new file to the
-        <a href="https://github.com/evylang/evy/tree/main/docs/release-notes"
-          >release-notes directory</a
-        >. A minor version bump indicates the completion of a
-        <a href="https://github.com/evylang/evy/milestones">milestone</a>. The release notes file
-        should be named according to the new version, for example, <code>v0.2.0.md</code>.
-      </p>
-      <p>
-        To trigger a <strong>minor</strong> version bump a new file must be added to the
-        <a href="https://github.com/evylang/evy/tree/main/docs/release-notes"
-          >release-notes directory</a
-        >. A minor version bump signifies the completion of a milestone. The release notes file is
-        named according to the new version, for example <code>v0.2.0.md</code>.
-      </p>
-      <p>
-        Evy's current major version is still 0, this may change in the future. Evy's language
-        syntax, tooling, and public API are still under development and not yet considered stable.
-        Additionally, for major version 0, the meaning of patch and minor versions does not conform
-        to the standard <a href="https://semver.org/">semantic versioning specifications</a>.
-      </p>
+      <div class="max-width-wrapper">
+        <h1>Releasing</h1>
+        <p>
+          Evy automatically releases with every new merge to the <code>main</code> branch on GitHub.
+          This process publishes artifacts for all major operating systems and architectures under
+          <a href="https://github.com/evylang/evy/releases">releases</a> as part of a successful CI
+          run. Additionally, the <code>evylang/tap/evy</code> brew formula is updated to the latest
+          version.
+        </p>
+        <p>
+          By default, each release receives a semantic <strong>patch</strong> bump. For example, if
+          the latest version is <code>v0.2.4</code>, the next one will be <code>v0.2.5</code> by
+          default.
+        </p>
+        <p>
+          To trigger a minor version bump, add a new file to the
+          <a href="https://github.com/evylang/evy/tree/main/docs/release-notes"
+            >release-notes directory</a
+          >. A minor version bump indicates the completion of a
+          <a href="https://github.com/evylang/evy/milestones">milestone</a>. The release notes file
+          should be named according to the new version, for example, <code>v0.2.0.md</code>.
+        </p>
+        <p>
+          To trigger a <strong>minor</strong> version bump a new file must be added to the
+          <a href="https://github.com/evylang/evy/tree/main/docs/release-notes"
+            >release-notes directory</a
+          >. A minor version bump signifies the completion of a milestone. The release notes file is
+          named according to the new version, for example <code>v0.2.0.md</code>.
+        </p>
+        <p>
+          Evy's current major version is still 0, this may change in the future. Evy's language
+          syntax, tooling, and public API are still under development and not yet considered stable.
+          Additionally, for major version 0, the meaning of patch and minor versions does not
+          conform to the standard
+          <a href="https://semver.org/">semantic versioning specifications</a>.
+        </p>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/development/releasing.html
+++ b/frontend/preview/development/releasing.html
@@ -35,11 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
-
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/index.html
+++ b/frontend/preview/index.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Documentation</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/index.html
+++ b/frontend/preview/index.html
@@ -522,9 +522,9 @@
       </ul>
 
       <ul class="icons">
-        <li><a href="/discord" class="icon-discord"></a></li>
-        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
-        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+        <li><a href="/discord" class="icon-discord" target="_blank"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github" target="_blank"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email" target="_blank"></a></li>
       </ul>
     </nav>
 

--- a/frontend/preview/index.html
+++ b/frontend/preview/index.html
@@ -529,40 +529,42 @@
     </nav>
 
     <main>
-      <h1>Documentation</h1>
-      <p>Learn programming with Evy</p>
-      <ul>
-        <li>
-          Check out the
-          <a href="https://github.com/evylang/evy/wiki">Learn and Practise</a> resources.
-        </li>
-        <li>
-          Explore the samples on the <a href="/play">Playground</a> or the
-          <a href="https://github.com/evylang/evy/wiki/gallery">Gallery</a>.
-        </li>
-        <li>
-          Ask questions or discuss Evy in the <a href="/discord">Evy community</a> on Discord.
-        </li>
-      </ul>
-      <p>Learn more about the Evy language and tools</p>
-      <ul>
-        <li>
-          <a href="syntax_by_example.html">Syntax by Example</a>: Learn the Evy syntax with a
-          collection of examples.
-        </li>
-        <li>
-          <a href="builtins.html">Built-in Documentation</a>: Get details on built-in functions and
-          events in Evy.
-        </li>
-        <li>
-          <a href="spec.html">Language Specification</a>: Read a formal definition of the Evy syntax
-          and language.
-        </li>
-        <li>
-          <a href="usage.html"><code>evy</code> Usage</a>: Learn how to use the
-          <code>evy</code> command line tool.
-        </li>
-      </ul>
+      <div class="max-width-wrapper">
+        <h1>Documentation</h1>
+        <p>Learn programming with Evy</p>
+        <ul>
+          <li>
+            Check out the
+            <a href="https://github.com/evylang/evy/wiki">Learn and Practise</a> resources.
+          </li>
+          <li>
+            Explore the samples on the <a href="/play">Playground</a> or the
+            <a href="https://github.com/evylang/evy/wiki/gallery">Gallery</a>.
+          </li>
+          <li>
+            Ask questions or discuss Evy in the <a href="/discord">Evy community</a> on Discord.
+          </li>
+        </ul>
+        <p>Learn more about the Evy language and tools</p>
+        <ul>
+          <li>
+            <a href="syntax_by_example.html">Syntax by Example</a>: Learn the Evy syntax with a
+            collection of examples.
+          </li>
+          <li>
+            <a href="builtins.html">Built-in Documentation</a>: Get details on built-in functions
+            and events in Evy.
+          </li>
+          <li>
+            <a href="spec.html">Language Specification</a>: Read a formal definition of the Evy
+            syntax and language.
+          </li>
+          <li>
+            <a href="usage.html"><code>evy</code> Usage</a>: Learn how to use the
+            <code>evy</code> command line tool.
+          </li>
+        </ul>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/index.html
+++ b/frontend/preview/index.html
@@ -40,7 +40,7 @@
             <input type="text" placeholder="Search..." />
           </div>
           <a href="index.html"><strong>Documentation</strong></a>
-          <a href="contributing/index.html">Contributing</a>
+          <a href="/play">Playground</a>
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/index.html
+++ b/frontend/preview/index.html
@@ -35,10 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
           <a href="index.html"><strong>Documentation</strong></a>
           <a href="/play">Playground</a>
           <button>About</button>

--- a/frontend/preview/papers/index.html
+++ b/frontend/preview/papers/index.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Papers</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/papers/index.html
+++ b/frontend/preview/papers/index.html
@@ -59,12 +59,14 @@
     </header>
 
     <main>
-      <h1>Papers</h1>
-      <ul>
-        <li>
-          <a href="evy-2401.pdf">Evy, a New Approach to Introductory Programming</a>, Feb 2024
-        </li>
-      </ul>
+      <div class="max-width-wrapper">
+        <h1>Papers</h1>
+        <ul>
+          <li>
+            <a href="evy-2401.pdf">Evy, a New Approach to Introductory Programming</a>, Feb 2024
+          </li>
+        </ul>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/papers/index.html
+++ b/frontend/preview/papers/index.html
@@ -35,11 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
-
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/release-notes/v0.1.0.html
+++ b/frontend/preview/release-notes/v0.1.0.html
@@ -59,33 +59,37 @@
     </header>
 
     <main>
-      <h2><a id="theme-launch-" href="#theme-launch-" class="anchor">#</a>Theme: Launch 🚀</h2>
-      <ul>
-        <li>
-          The <strong>Evy language</strong> is now complete and available for use in the browser and
-          command-line environments.<br />
-          <a href="/play">Try It Out</a>!
-        </li>
-        <li>
-          The <strong>Evy playground</strong> is now complete, as per the
-          <a
-            href="https://drive.google.com/file/d/1yFJlt38oykjPNTgRYgcO1YkO90fSsEuW/view?usp=sharing"
-            >design spec</a
-          >.<br />
-          Thank you <a href="https://twitter.com/jasonstrachan">Jason</a> for donating the graphic
-          design 💝!
-        </li>
-        <li>
-          <strong>Documentation</strong> for the Evy language and built-ins is now complete. For
-          more information see:<br />
-          <a href="/docs">Overview</a> |
-          <a href="https://github.com/evylang/evy/blob/main/docs/spec.md">Language specification</a>
-          |
-          <a href="https://github.com/evylang/evy/blob/main/docs/builtins.md"
-            >Built-ins documentation</a
-          >
-        </li>
-      </ul>
+      <div class="max-width-wrapper">
+        <h2><a id="theme-launch-" href="#theme-launch-" class="anchor">#</a>Theme: Launch 🚀</h2>
+        <ul>
+          <li>
+            The <strong>Evy language</strong> is now complete and available for use in the browser
+            and command-line environments.<br />
+            <a href="/play">Try It Out</a>!
+          </li>
+          <li>
+            The <strong>Evy playground</strong> is now complete, as per the
+            <a
+              href="https://drive.google.com/file/d/1yFJlt38oykjPNTgRYgcO1YkO90fSsEuW/view?usp=sharing"
+              >design spec</a
+            >.<br />
+            Thank you <a href="https://twitter.com/jasonstrachan">Jason</a> for donating the graphic
+            design 💝!
+          </li>
+          <li>
+            <strong>Documentation</strong> for the Evy language and built-ins is now complete. For
+            more information see:<br />
+            <a href="/docs">Overview</a> |
+            <a href="https://github.com/evylang/evy/blob/main/docs/spec.md"
+              >Language specification</a
+            >
+            |
+            <a href="https://github.com/evylang/evy/blob/main/docs/builtins.md"
+              >Built-ins documentation</a
+            >
+          </li>
+        </ul>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/release-notes/v0.1.0.html
+++ b/frontend/preview/release-notes/v0.1.0.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Theme: Launch 🚀</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/release-notes/v0.1.0.html
+++ b/frontend/preview/release-notes/v0.1.0.html
@@ -35,11 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
-
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -522,9 +522,9 @@
       </ul>
 
       <ul class="icons">
-        <li><a href="/discord" class="icon-discord"></a></li>
-        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
-        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+        <li><a href="/discord" class="icon-discord" target="_blank"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github" target="_blank"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email" target="_blank"></a></li>
       </ul>
     </nav>
 

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Language Specification</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -40,7 +40,7 @@
             <input type="text" placeholder="Search..." />
           </div>
           <a href="index.html"><strong>Documentation</strong></a>
-          <a href="contributing/index.html">Contributing</a>
+          <a href="/play">Playground</a>
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -529,79 +529,82 @@
     </nav>
 
     <main>
-      <h1>Language Specification</h1>
-      <p>
-        Evy is a
-        <a href="https://developer.mozilla.org/en-US/docs/Glossary/Static_typing"
-          >statically typed</a
-        >,
-        <a href="https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)"
-          >garbage collected</a
-        >, <a href="https://en.wikipedia.org/wiki/Procedural_programming">procedural</a> programming
-        language. Its main design goal is to help learn programming. Evy aims for simplicity and
-        directness in its tooling and syntax. Several features typical of modern programming
-        languages are purposefully left out.
-      </p>
-      <p>
-        To get an intuitive understanding of Evy, you can either look at its
-        <a href="syntax_by_example.html">syntax by example</a> or read through the
-        <a href="builtins.html">built-ins documentation</a>.
-      </p>
-      <h2><a id="syntax-grammar" href="#syntax-grammar" class="anchor">#</a>Syntax Grammar</h2>
-      <p>
-        The Evy syntax grammar is a
-        <a href="https://en.wikipedia.org/wiki/Wirth_syntax_notation">WSN</a> grammar, which is a
-        formal set of rules that define how Evy programs are written. The Evy interpreter uses the
-        syntax grammar to parse Evy source code, which means that it checks that the code follows
-        the rules of the grammar.
-      </p>
-      <h3>
-        <a id="wsn-syntax-grammar" href="#wsn-syntax-grammar" class="anchor">#</a>WSN Syntax Grammar
-      </h3>
-      <p>
-        Evy's syntax is specified using a WSN grammar, a variant of
-        <a href="https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form">EBNF</a> grammars,
-        borrowing concepts from the
-        <a href="https://go.dev/ref/spec">Go Programming Language Specification</a>.
-      </p>
-      <p>
-        <strong>Productions</strong> are the top-level elements of a WSN grammar. For example, the
-        production
-        <code>OPERATOR = &quot;+&quot; | &quot;-&quot; | &quot;*&quot; | &quot;/&quot; .</code>
-        specifies that an operator can be one of the characters <code>+</code>, <code>-</code>,
-        <code>*</code>, or <code>/</code>.
-      </p>
-      <p>
-        A production consists of an <strong>expression</strong> assigned to an
-        <strong>identifier</strong> or production name. Each production is terminated by a period
-        <code>.</code>. An expression consists of <strong>terms</strong> and the following
-        <strong>operators</strong> in increasing precedence:
-      </p>
-      <ul>
-        <li>
-          <strong>Alternation:</strong> <code>|</code> stands for &quot;or&quot;. For example,
-          <code>a | b</code> stands for <code>a</code> or <code>b</code>.
-        </li>
-        <li>
-          <strong>Grouping:</strong> <code>()</code> stands for grouping. For example,
-          <code>(a|b)c</code> stands for <code>ac</code> or <code>bc</code>.
-        </li>
-        <li>
-          <strong>Optionality:</strong> <code>[]</code> stands for optionality. For example,
-          <code>[a]b</code> stands for <code>ab</code> or <code>b</code>.
-        </li>
-        <li>
-          <strong>Repetition:</strong> <code>{}</code> stands for repetition. For example,
-          <code>{a}</code> stands for the empty string, <code>a</code>, <code>aa</code>,
-          <code>aaa</code>, ...&quot;.
-        </li>
-      </ul>
-      <p>
-        <code>a … b</code> stands for a range of single characters from <code>a</code> to
-        <code>b</code>, inclusive.
-      </p>
-      <p>Here is a WSN defining itself:</p>
-      <pre><code>syntax     = { production } .
+      <div class="max-width-wrapper">
+        <h1>Language Specification</h1>
+        <p>
+          Evy is a
+          <a href="https://developer.mozilla.org/en-US/docs/Glossary/Static_typing"
+            >statically typed</a
+          >,
+          <a href="https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)"
+            >garbage collected</a
+          >,
+          <a href="https://en.wikipedia.org/wiki/Procedural_programming">procedural</a> programming
+          language. Its main design goal is to help learn programming. Evy aims for simplicity and
+          directness in its tooling and syntax. Several features typical of modern programming
+          languages are purposefully left out.
+        </p>
+        <p>
+          To get an intuitive understanding of Evy, you can either look at its
+          <a href="syntax_by_example.html">syntax by example</a> or read through the
+          <a href="builtins.html">built-ins documentation</a>.
+        </p>
+        <h2><a id="syntax-grammar" href="#syntax-grammar" class="anchor">#</a>Syntax Grammar</h2>
+        <p>
+          The Evy syntax grammar is a
+          <a href="https://en.wikipedia.org/wiki/Wirth_syntax_notation">WSN</a> grammar, which is a
+          formal set of rules that define how Evy programs are written. The Evy interpreter uses the
+          syntax grammar to parse Evy source code, which means that it checks that the code follows
+          the rules of the grammar.
+        </p>
+        <h3>
+          <a id="wsn-syntax-grammar" href="#wsn-syntax-grammar" class="anchor">#</a>WSN Syntax
+          Grammar
+        </h3>
+        <p>
+          Evy's syntax is specified using a WSN grammar, a variant of
+          <a href="https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form">EBNF</a>
+          grammars, borrowing concepts from the
+          <a href="https://go.dev/ref/spec">Go Programming Language Specification</a>.
+        </p>
+        <p>
+          <strong>Productions</strong> are the top-level elements of a WSN grammar. For example, the
+          production
+          <code>OPERATOR = &quot;+&quot; | &quot;-&quot; | &quot;*&quot; | &quot;/&quot; .</code>
+          specifies that an operator can be one of the characters <code>+</code>, <code>-</code>,
+          <code>*</code>, or <code>/</code>.
+        </p>
+        <p>
+          A production consists of an <strong>expression</strong> assigned to an
+          <strong>identifier</strong> or production name. Each production is terminated by a period
+          <code>.</code>. An expression consists of <strong>terms</strong> and the following
+          <strong>operators</strong> in increasing precedence:
+        </p>
+        <ul>
+          <li>
+            <strong>Alternation:</strong> <code>|</code> stands for &quot;or&quot;. For example,
+            <code>a | b</code> stands for <code>a</code> or <code>b</code>.
+          </li>
+          <li>
+            <strong>Grouping:</strong> <code>()</code> stands for grouping. For example,
+            <code>(a|b)c</code> stands for <code>ac</code> or <code>bc</code>.
+          </li>
+          <li>
+            <strong>Optionality:</strong> <code>[]</code> stands for optionality. For example,
+            <code>[a]b</code> stands for <code>ab</code> or <code>b</code>.
+          </li>
+          <li>
+            <strong>Repetition:</strong> <code>{}</code> stands for repetition. For example,
+            <code>{a}</code> stands for the empty string, <code>a</code>, <code>aa</code>,
+            <code>aaa</code>, ...&quot;.
+          </li>
+        </ul>
+        <p>
+          <code>a … b</code> stands for a range of single characters from <code>a</code> to
+          <code>b</code>, inclusive.
+        </p>
+        <p>Here is a WSN defining itself:</p>
+        <pre><code>syntax     = { production } .
 production = identifier &quot;=&quot; expression &quot;.&quot; .
 expression = terms { &quot;|&quot; terms } .
 terms      = term { term } .
@@ -615,43 +618,44 @@ literal    = &quot;&quot;&quot; CHARACTER { CHARACTER } &quot;&quot;&quot; . /* 
 LETTER     = &quot;a&quot; … &quot;z&quot; | &quot;A&quot; … &quot;Z&quot; | &quot;_&quot; .
 CHARACTER  = /* an arbitrary Unicode code point */ .
 </code></pre>
-      <p>
-        <strong>Terminals</strong> are the leaves in the grammar that cannot be expanded further. By
-        convention, terminals are identified by production names in uppercase.
-      </p>
-      <p>
-        <strong>Non-terminals</strong>, on the other hand, can be expanded into other productions.
-        This means that they can be replaced by a more complex expression. By convention,
-        non-terminals are identified by production names in lowercase.
-      </p>
-      <p>
-        <strong>Literals</strong> or lexical tokens are enclosed in double quotes
-        <code>&quot;&quot;</code>. Comments are fenced by <code>/*</code> … <code>*/</code>.
-      </p>
-      <p>
-        There are two special fencing tokens in Evy's grammar related to
-        <strong>horizontal whitespace</strong>, <code>&lt;-</code> … <code>-&gt;</code> and
-        <code>&lt;+</code> … <code>+&gt;</code>. <code>&lt;-</code> … <code>-&gt;</code> means no
-        horizontal whitespace is allowed between the terminals of the enclosed expression, e.g.
-        <code>3+5</code> inside <code>&lt;-</code> … <code>-&gt;</code> is allowed, but
-        <code>3 + 5</code> is not. The fencing tokens <code>&lt;+</code> … <code>+&gt;</code> are
-        the default and mean horizontal whitespace is allowed (again) between terminals.
-      </p>
-      <p>See the section on <a href="#whitespace">whitespace</a> for further details.</p>
-      <h3>
-        <a id="evy-syntax-grammar" href="#evy-syntax-grammar" class="anchor">#</a>Evy Syntax Grammar
-      </h3>
-      <p>
-        Evy source code is UTF-8 encoded, which means that it can contain any Unicode character. The
-        NUL character <code>U+0000</code> is not allowed, as it is a special character that is used
-        during compilation.
-      </p>
-      <p>
-        The <code>WS</code> abbreviation in the grammar comments below refers to horizontal
-        whitespace, which is any combination of spaces and tabs. The following listing contains the
-        complete syntax grammar for Evy.
-      </p>
-      <pre><code>program    = { statement | func | event_handler | nl } eof .
+        <p>
+          <strong>Terminals</strong> are the leaves in the grammar that cannot be expanded further.
+          By convention, terminals are identified by production names in uppercase.
+        </p>
+        <p>
+          <strong>Non-terminals</strong>, on the other hand, can be expanded into other productions.
+          This means that they can be replaced by a more complex expression. By convention,
+          non-terminals are identified by production names in lowercase.
+        </p>
+        <p>
+          <strong>Literals</strong> or lexical tokens are enclosed in double quotes
+          <code>&quot;&quot;</code>. Comments are fenced by <code>/*</code> … <code>*/</code>.
+        </p>
+        <p>
+          There are two special fencing tokens in Evy's grammar related to
+          <strong>horizontal whitespace</strong>, <code>&lt;-</code> … <code>-&gt;</code> and
+          <code>&lt;+</code> … <code>+&gt;</code>. <code>&lt;-</code> … <code>-&gt;</code> means no
+          horizontal whitespace is allowed between the terminals of the enclosed expression, e.g.
+          <code>3+5</code> inside <code>&lt;-</code> … <code>-&gt;</code> is allowed, but
+          <code>3 + 5</code> is not. The fencing tokens <code>&lt;+</code> … <code>+&gt;</code> are
+          the default and mean horizontal whitespace is allowed (again) between terminals.
+        </p>
+        <p>See the section on <a href="#whitespace">whitespace</a> for further details.</p>
+        <h3>
+          <a id="evy-syntax-grammar" href="#evy-syntax-grammar" class="anchor">#</a>Evy Syntax
+          Grammar
+        </h3>
+        <p>
+          Evy source code is UTF-8 encoded, which means that it can contain any Unicode character.
+          The NUL character <code>U+0000</code> is not allowed, as it is a special character that is
+          used during compilation.
+        </p>
+        <p>
+          The <code>WS</code> abbreviation in the grammar comments below refers to horizontal
+          whitespace, which is any combination of spaces and tabs. The following listing contains
+          the complete syntax grammar for Evy.
+        </p>
+        <pre><code>program    = { statement | func | event_handler | nl } eof .
 statements = { nl } statement { statement | nl } .
 statement  = typed_decl_stmt | inferred_decl_stmt |
              assign_stmt |
@@ -762,68 +766,68 @@ DECIMAL_DIGIT  = &quot;0&quot; … &quot;9&quot; .
 NL             = &quot;\n&quot;  . /* end of file */
 EOF            = &quot;&quot; . /* end of file */
 </code></pre>
-      <h2><a id="comments" href="#comments" class="anchor">#</a>Comments</h2>
-      <p>
-        There is only one type of comment, the line comment which starts with <code>//</code> and
-        stops at the end of the line. Line comments cannot start inside string literals.
-      </p>
-      <h2><a id="types" href="#types" class="anchor">#</a>Types</h2>
-      <p>
-        Evy has a static <strong>type system</strong> where the types of variables, parameters and
-        expressions are known at parse time. This means that the parser can check for type errors
-        before the program is run.
-      </p>
-      <p>
-        There are three <strong>basic types</strong>: <code>num</code>, <code>string</code> and
-        <code>bool</code> as well as two <strong>composite types</strong>: arrays
-        <code>[]</code> and maps <code>{}</code>. The <strong>dynamic</strong> type
-        <code>any</code> can hold any of the previously listed types.
-      </p>
-      <p>
-        Composite types can nest further composite types, for example <code>[]{}string</code> is an
-        array of maps with string values.
-      </p>
-      <p>A <code>bool</code> value is either <code>true</code> or <code>false</code>.</p>
-      <p>
-        A number value can be expressed as integer <code>1234</code> or decimal <code>56.78</code>.
-        Internally a number is represented as a
-        <a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format"
-          >double-precision floating-point number</a
-        >
-        according to the IEEE-754 64-bit floating point standard.
-      </p>
-      <h2>
-        <a id="variables-and-declarations" href="#variables-and-declarations" class="anchor">#</a
-        >Variables and Declarations
-      </h2>
-      <p>
-        Variables hold values of a specific type. They must be <strong>declared</strong> before they
-        can be used. A declared variable must be used at least once, meaning it must be used in the
-        right hand side of an assignment or passed as an argument to a function call. There are two
-        types of variable declarations: inferred declarations and typed declarations.
-      </p>
-      <p>
-        <strong>Inferred declarations</strong> do not specify the type of the variable explicitly.
-        The type of the variable is inferred from the value that it is initialized to. For example,
-        the following code declares a variable <code>n</code> and initializes it to the value
-        <code>1</code>. The type of <code>n</code> is inferred to be <code>num</code>.
-      </p>
-      <pre><code>n := 1
+        <h2><a id="comments" href="#comments" class="anchor">#</a>Comments</h2>
+        <p>
+          There is only one type of comment, the line comment which starts with <code>//</code> and
+          stops at the end of the line. Line comments cannot start inside string literals.
+        </p>
+        <h2><a id="types" href="#types" class="anchor">#</a>Types</h2>
+        <p>
+          Evy has a static <strong>type system</strong> where the types of variables, parameters and
+          expressions are known at parse time. This means that the parser can check for type errors
+          before the program is run.
+        </p>
+        <p>
+          There are three <strong>basic types</strong>: <code>num</code>, <code>string</code> and
+          <code>bool</code> as well as two <strong>composite types</strong>: arrays
+          <code>[]</code> and maps <code>{}</code>. The <strong>dynamic</strong> type
+          <code>any</code> can hold any of the previously listed types.
+        </p>
+        <p>
+          Composite types can nest further composite types, for example <code>[]{}string</code> is
+          an array of maps with string values.
+        </p>
+        <p>A <code>bool</code> value is either <code>true</code> or <code>false</code>.</p>
+        <p>
+          A number value can be expressed as integer <code>1234</code> or decimal
+          <code>56.78</code>. Internally a number is represented as a
+          <a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format"
+            >double-precision floating-point number</a
+          >
+          according to the IEEE-754 64-bit floating point standard.
+        </p>
+        <h2>
+          <a id="variables-and-declarations" href="#variables-and-declarations" class="anchor">#</a
+          >Variables and Declarations
+        </h2>
+        <p>
+          Variables hold values of a specific type. They must be <strong>declared</strong> before
+          they can be used. A declared variable must be used at least once, meaning it must be used
+          in the right hand side of an assignment or passed as an argument to a function call. There
+          are two types of variable declarations: inferred declarations and typed declarations.
+        </p>
+        <p>
+          <strong>Inferred declarations</strong> do not specify the type of the variable explicitly.
+          The type of the variable is inferred from the value that it is initialized to. For
+          example, the following code declares a variable <code>n</code> and initializes it to the
+          value <code>1</code>. The type of <code>n</code> is inferred to be <code>num</code>.
+        </p>
+        <pre><code>n := 1
 </code></pre>
-      <p>
-        <strong>Typed declarations</strong> explicitly specify the type of the variable. The
-        variable is initialized to the type's zero value. For example, the following code declares a
-        variable <code>s</code> of type <code>string</code> and initializes it to the empty string
-        <code>&quot;&quot;</code>.
-      </p>
-      <pre><code>s:string
+        <p>
+          <strong>Typed declarations</strong> explicitly specify the type of the variable. The
+          variable is initialized to the type's zero value. For example, the following code declares
+          a variable <code>s</code> of type <code>string</code> and initializes it to the empty
+          string <code>&quot;&quot;</code>.
+        </p>
+        <pre><code>s:string
 </code></pre>
-      <p>
-        <code>arr := []</code> infers an array of type any, <code>[]any</code>.
-        <code>map := {}</code> infers a map of type any, <code>{}any</code>. The strictest possible
-        type is inferred for composite types:
-      </p>
-      <pre><code class="language-evy">arr1 := [1 2 3] // []num
+        <p>
+          <code>arr := []</code> infers an array of type any, <code>[]any</code>.
+          <code>map := {}</code> infers a map of type any, <code>{}any</code>. The strictest
+          possible type is inferred for composite types:
+        </p>
+        <pre><code class="language-evy">arr1 := [1 2 3] // []num
 arr2 := [1] + [] // []num
 print 1 (typeof arr1) (typeof arr2)
 
@@ -836,152 +840,153 @@ map1 := {} // {}any
 map2 := {age:10} // {}num
 print 3 (typeof map1) (typeof map2)
 </code></pre>
-      <p>
-        The <a href="#typeof"><code>typeof</code></a> function returns the type as string
-        representation, so the code above outputs:
-      </p>
-      <pre><code class="language-evy:output">1 []num []num
+        <p>
+          The <a href="#typeof"><code>typeof</code></a> function returns the type as string
+          representation, so the code above outputs:
+        </p>
+        <pre><code class="language-evy:output">1 []num []num
 2 []any [][]any []any
 3 {}any {}num
 </code></pre>
-      <h2><a id="zero-values" href="#zero-values" class="anchor">#</a>Zero Values</h2>
-      <p>
-        Variables declared via typed declaration are initialized to the zero value of their type:
-      </p>
-      <ul>
-        <li>Number: <code>0</code></li>
-        <li>String: <code>&quot;&quot;</code></li>
-        <li>Boolean: <code>false</code></li>
-        <li>Any: <code>false</code></li>
-        <li>Array: <code>[]</code></li>
-        <li>Map: <code>{}</code></li>
-      </ul>
-      <p>
-        The empty array becomes <code>[]any</code> in inferred declarations. Otherwise the empty
-        array literal assumes the array type <code>[]TYPE</code> required by the assigned variable
-        or parameter. For example, the following code
-      </p>
-      <pre><code class="language-evy">arr:[]num
+        <h2><a id="zero-values" href="#zero-values" class="anchor">#</a>Zero Values</h2>
+        <p>
+          Variables declared via typed declaration are initialized to the zero value of their type:
+        </p>
+        <ul>
+          <li>Number: <code>0</code></li>
+          <li>String: <code>&quot;&quot;</code></li>
+          <li>Boolean: <code>false</code></li>
+          <li>Any: <code>false</code></li>
+          <li>Array: <code>[]</code></li>
+          <li>Map: <code>{}</code></li>
+        </ul>
+        <p>
+          The empty array becomes <code>[]any</code> in inferred declarations. Otherwise the empty
+          array literal assumes the array type <code>[]TYPE</code> required by the assigned variable
+          or parameter. For example, the following code
+        </p>
+        <pre><code class="language-evy">arr:[]num
 print 1 arr (typeof arr)
 arr = []
 print 2 arr (typeof arr)
 print 3 (typeof [])
 </code></pre>
-      <p>generates the output</p>
-      <pre><code class="language-evy:output">1 [] []num
+        <p>generates the output</p>
+        <pre><code class="language-evy:output">1 [] []num
 2 [] []num
 3 []any
 </code></pre>
-      <p>
-        Similarly, the empty map literal becomes <code>{}any</code> in inferred declarations.
-        Otherwise the empty map literal assumes the map type <code>{}TYPE</code> required.
-      </p>
-      <h2><a id="assignments" href="#assignments" class="anchor">#</a>Assignments</h2>
-      <p>
-        Assignments are defined by an equal sign <code>=</code>. The left-hand side of the
-        <code>=</code> must contain an <strong>assignment target</strong>, a variable, an indexed
-        array, or a map field. The assignment target must be declared before the assignment, either
-        implicitly via type inference or explicitly via a type declaration. It can also be a
-        parameter of a function or event handler definition.
-        <a href="#assignability">Assignability</a> provides rules on which value types can be
-        assigned to which target types.
-      </p>
-      <p>
-        For example, the following code declares a string variable named <code>s</code> and
-        initializes it to the value <code>&quot;a&quot;</code> through inference. Then, it assigns
-        the value <code>&quot;b&quot;</code> to <code>s</code>. Finally, it tries to assign the
-        value <code>100</code> to <code>s</code>, which will cause a parse error because
-        <code>s</code> is a string variable and <code>100</code> is a number.
-      </p>
-      <pre><code class="language-evy">s := &quot;a&quot;
+        <p>
+          Similarly, the empty map literal becomes <code>{}any</code> in inferred declarations.
+          Otherwise the empty map literal assumes the map type <code>{}TYPE</code> required.
+        </p>
+        <h2><a id="assignments" href="#assignments" class="anchor">#</a>Assignments</h2>
+        <p>
+          Assignments are defined by an equal sign <code>=</code>. The left-hand side of the
+          <code>=</code> must contain an <strong>assignment target</strong>, a variable, an indexed
+          array, or a map field. The assignment target must be declared before the assignment,
+          either implicitly via type inference or explicitly via a type declaration. It can also be
+          a parameter of a function or event handler definition.
+          <a href="#assignability">Assignability</a> provides rules on which value types can be
+          assigned to which target types.
+        </p>
+        <p>
+          For example, the following code declares a string variable named <code>s</code> and
+          initializes it to the value <code>&quot;a&quot;</code> through inference. Then, it assigns
+          the value <code>&quot;b&quot;</code> to <code>s</code>. Finally, it tries to assign the
+          value <code>100</code> to <code>s</code>, which will cause a parse error because
+          <code>s</code> is a string variable and <code>100</code> is a number.
+        </p>
+        <pre><code class="language-evy">s := &quot;a&quot;
 print 1 s
 s = &quot;b&quot;
 print 2 s
 // s = 100 // parse error, wrong type
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">1 a
+        <p>Output</p>
+        <pre><code class="language-evy:output">1 a
 2 b
 </code></pre>
-      <h2>
-        <a id="copy-and-reference" href="#copy-and-reference" class="anchor">#</a>Copy and Reference
-      </h2>
-      <p>
-        When a variable of a basic type <code>num</code>, <code>string</code>, or
-        <code>bool</code> is the value of an assignment, a <strong>copy</strong> of its value is
-        made. A copy is also made when a variable of a basic type is used as the value in an
-        inferred declaration or passed as an argument to a function.
-      </p>
-      <pre><code class="language-evy">a := 1
+        <h2>
+          <a id="copy-and-reference" href="#copy-and-reference" class="anchor">#</a>Copy and
+          Reference
+        </h2>
+        <p>
+          When a variable of a basic type <code>num</code>, <code>string</code>, or
+          <code>bool</code> is the value of an assignment, a <strong>copy</strong> of its value is
+          made. A copy is also made when a variable of a basic type is used as the value in an
+          inferred declaration or passed as an argument to a function.
+        </p>
+        <pre><code class="language-evy">a := 1
 b := a
 print a b
 a = 2 // `b` keeps its initial value
 print a b
 </code></pre>
-      <p>generates the output</p>
-      <pre><code class="language-evy:output">1 1
+        <p>generates the output</p>
+        <pre><code class="language-evy:output">1 1
 2 1
 </code></pre>
-      <p>
-        By contrast, composite types - maps and arrays - are
-        <strong>passed by reference</strong> and no copy is made. Modifying the contents of an array
-        referenced by one variable also modifies the contents of the array referenced by another
-        variable. This is also true for argument passing and inferred declarations:
-      </p>
-      <pre><code class="language-evy">a := [1]
+        <p>
+          By contrast, composite types - maps and arrays - are
+          <strong>passed by reference</strong> and no copy is made. Modifying the contents of an
+          array referenced by one variable also modifies the contents of the array referenced by
+          another variable. This is also true for argument passing and inferred declarations:
+        </p>
+        <pre><code class="language-evy">a := [1]
 b := a
 print a b
 a[0] = 2 // the value of `b` is also updated
 print a b
 </code></pre>
-      <p>generates the output</p>
-      <pre><code class="language-evy:output">[1] [1]
+        <p>generates the output</p>
+        <pre><code class="language-evy:output">[1] [1]
 [2] [2]
 </code></pre>
-      <p>
-        For the dynamic type <code>any</code>, a copy is made if the value is a basic type. The
-        variable is passed by reference if the value is a composite type.
-      </p>
-      <h2><a id="variable-names" href="#variable-names" class="anchor">#</a>Variable Names</h2>
-      <p>
-        Variable names in Evy must start with a letter or underscore, and can contain any
-        combination of letters, numbers, and underscores. They cannot be the same as keywords, such
-        as <code>if</code>, <code>func</code>, or any built-in or defined function names.
-      </p>
-      <h2><a id="scope" href="#scope" class="anchor">#</a>Scope</h2>
-      <p><strong>Scope</strong> refers to the visibility of a variable or function.</p>
-      <p>
-        Functions can only be defined at the top level of the program, known as
-        <strong>global scope</strong>. A function does not have to be defined before it can be
-        called; it can also be defined afterwards. This allows for
-        <a href="https://en.wikipedia.org/wiki/Mutual_recursion">mutual recursion</a>, where
-        function <code>a</code> calls function <code>b</code> and function <code>b</code> calls
-        function <code>a</code>.
-      </p>
-      <p>
-        Variables, by contrast, must be declared and given an unchangeable type before they can be
-        used. Variables can be declared at the top level of the program, at
-        <strong>global scope</strong>, or within a block-statement, at <em>block scope</em>.
-      </p>
-      <p>
-        A <strong>block-statement</strong> is a block of statements that ends with the keyword
-        <code>end</code>. A function's parameter declaration and the function body following the
-        line starting with <code>func</code> is a block-statement. The statements between
-        <code>if</code> and <code>else</code> are a block. The statements between
-        <code>while</code>/<code>for</code>/<code>else</code> and <code>end</code> are a block.
-        Blocks can be nested within other blocks.
-      </p>
-      <p>
-        A variable declared inside a block only exists until the end of the block. It cannot be used
-        outside the block.
-      </p>
-      <p>
-        Variable names in an inner block can <strong>shadow</strong> or override the same variable
-        name from an outer block, which makes the variable of the outer block inaccessible to the
-        inner block. However, when the inner block is finished, the variable from the outer block is
-        restored and unchanged:
-      </p>
-      <pre><code class="language-evy">x := &quot;outer&quot;
+        <p>
+          For the dynamic type <code>any</code>, a copy is made if the value is a basic type. The
+          variable is passed by reference if the value is a composite type.
+        </p>
+        <h2><a id="variable-names" href="#variable-names" class="anchor">#</a>Variable Names</h2>
+        <p>
+          Variable names in Evy must start with a letter or underscore, and can contain any
+          combination of letters, numbers, and underscores. They cannot be the same as keywords,
+          such as <code>if</code>, <code>func</code>, or any built-in or defined function names.
+        </p>
+        <h2><a id="scope" href="#scope" class="anchor">#</a>Scope</h2>
+        <p><strong>Scope</strong> refers to the visibility of a variable or function.</p>
+        <p>
+          Functions can only be defined at the top level of the program, known as
+          <strong>global scope</strong>. A function does not have to be defined before it can be
+          called; it can also be defined afterwards. This allows for
+          <a href="https://en.wikipedia.org/wiki/Mutual_recursion">mutual recursion</a>, where
+          function <code>a</code> calls function <code>b</code> and function <code>b</code> calls
+          function <code>a</code>.
+        </p>
+        <p>
+          Variables, by contrast, must be declared and given an unchangeable type before they can be
+          used. Variables can be declared at the top level of the program, at
+          <strong>global scope</strong>, or within a block-statement, at <em>block scope</em>.
+        </p>
+        <p>
+          A <strong>block-statement</strong> is a block of statements that ends with the keyword
+          <code>end</code>. A function's parameter declaration and the function body following the
+          line starting with <code>func</code> is a block-statement. The statements between
+          <code>if</code> and <code>else</code> are a block. The statements between
+          <code>while</code>/<code>for</code>/<code>else</code> and <code>end</code> are a block.
+          Blocks can be nested within other blocks.
+        </p>
+        <p>
+          A variable declared inside a block only exists until the end of the block. It cannot be
+          used outside the block.
+        </p>
+        <p>
+          Variable names in an inner block can <strong>shadow</strong> or override the same variable
+          name from an outer block, which makes the variable of the outer block inaccessible to the
+          inner block. However, when the inner block is finished, the variable from the outer block
+          is restored and unchanged:
+        </p>
+        <pre><code class="language-evy">x := &quot;outer&quot;
 print 1 x
 for range 1
     x := true
@@ -989,133 +994,134 @@ for range 1
 end
 print 3 x
 </code></pre>
-      <p>This program will print</p>
-      <pre><code class="language-evy:output">1 outer
+        <p>This program will print</p>
+        <pre><code class="language-evy:output">1 outer
 2 true
 3 outer
 </code></pre>
-      <h2><a id="strings" href="#strings" class="anchor">#</a>Strings</h2>
-      <p>
-        A <strong>string</strong> is a sequence of
-        <a href="https://en.wikipedia.org/wiki/Unicode">Unicode code points</a>. Unicode is a
-        standard that defines a unique code point for every character in every language. This means
-        that a string can contain characters from any language, including English, French, Spanish,
-        Chinese, Japanese, and Korean.
-      </p>
-      <p>
-        A <strong>string literal</strong> is a sequence of characters enclosed by double quotes. The
-        characters in a string literal are interpreted as Unicode code points. This means that a
-        string literal can contain any character that has a Unicode code point, including letters,
-        numbers, punctuation marks, and emojis.
-      </p>
-      <p>
-        The example code <code>str := &quot;Hallöchen Welt 👋🌍&quot;</code> defines a string
-        variable <code>str</code> and initializes it with a string literal that contains the German
-        words &quot;Hallöchen Welt&quot; and the emojis &quot;👋🌍&quot;.
-      </p>
-      <p>
-        The <code>len str</code> function returns the number of Unicode code points, or
-        <strong>characters</strong>, in the string. The loop
-        <code>for ch := range str</code> iterates over all characters of the string. Individual
-        characters of a string can be read by index, starting at <code>0</code>. Strings can be
-        concatenated with the <code>+</code> operator.
-      </p>
-      <p>
-        The backslash character <code>\</code> can be used to represent special characters in
-        strings. For example, the <code>\t</code> escape sequence represents a tab character, and
-        the <code>\n</code> escape sequence represents a newline character. Quotes in string
-        literals must also be escaped with backslashes. To print a backslash character, use
-        <code>\\</code>.
-      </p>
-      <p>For example the following code</p>
-      <pre><code class="language-evy">str := &quot;hello&quot;
+        <h2><a id="strings" href="#strings" class="anchor">#</a>Strings</h2>
+        <p>
+          A <strong>string</strong> is a sequence of
+          <a href="https://en.wikipedia.org/wiki/Unicode">Unicode code points</a>. Unicode is a
+          standard that defines a unique code point for every character in every language. This
+          means that a string can contain characters from any language, including English, French,
+          Spanish, Chinese, Japanese, and Korean.
+        </p>
+        <p>
+          A <strong>string literal</strong> is a sequence of characters enclosed by double quotes.
+          The characters in a string literal are interpreted as Unicode code points. This means that
+          a string literal can contain any character that has a Unicode code point, including
+          letters, numbers, punctuation marks, and emojis.
+        </p>
+        <p>
+          The example code <code>str := &quot;Hallöchen Welt 👋🌍&quot;</code> defines a string
+          variable <code>str</code> and initializes it with a string literal that contains the
+          German words &quot;Hallöchen Welt&quot; and the emojis &quot;👋🌍&quot;.
+        </p>
+        <p>
+          The <code>len str</code> function returns the number of Unicode code points, or
+          <strong>characters</strong>, in the string. The loop
+          <code>for ch := range str</code> iterates over all characters of the string. Individual
+          characters of a string can be read by index, starting at <code>0</code>. Strings can be
+          concatenated with the <code>+</code> operator.
+        </p>
+        <p>
+          The backslash character <code>\</code> can be used to represent special characters in
+          strings. For example, the <code>\t</code> escape sequence represents a tab character, and
+          the <code>\n</code> escape sequence represents a newline character. Quotes in string
+          literals must also be escaped with backslashes. To print a backslash character, use
+          <code>\\</code>.
+        </p>
+        <p>For example the following code</p>
+        <pre><code class="language-evy">str := &quot;hello&quot;
 str = str + &quot;, &quot; + str // hello, hello
 str = &quot;H&quot; + str[1:] // Hello, hello
 str = &quot;She said, \&quot;&quot; + str + &quot;!\&quot;&quot;
 print str
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">She said, &quot;Hello, hello!&quot;
+        <p>outputs</p>
+        <pre><code class="language-evy:output">She said, &quot;Hello, hello!&quot;
 </code></pre>
-      <h2><a id="arrays" href="#arrays" class="anchor">#</a>Arrays</h2>
-      <p>
-        <strong>Arrays</strong> are collections of elements that have the same type. They are
-        declared with brackets <code>[]</code>, and the elements are separated by a space. For
-        example, the following code declares two arrays of numbers
-      </p>
-      <pre><code class="language-evy">arr1 := [1 2 3]
+        <h2><a id="arrays" href="#arrays" class="anchor">#</a>Arrays</h2>
+        <p>
+          <strong>Arrays</strong> are collections of elements that have the same type. They are
+          declared with brackets <code>[]</code>, and the elements are separated by a space. For
+          example, the following code declares two arrays of numbers
+        </p>
+        <pre><code class="language-evy">arr1 := [1 2 3]
 arr2:[]num
 print arr1 arr2
 </code></pre>
-      <p>The output is</p>
-      <pre><code class="language-evy:output">[1 2 3] []
+        <p>The output is</p>
+        <pre><code class="language-evy:output">[1 2 3] []
 </code></pre>
-      <p>
-        Arrays can also be nested, meaning that they can contain other arrays or maps. For example,
-        the following code declares an array of maps of strings <code>arr:[]{}string</code>.
-      </p>
-      <p>
-        An array composed of different types becomes an array of type any, <code>[]any</code>, for
-        example
-      </p>
-      <pre><code class="language-evy">arr := [&quot;abc&quot; 123] // []any
+        <p>
+          Arrays can also be nested, meaning that they can contain other arrays or maps. For
+          example, the following code declares an array of maps of strings
+          <code>arr:[]{}string</code>.
+        </p>
+        <p>
+          An array composed of different types becomes an array of type any, <code>[]any</code>, for
+          example
+        </p>
+        <pre><code class="language-evy">arr := [&quot;abc&quot; 123] // []any
 print &quot;Type of arr:&quot; (typeof arr)
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">Type of arr: []any
+        <p>outputs</p>
+        <pre><code class="language-evy:output">Type of arr: []any
 </code></pre>
-      <p>
-        The function <code>len arr</code> returns the length of the array, which is the number of
-        elements in the array. The loop <code>for el := range arr</code> iterates over all elements
-        of the array in order.
-      </p>
-      <p>
-        Arrays can be concatenated with the <code>+</code> operator, for example
-        <code>arr2 := arr + arr</code>. Only arrays of the same type can be concatenated. If you try
-        to concatenate two literals of different types such as
-        <code>arr := [1 2] + [&quot;a&quot; &quot;b&quot;]</code>, you will get a parse error. Use
-        <code>arr := [1 2 &quot;a&quot; &quot;b&quot;]</code> instead.
-      </p>
-      <p>
-        The elements of an array can be accessed via index starting at <code>0</code>. In the
-        example <code>arr := [&quot;abc&quot; 123]</code> the first element in the array
-        <code>arr[0]</code> is <code>&quot;abc&quot;</code>.
-      </p>
-      <p>
-        The empty array becomes <code>[]any</code> in inferred declarations, otherwise the empty
-        array literal assumes the array type required by the assigned variable or parameter.
-        <code>arr:[]any</code> and <code>arr := []</code> are equivalent.
-      </p>
-      <p>
-        In order to distinguish between array literals and array indices, there cannot be any
-        whitespace between array variable and index. For example, the following code
-      </p>
-      <pre><code class="language-evy">arr := [&quot;a&quot; &quot;b&quot;]
+        <p>
+          The function <code>len arr</code> returns the length of the array, which is the number of
+          elements in the array. The loop <code>for el := range arr</code> iterates over all
+          elements of the array in order.
+        </p>
+        <p>
+          Arrays can be concatenated with the <code>+</code> operator, for example
+          <code>arr2 := arr + arr</code>. Only arrays of the same type can be concatenated. If you
+          try to concatenate two literals of different types such as
+          <code>arr := [1 2] + [&quot;a&quot; &quot;b&quot;]</code>, you will get a parse error. Use
+          <code>arr := [1 2 &quot;a&quot; &quot;b&quot;]</code> instead.
+        </p>
+        <p>
+          The elements of an array can be accessed via index starting at <code>0</code>. In the
+          example <code>arr := [&quot;abc&quot; 123]</code> the first element in the array
+          <code>arr[0]</code> is <code>&quot;abc&quot;</code>.
+        </p>
+        <p>
+          The empty array becomes <code>[]any</code> in inferred declarations, otherwise the empty
+          array literal assumes the array type required by the assigned variable or parameter.
+          <code>arr:[]any</code> and <code>arr := []</code> are equivalent.
+        </p>
+        <p>
+          In order to distinguish between array literals and array indices, there cannot be any
+          whitespace between array variable and index. For example, the following code
+        </p>
+        <pre><code class="language-evy">arr := [&quot;a&quot; &quot;b&quot;]
 print 1 arr[1] // index
 print 2 arr [1] // literal
 arr[0] = &quot;A&quot;
 print 3 arr
 // arr [1] = &quot;B&quot; // whitespace before `[` is invalid
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">1 b
+        <p>outputs</p>
+        <pre><code class="language-evy:output">1 b
 2 [a b] [1]
 3 [A b]
 </code></pre>
-      <h2><a id="maps" href="#maps" class="anchor">#</a>Maps</h2>
-      <p>
-        <strong>Maps</strong> are key-value stores, where the values can be looked up by their key,
-        for example <code>map := { key1:&quot;value1&quot; key2:&quot;value2&quot; }</code>.
-      </p>
-      <p>
-        Map values can be accessed with the dot expression, for example <code>map.key1</code>. If
-        maps are accessed via the dot expression the key must match the grammars
-        <code>ident</code> production. Map keys in dot expression and map literals may be Evy
-        keywords. Map values can also be accessed with an index expression which allows for
-        evaluation, non-ident keys and variable usage.
-      </p>
-      <p>For example the following code</p>
-      <pre><code class="language-evy">m := {letters:&quot;abc&quot; for:&quot;u&quot;}
+        <h2><a id="maps" href="#maps" class="anchor">#</a>Maps</h2>
+        <p>
+          <strong>Maps</strong> are key-value stores, where the values can be looked up by their
+          key, for example <code>map := { key1:&quot;value1&quot; key2:&quot;value2&quot; }</code>.
+        </p>
+        <p>
+          Map values can be accessed with the dot expression, for example <code>map.key1</code>. If
+          maps are accessed via the dot expression the key must match the grammars
+          <code>ident</code> production. Map keys in dot expression and map literals may be Evy
+          keywords. Map values can also be accessed with an index expression which allows for
+          evaluation, non-ident keys and variable usage.
+        </p>
+        <p>For example the following code</p>
+        <pre><code class="language-evy">m := {letters:&quot;abc&quot; for:&quot;u&quot;}
 print 1 m.letters m.for
 print 2 m[&quot;letters&quot;] m[&quot;for&quot;]
 
@@ -1124,449 +1130,458 @@ m[key] = &quot;äöü&quot;
 print 3 m[key]
 print 4 m[&quot;German letters&quot;]
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">1 abc u
+        <p>outputs</p>
+        <pre><code class="language-evy:output">1 abc u
 2 abc u
 3 äöü
 4 äöü
 </code></pre>
-      <p>
-        The <code>has</code> function tests for the existence of a key in a map. The following code
-      </p>
-      <pre><code class="language-evy">m := {letters:&quot;abc&quot;}
+        <p>
+          The <code>has</code> function tests for the existence of a key in a map. The following
+          code
+        </p>
+        <pre><code class="language-evy">m := {letters:&quot;abc&quot;}
 print 1 (has m &quot;letters&quot;)
 print 2 (has m &quot;digits&quot;)
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">1 true
+        <p>outputs</p>
+        <pre><code class="language-evy:output">1 true
 2 false
 </code></pre>
-      <p>
-        The <code>del</code> function deletes a key from a map if it exists and does nothing if the
-        key does not exist. The following code
-      </p>
-      <pre><code class="language-evy">m := {letters:&quot;abc&quot;}
+        <p>
+          The <code>del</code> function deletes a key from a map if it exists and does nothing if
+          the key does not exist. The following code
+        </p>
+        <pre><code class="language-evy">m := {letters:&quot;abc&quot;}
 del m &quot;letters&quot;
 print m
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">{}
+        <p>outputs</p>
+        <pre><code class="language-evy:output">{}
 </code></pre>
-      <p>
-        The loop <code>for key := range map</code> iterates over all map keys. It is safe to delete
-        values from the map with the built-in function <code>del</code> while iterating. The keys
-        are iterated in the order in which they are inserted. Any values inserted into the map
-        during the iteration will not be included in the iteration.
-      </p>
-      <p>The function <code>len m</code> returns the number of key-value pairs in the map.</p>
-      <p>
-        The empty map literal becomes <code>{}any</code> in inferred declarations, otherwise the
-        empty map literal assumes the type required by the map type of the assigned variable or
-        parameter. <code>m:{}any</code> and <code>m := {}</code> are equivalent.
-      </p>
-      <p>
-        No whitespace is allowed around the dot expression <code>.</code>, and before the index
-        expression <code>[</code>.
-      </p>
-      <h2><a id="index-and-slice" href="#index-and-slice" class="anchor">#</a>Index and Slice</h2>
-      <p>
-        An array or string <strong>index</strong> in Evy is a number that is used to access a
-        specific element of an array or character of a string. Array indices start at
-        <code>0</code>, so the first element of an array is <code>arr[0]</code>. A negative index
-        <code>-i</code> is a shorthand for <code>(len arr) - i</code>, so
-        <code>arr[-1]</code> refers to the last element of arr.
-      </p>
-      <p>For example, the following code</p>
-      <pre><code class="language-evy">arr := [&quot;a&quot; &quot;b&quot; &quot;c&quot;]
+        <p>
+          The loop <code>for key := range map</code> iterates over all map keys. It is safe to
+          delete values from the map with the built-in function <code>del</code> while iterating.
+          The keys are iterated in the order in which they are inserted. Any values inserted into
+          the map during the iteration will not be included in the iteration.
+        </p>
+        <p>The function <code>len m</code> returns the number of key-value pairs in the map.</p>
+        <p>
+          The empty map literal becomes <code>{}any</code> in inferred declarations, otherwise the
+          empty map literal assumes the type required by the map type of the assigned variable or
+          parameter. <code>m:{}any</code> and <code>m := {}</code> are equivalent.
+        </p>
+        <p>
+          No whitespace is allowed around the dot expression <code>.</code>, and before the index
+          expression <code>[</code>.
+        </p>
+        <h2><a id="index-and-slice" href="#index-and-slice" class="anchor">#</a>Index and Slice</h2>
+        <p>
+          An array or string <strong>index</strong> in Evy is a number that is used to access a
+          specific element of an array or character of a string. Array indices start at
+          <code>0</code>, so the first element of an array is <code>arr[0]</code>. A negative index
+          <code>-i</code> is a shorthand for <code>(len arr) - i</code>, so
+          <code>arr[-1]</code> refers to the last element of arr.
+        </p>
+        <p>For example, the following code</p>
+        <pre><code class="language-evy">arr := [&quot;a&quot; &quot;b&quot; &quot;c&quot;]
 print 1 arr[0]
 print 2 arr[-1]
 </code></pre>
-      <p>will print the first and last elements of the array</p>
-      <pre><code class="language-evy:output">1 a
+        <p>will print the first and last elements of the array</p>
+        <pre><code class="language-evy:output">1 a
 2 c
 </code></pre>
-      <p>
-        A <strong>slice</strong> is a way to access portions of an array or a string. It is a
-        substring or subarray that is copied from the original array or string. The slice expression
-        <code>arr[start:end]</code> copies a substring or subarray starting with the value at index
-        <code>arr[start]</code>. The length of the slice is <code>end-start</code>. The end index
-        <code>arr[end]</code> is not included in the slice. If <code>start</code> is left out, it
-        defaults to <code>0</code>. If <code>end</code> is left out, it defaults to
-        <code>len arr</code>.
-      </p>
-      <p>
-        As with an <strong>index</strong>, the <code>start</code> or <code>end</code> value of a
-        slice expression may be a negative <code>-i</code> as a shorthand for the normalized value
-        <code>(len arr) - i</code>. After <code>start</code> and <code>end</code> are normalized,
-        their values in the expression <code>arr[start:end]</code> must satisfy
-        <code>0 &lt;= start &lt;= end &lt;= (len arr)</code>.
-      </p>
-      <p>For example, the following code</p>
-      <pre><code class="language-evy">s := &quot;abcd&quot;
+        <p>
+          A <strong>slice</strong> is a way to access portions of an array or a string. It is a
+          substring or subarray that is copied from the original array or string. The slice
+          expression <code>arr[start:end]</code> copies a substring or subarray starting with the
+          value at index <code>arr[start]</code>. The length of the slice is <code>end-start</code>.
+          The end index <code>arr[end]</code> is not included in the slice. If <code>start</code> is
+          left out, it defaults to <code>0</code>. If <code>end</code> is left out, it defaults to
+          <code>len arr</code>.
+        </p>
+        <p>
+          As with an <strong>index</strong>, the <code>start</code> or <code>end</code> value of a
+          slice expression may be a negative <code>-i</code> as a shorthand for the normalized value
+          <code>(len arr) - i</code>. After <code>start</code> and <code>end</code> are normalized,
+          their values in the expression <code>arr[start:end]</code> must satisfy
+          <code>0 &lt;= start &lt;= end &lt;= (len arr)</code>.
+        </p>
+        <p>For example, the following code</p>
+        <pre><code class="language-evy">s := &quot;abcd&quot;
 print 1 s[1:3]
 print 2 s[:2]
 print 3 s[2:]
 print 4 s[:]
 print 5 s[:-1]
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">1 bc
+        <p>outputs</p>
+        <pre><code class="language-evy:output">1 bc
 2 ab
 3 cd
 4 abcd
 5 abc
 </code></pre>
-      <p>
-        If you try to access an element of an array or string that is out of bounds, a
-        <a href="#run-time-panics-and-recoverable-errors">runtime panic</a> will occur. Slice
-        expressions must not be preceded by whitespace before the <code>[</code> character, just
-        like indexing an array or string. For more details, see the section on
-        <a href="#whitespace">whitespace</a>.
-      </p>
-      <h2>
-        <a id="operators-and-expressions" href="#operators-and-expressions" class="anchor">#</a
-        >Operators and Expressions
-      </h2>
-      <p>
-        <strong>Operators</strong> are special symbols or identifiers that combine the values of
-        their operands into a single value. <strong>Operands</strong> are the variables or literal
-        values that the operator acts on. The combination of operands and operators is called
-        expression. An <strong>expression</strong> is a combination of literal values, operators,
-        variables, and further nested expressions that evaluates to a single value.
-      </p>
-      <p>In Evy, there are two types of operators: unary operators and binary operators:</p>
-      <ul>
-        <li>
-          <strong>Unary operators</strong> act on a single operand. For example, the unary operator
-          <code>-</code> negates the value of its operand.
-        </li>
-        <li>
-          <strong>Binary operators</strong> act on two operands. For example, the binary operator
-          <code>+</code> adds the two operands together.
-        </li>
-      </ul>
-      <p>
-        Operators can be combined to form larger expressions, for example, the expression
-        <code>-delta + 3</code> would first negate the value of the variable <code>delta</code> and
-        then add literal number <code>3</code> to the result.
-      </p>
-      <p>
-        Binary expressions can only be evaluated if the operands are of the same type. For example,
-        you cannot add a string to a number. There is no automated type conversion of operands.
-      </p>
-      <p>
-        There are a variety of binary operators: arithmetic, concatenation, logical, and comparison
-        operators.
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th>Operator</th>
-            <th>Operands</th>
-            <th>Result</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>+</code> <code>-</code> <code>*</code> <code>/</code> <code>%</code></td>
-            <td><code>num</code></td>
-            <td><code>num</code></td>
-            <td>arithmetic</td>
-          </tr>
-          <tr>
-            <td><code>+</code></td>
-            <td><code>string</code></td>
-            <td><code>string</code></td>
-            <td>concatenation</td>
-          </tr>
-          <tr>
-            <td><code>+</code></td>
-            <td>array</td>
-            <td>array</td>
-            <td>concatenation</td>
-          </tr>
-          <tr>
-            <td><code>and</code> <code>or</code></td>
-            <td><code>bool</code></td>
-            <td><code>bool</code></td>
-            <td>logical</td>
-          </tr>
-          <tr>
-            <td><code>&lt;</code> <code>&lt;=</code> <code>&gt;</code> <code>&gt;=</code></td>
-            <td><code>num</code></td>
-            <td><code>bool</code></td>
-            <td>comparison</td>
-          </tr>
-          <tr>
-            <td><code>&lt;</code> <code>&lt;=</code> <code>&gt;</code> <code>&gt;=</code></td>
-            <td><code>string</code></td>
-            <td><code>bool</code></td>
-            <td>comparison</td>
-          </tr>
-          <tr>
-            <td><code>==</code> <code>!=</code></td>
-            <td>all types</td>
-            <td><code>bool</code></td>
-            <td>comparison</td>
-          </tr>
-        </tbody>
-      </table>
-      <h3>
-        <a
-          id="arithmetic-and-concatenation-operators"
-          href="#arithmetic-and-concatenation-operators"
-          class="anchor"
-          >#</a
-        >Arithmetic and Concatenation Operators
-      </h3>
-      <p>
-        The <strong>arithmetic operators</strong> <code>+</code>, <code>-</code>, <code>*</code>,
-        <code>/</code>, and <code>%</code> stand for addition, subtraction, multiplication,
-        division, and the
-        <a href="https://en.wikipedia.org/wiki/Modulo_operation">modulo operator</a>. The symbol
-        <code>+</code> can also be used to concatenate strings and arrays.
-      </p>
-      <p>
-        The <strong>modulo operator</strong> <code>%</code>, also known as the remainder operator,
-        returns the remainder of a division operation. For example, <code>10 % 3</code> results in
-        <code>1</code>, because <code>10</code> divided by <code>3</code> has a remainder of
-        <code>1</code>.
-      </p>
-      <p>
-        The <strong>concatenation operator</strong> <code>+</code>, combines two strings or two
-        arrays together. For example, <code>&quot;fire&quot;</code> +
-        <code>&quot;engine&quot;</code> combines into the string
-        <code>&quot;fireengine&quot;</code>.
-      </p>
-      <h3>
-        <a id="logical-operators" href="#logical-operators" class="anchor">#</a>Logical Operators
-      </h3>
-      <p>
-        The <strong>logical operators</strong> <code>and</code> and <code>or</code> are used to
-        perform
-        <a href="https://en.wikipedia.org/wiki/Truth_table#Logical_conjunction_(AND)"
-          >logical conjunction</a
-        >
-        and
-        <a href="https://en.wikipedia.org/wiki/Truth_table#Logical_disjunction_(OR)"
-          >logical disjunction</a
-        >. They are used to perform logical operations on boolean values with type
-        <code>bool</code>.
-      </p>
-      <p>
-        The <code>and</code> operator evaluates to <code>true</code> if both operands are
-        <code>true</code>. The <code>or</code> operator evaluates to <code>true</code> if either
-        operand is <code>true</code>.
-      </p>
-      <p>
-        These operators perform
-        <a href="https://en.wikipedia.org/wiki/Short-circuit_evaluation">short-circuit evaluation</a
-        >, which means that the right-hand side of the operator is not evaluated if the result of
-        the operation can be determined from the left-hand side alone.
-      </p>
-      <p>
-        For example, the expression <code>false and true</code> evaluates to
-        <code>false</code> because the first operand is <code>false</code>. The second operand does
-        not need to be evaluated because the result of the expression is already known to be
-        <code>false</code>.
-      </p>
-      <h3>
-        <a id="comparison-operators" href="#comparison-operators" class="anchor">#</a>Comparison
-        Operators
-      </h3>
-      <p>
-        The <strong>comparison operators</strong> <code>&lt;</code> <code>&lt;=</code>
-        <code>&gt;</code> <code>&gt;=</code> stand for less, less or equal, greater, greater or
-        equal. Their operands may be <code>num</code> or <code>string</code> values. For
-        <code>string</code> types
-        <a href="https://en.wikipedia.org/wiki/Lexicographic_order">lexicographical comparison</a>
-        is used.
-      </p>
-      <p>
-        The <strong>comparison operators</strong> <code>==</code> and <code>!=</code> compare two
-        operands of the same type for equality and inequality. The operands of these operators can
-        be basic types, such as numbers and strings, or composite types, such as arrays and maps.
-        The result of a comparison operation is the boolean value <code>true</code> or
-        <code>false</code>.
-      </p>
-      <h3><a id="unary-operators" href="#unary-operators" class="anchor">#</a>Unary Operators</h3>
-      <p>
-        <strong>Unary operators</strong> are operators that operate on a single operand. In Evy,
-        there are two unary operators: <code>-</code> and <code>!</code>.
-      </p>
-      <ul>
-        <li>
-          The unary operator <code>-</code> negates the value of a numeric operand. For example,
-          <code>-delta</code> negates the value of <code>delta</code>.
-        </li>
-        <li>
-          The unary operator <code>!</code> performs
-          <a href="https://en.wikipedia.org/wiki/Truth_table#Logical_negation">logical negation</a>
-          on a boolean operand. For example, <code>!true</code> evaluates to <code>false</code>.
-        </li>
-      </ul>
-      <p>
-        Unary operators must not be immediately followed by whitespace. For example, the
-        <code>-delta</code> is valid, but <code>- delta</code> is not.
-      </p>
-      <p>The following sample illustrates the care needed with operators and whitespace</p>
-      <pre><code class="language-evy">a := 10
+        <p>
+          If you try to access an element of an array or string that is out of bounds, a
+          <a href="#run-time-panics-and-recoverable-errors">runtime panic</a> will occur. Slice
+          expressions must not be preceded by whitespace before the <code>[</code> character, just
+          like indexing an array or string. For more details, see the section on
+          <a href="#whitespace">whitespace</a>.
+        </p>
+        <h2>
+          <a id="operators-and-expressions" href="#operators-and-expressions" class="anchor">#</a
+          >Operators and Expressions
+        </h2>
+        <p>
+          <strong>Operators</strong> are special symbols or identifiers that combine the values of
+          their operands into a single value. <strong>Operands</strong> are the variables or literal
+          values that the operator acts on. The combination of operands and operators is called
+          expression. An <strong>expression</strong> is a combination of literal values, operators,
+          variables, and further nested expressions that evaluates to a single value.
+        </p>
+        <p>In Evy, there are two types of operators: unary operators and binary operators:</p>
+        <ul>
+          <li>
+            <strong>Unary operators</strong> act on a single operand. For example, the unary
+            operator <code>-</code> negates the value of its operand.
+          </li>
+          <li>
+            <strong>Binary operators</strong> act on two operands. For example, the binary operator
+            <code>+</code> adds the two operands together.
+          </li>
+        </ul>
+        <p>
+          Operators can be combined to form larger expressions, for example, the expression
+          <code>-delta + 3</code> would first negate the value of the variable
+          <code>delta</code> and then add literal number <code>3</code> to the result.
+        </p>
+        <p>
+          Binary expressions can only be evaluated if the operands are of the same type. For
+          example, you cannot add a string to a number. There is no automated type conversion of
+          operands.
+        </p>
+        <p>
+          There are a variety of binary operators: arithmetic, concatenation, logical, and
+          comparison operators.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Operator</th>
+              <th>Operands</th>
+              <th>Result</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>+</code> <code>-</code> <code>*</code> <code>/</code> <code>%</code></td>
+              <td><code>num</code></td>
+              <td><code>num</code></td>
+              <td>arithmetic</td>
+            </tr>
+            <tr>
+              <td><code>+</code></td>
+              <td><code>string</code></td>
+              <td><code>string</code></td>
+              <td>concatenation</td>
+            </tr>
+            <tr>
+              <td><code>+</code></td>
+              <td>array</td>
+              <td>array</td>
+              <td>concatenation</td>
+            </tr>
+            <tr>
+              <td><code>and</code> <code>or</code></td>
+              <td><code>bool</code></td>
+              <td><code>bool</code></td>
+              <td>logical</td>
+            </tr>
+            <tr>
+              <td><code>&lt;</code> <code>&lt;=</code> <code>&gt;</code> <code>&gt;=</code></td>
+              <td><code>num</code></td>
+              <td><code>bool</code></td>
+              <td>comparison</td>
+            </tr>
+            <tr>
+              <td><code>&lt;</code> <code>&lt;=</code> <code>&gt;</code> <code>&gt;=</code></td>
+              <td><code>string</code></td>
+              <td><code>bool</code></td>
+              <td>comparison</td>
+            </tr>
+            <tr>
+              <td><code>==</code> <code>!=</code></td>
+              <td>all types</td>
+              <td><code>bool</code></td>
+              <td>comparison</td>
+            </tr>
+          </tbody>
+        </table>
+        <h3>
+          <a
+            id="arithmetic-and-concatenation-operators"
+            href="#arithmetic-and-concatenation-operators"
+            class="anchor"
+            >#</a
+          >Arithmetic and Concatenation Operators
+        </h3>
+        <p>
+          The <strong>arithmetic operators</strong> <code>+</code>, <code>-</code>, <code>*</code>,
+          <code>/</code>, and <code>%</code> stand for addition, subtraction, multiplication,
+          division, and the
+          <a href="https://en.wikipedia.org/wiki/Modulo_operation">modulo operator</a>. The symbol
+          <code>+</code> can also be used to concatenate strings and arrays.
+        </p>
+        <p>
+          The <strong>modulo operator</strong> <code>%</code>, also known as the remainder operator,
+          returns the remainder of a division operation. For example, <code>10 % 3</code> results in
+          <code>1</code>, because <code>10</code> divided by <code>3</code> has a remainder of
+          <code>1</code>.
+        </p>
+        <p>
+          The <strong>concatenation operator</strong> <code>+</code>, combines two strings or two
+          arrays together. For example, <code>&quot;fire&quot;</code> +
+          <code>&quot;engine&quot;</code> combines into the string
+          <code>&quot;fireengine&quot;</code>.
+        </p>
+        <h3>
+          <a id="logical-operators" href="#logical-operators" class="anchor">#</a>Logical Operators
+        </h3>
+        <p>
+          The <strong>logical operators</strong> <code>and</code> and <code>or</code> are used to
+          perform
+          <a href="https://en.wikipedia.org/wiki/Truth_table#Logical_conjunction_(AND)"
+            >logical conjunction</a
+          >
+          and
+          <a href="https://en.wikipedia.org/wiki/Truth_table#Logical_disjunction_(OR)"
+            >logical disjunction</a
+          >. They are used to perform logical operations on boolean values with type
+          <code>bool</code>.
+        </p>
+        <p>
+          The <code>and</code> operator evaluates to <code>true</code> if both operands are
+          <code>true</code>. The <code>or</code> operator evaluates to <code>true</code> if either
+          operand is <code>true</code>.
+        </p>
+        <p>
+          These operators perform
+          <a href="https://en.wikipedia.org/wiki/Short-circuit_evaluation"
+            >short-circuit evaluation</a
+          >, which means that the right-hand side of the operator is not evaluated if the result of
+          the operation can be determined from the left-hand side alone.
+        </p>
+        <p>
+          For example, the expression <code>false and true</code> evaluates to
+          <code>false</code> because the first operand is <code>false</code>. The second operand
+          does not need to be evaluated because the result of the expression is already known to be
+          <code>false</code>.
+        </p>
+        <h3>
+          <a id="comparison-operators" href="#comparison-operators" class="anchor">#</a>Comparison
+          Operators
+        </h3>
+        <p>
+          The <strong>comparison operators</strong> <code>&lt;</code> <code>&lt;=</code>
+          <code>&gt;</code> <code>&gt;=</code> stand for less, less or equal, greater, greater or
+          equal. Their operands may be <code>num</code> or <code>string</code> values. For
+          <code>string</code> types
+          <a href="https://en.wikipedia.org/wiki/Lexicographic_order">lexicographical comparison</a>
+          is used.
+        </p>
+        <p>
+          The <strong>comparison operators</strong> <code>==</code> and <code>!=</code> compare two
+          operands of the same type for equality and inequality. The operands of these operators can
+          be basic types, such as numbers and strings, or composite types, such as arrays and maps.
+          The result of a comparison operation is the boolean value <code>true</code> or
+          <code>false</code>.
+        </p>
+        <h3><a id="unary-operators" href="#unary-operators" class="anchor">#</a>Unary Operators</h3>
+        <p>
+          <strong>Unary operators</strong> are operators that operate on a single operand. In Evy,
+          there are two unary operators: <code>-</code> and <code>!</code>.
+        </p>
+        <ul>
+          <li>
+            The unary operator <code>-</code> negates the value of a numeric operand. For example,
+            <code>-delta</code> negates the value of <code>delta</code>.
+          </li>
+          <li>
+            The unary operator <code>!</code> performs
+            <a href="https://en.wikipedia.org/wiki/Truth_table#Logical_negation"
+              >logical negation</a
+            >
+            on a boolean operand. For example, <code>!true</code> evaluates to <code>false</code>.
+          </li>
+        </ul>
+        <p>
+          Unary operators must not be immediately followed by whitespace. For example, the
+          <code>-delta</code> is valid, but <code>- delta</code> is not.
+        </p>
+        <p>The following sample illustrates the care needed with operators and whitespace</p>
+        <pre><code class="language-evy">a := 10
 b := 3
 print 1 a-b
 print 2 (a - b)
 print 3 a -b
 // print a - b // parse error
 </code></pre>
-      <p>Output:</p>
-      <pre><code class="language-evy:output">1 7
+        <p>Output:</p>
+        <pre><code class="language-evy:output">1 7
 2 7
 3 10 -3
 </code></pre>
-      <p>
-        For more information about whitespace, see the <a href="#whitespace">whitespace</a> section.
-      </p>
-      <h2><a id="precedence" href="#precedence" class="anchor">#</a>Precedence</h2>
-      <p>
-        Operators in Evy are evaluated in a specific order, called <strong>precedence</strong>. The
-        order of precedence is as follows:
-      </p>
-      <ol>
-        <li>
-          Indexing, dot notation and grouped expressions: <code>a[i]</code> <code>a.b</code>
-          <code>(</code> … <code>)</code>
-        </li>
-        <li>Unary operators: <code>-delta</code> <code>!true</code></li>
-        <li>
-          Binary operators
-          <ol>
-            <li>
-              Multiplication, division, and modulo: <code>*</code> <code>/</code> <code>%</code>
-            </li>
-            <li>Addition and subtraction: <code>+</code> <code>-</code></li>
-            <li>
-              Comparison operators: <code>&lt;</code> <code>&lt;=</code> <code>&gt;</code>
-              <code>&gt;=</code>
-            </li>
-            <li>Equality operators: <code>==</code> <code>!=</code></li>
-            <li>Logical conjunction: <code>and</code></li>
-            <li>Logical disjunction: <code>or</code></li>
-          </ol>
-        </li>
-      </ol>
-      <p>
-        Operators of the same precedence are evaluated from left to right. For example, the
-        expression <code>a[i] - 5 * 2</code> will be evaluated as follows:
-      </p>
-      <ul>
-        <li>The index <code>a[i]</code> will be evaluated first.</li>
-        <li>The multiplication <code>5 * 2</code> will be evaluated next.</li>
-        <li>The subtraction <code>- 5 * 2</code> will be evaluated last.</li>
-      </ul>
-      <p>
-        If you want to change the order of precedence, you can use parentheses to group expressions.
-        For example, the expression <code>(a[i] - 5) * 2</code> will be evaluated as follows:
-      </p>
-      <ul>
-        <li>The expression <code>a[i] - 5</code> will be evaluated first.</li>
-        <li>The multiplication <code>* 2</code> will be evaluated next.</li>
-      </ul>
-      <h2><a id="statements" href="#statements" class="anchor">#</a>Statements</h2>
-      <p>
-        A <strong>statement</strong> is a unit of code that performs an action. Statements are the
-        building blocks of programs, and they can be used to control the flow of execution.
-      </p>
-      <p>Statements can be divided into two categories: block statements and basic statements.</p>
-      <ul>
-        <li>
-          <strong>Basic statements</strong> are statements that cannot be broken down into further
-          statements.
-        </li>
-        <li><strong>Block statements</strong> are statements that contain further statements.</li>
-      </ul>
-      <p>There are 5 types of block statements in Evy:</p>
-      <ul>
-        <li>Function definition</li>
-        <li>Event Handler definitions</li>
-        <li>If statements</li>
-        <li>For statements</li>
-        <li>While statements</li>
-      </ul>
-      <p>There are 5 types of basic statements in Evy:</p>
-      <ul>
-        <li>Variable declaration statement</li>
-        <li>Assignment statement</li>
-        <li>Function call statement</li>
-        <li>Return statement</li>
-        <li>Break statement</li>
-      </ul>
-      <p>
-        Not all statements are allowed in all contexts. For example, a return statement may only be
-        used within a function definition.
-      </p>
-      <h2><a id="whitespace" href="#whitespace" class="anchor">#</a>Whitespace</h2>
-      <p>
-        Whitespace in Evy is used to separate different parts of a program. There are two types of
-        whitespace in Evy: vertical whitespace and horizontal whitespace.
-      </p>
-      <h3>
-        <a id="vertical-whitespace" href="#vertical-whitespace" class="anchor">#</a>Vertical
-        Whitespace
-      </h3>
-      <p>
-        Vertical whitespace is a sequence of one or more newline characters that can optionally
-        contain comments. It is used to terminate or end basic statements in Evy. A basic statement
-        is a statement that cannot be broken up into smaller statements, such as a variable
-        declaration, an assignment or a function call.
-      </p>
-      <p>
-        Evy does not allow multiple statements on a single line. For example, the following code is
-        invalid because it contains two statements, a declaration and a function call, on one line:
-      </p>
-      <p><code>x := 1 print x</code></p>
-      <p>
-        It is also not possible to break up a single basic statement over more than one line. For
-        example, the following code is invalid because the arithmetic expression
-        <code>1 + 2</code> is split over two lines:
-      </p>
-      <pre><code>x := 1 +
+        <p>
+          For more information about whitespace, see the
+          <a href="#whitespace">whitespace</a> section.
+        </p>
+        <h2><a id="precedence" href="#precedence" class="anchor">#</a>Precedence</h2>
+        <p>
+          Operators in Evy are evaluated in a specific order, called <strong>precedence</strong>.
+          The order of precedence is as follows:
+        </p>
+        <ol>
+          <li>
+            Indexing, dot notation and grouped expressions: <code>a[i]</code> <code>a.b</code>
+            <code>(</code> … <code>)</code>
+          </li>
+          <li>Unary operators: <code>-delta</code> <code>!true</code></li>
+          <li>
+            Binary operators
+            <ol>
+              <li>
+                Multiplication, division, and modulo: <code>*</code> <code>/</code> <code>%</code>
+              </li>
+              <li>Addition and subtraction: <code>+</code> <code>-</code></li>
+              <li>
+                Comparison operators: <code>&lt;</code> <code>&lt;=</code> <code>&gt;</code>
+                <code>&gt;=</code>
+              </li>
+              <li>Equality operators: <code>==</code> <code>!=</code></li>
+              <li>Logical conjunction: <code>and</code></li>
+              <li>Logical disjunction: <code>or</code></li>
+            </ol>
+          </li>
+        </ol>
+        <p>
+          Operators of the same precedence are evaluated from left to right. For example, the
+          expression <code>a[i] - 5 * 2</code> will be evaluated as follows:
+        </p>
+        <ul>
+          <li>The index <code>a[i]</code> will be evaluated first.</li>
+          <li>The multiplication <code>5 * 2</code> will be evaluated next.</li>
+          <li>The subtraction <code>- 5 * 2</code> will be evaluated last.</li>
+        </ul>
+        <p>
+          If you want to change the order of precedence, you can use parentheses to group
+          expressions. For example, the expression <code>(a[i] - 5) * 2</code> will be evaluated as
+          follows:
+        </p>
+        <ul>
+          <li>The expression <code>a[i] - 5</code> will be evaluated first.</li>
+          <li>The multiplication <code>* 2</code> will be evaluated next.</li>
+        </ul>
+        <h2><a id="statements" href="#statements" class="anchor">#</a>Statements</h2>
+        <p>
+          A <strong>statement</strong> is a unit of code that performs an action. Statements are the
+          building blocks of programs, and they can be used to control the flow of execution.
+        </p>
+        <p>Statements can be divided into two categories: block statements and basic statements.</p>
+        <ul>
+          <li>
+            <strong>Basic statements</strong> are statements that cannot be broken down into further
+            statements.
+          </li>
+          <li><strong>Block statements</strong> are statements that contain further statements.</li>
+        </ul>
+        <p>There are 5 types of block statements in Evy:</p>
+        <ul>
+          <li>Function definition</li>
+          <li>Event Handler definitions</li>
+          <li>If statements</li>
+          <li>For statements</li>
+          <li>While statements</li>
+        </ul>
+        <p>There are 5 types of basic statements in Evy:</p>
+        <ul>
+          <li>Variable declaration statement</li>
+          <li>Assignment statement</li>
+          <li>Function call statement</li>
+          <li>Return statement</li>
+          <li>Break statement</li>
+        </ul>
+        <p>
+          Not all statements are allowed in all contexts. For example, a return statement may only
+          be used within a function definition.
+        </p>
+        <h2><a id="whitespace" href="#whitespace" class="anchor">#</a>Whitespace</h2>
+        <p>
+          Whitespace in Evy is used to separate different parts of a program. There are two types of
+          whitespace in Evy: vertical whitespace and horizontal whitespace.
+        </p>
+        <h3>
+          <a id="vertical-whitespace" href="#vertical-whitespace" class="anchor">#</a>Vertical
+          Whitespace
+        </h3>
+        <p>
+          Vertical whitespace is a sequence of one or more newline characters that can optionally
+          contain comments. It is used to terminate or end basic statements in Evy. A basic
+          statement is a statement that cannot be broken up into smaller statements, such as a
+          variable declaration, an assignment or a function call.
+        </p>
+        <p>
+          Evy does not allow multiple statements on a single line. For example, the following code
+          is invalid because it contains two statements, a declaration and a function call, on one
+          line:
+        </p>
+        <p><code>x := 1 print x</code></p>
+        <p>
+          It is also not possible to break up a single basic statement over more than one line. For
+          example, the following code is invalid because the arithmetic expression
+          <code>1 + 2</code> is split over two lines:
+        </p>
+        <pre><code>x := 1 +
      2
 </code></pre>
-      <p>
-        The rule that basic statements cannot be split across multiple lines has one exception:
-        Array literals and map literals can be broken up over multiple lines, as long as each line
-        is a complete expression. For example, the following code is valid because it is a
-        declaration with a multiline map literal:
-      </p>
-      <pre><code class="language-evy">person := {
+        <p>
+          The rule that basic statements cannot be split across multiple lines has one exception:
+          Array literals and map literals can be broken up over multiple lines, as long as each line
+          is a complete expression. For example, the following code is valid because it is a
+          declaration with a multiline map literal:
+        </p>
+        <pre><code class="language-evy">person := {
     name:&quot;Jane Goddall&quot;
     born:1934
 }
 print person
 </code></pre>
-      <h2>
-        <a id="horizontal-whitespace" href="#horizontal-whitespace" class="anchor">#</a>Horizontal
-        Whitespace
-      </h2>
-      <p>
-        <strong>Horizontal whitespace</strong> is a sequence of tabs or spaces that is used to
-        separate elements in lists. Lists include the argument list to a function call, the element
-        list of an array literal, and the value in the key-value pairs of a map literal. However,
-        horizontal whitespace is not allowed <em>within</em> this list elements.
-      </p>
-      <p>
-        Horizontal whitespace is not allowed around the dot expression <code>.</code> or before the
-        opening brace <code>[</code> in an index expression or slice expression. However, it is
-        allowed <em>within</em> the grouping expression, index expression, and slice expression,
-        even if the expression is an element of a list such as an argument to a function call.
-      </p>
-      <p>
-        Assignments, inferred variable declarations, return statements and the the expression inside
-        an index expression <code>[ … ]</code> <em>can</em> have whitespace around their binary
-        operators. The whitespace around the operators is optional, but it is often used to improve
-        the readability of the code, for example:
-      </p>
-      <pre><code class="language-evy">x := 5 + 3
+        <h2>
+          <a id="horizontal-whitespace" href="#horizontal-whitespace" class="anchor">#</a>Horizontal
+          Whitespace
+        </h2>
+        <p>
+          <strong>Horizontal whitespace</strong> is a sequence of tabs or spaces that is used to
+          separate elements in lists. Lists include the argument list to a function call, the
+          element list of an array literal, and the value in the key-value pairs of a map literal.
+          However, horizontal whitespace is not allowed <em>within</em> this list elements.
+        </p>
+        <p>
+          Horizontal whitespace is not allowed around the dot expression <code>.</code> or before
+          the opening brace <code>[</code> in an index expression or slice expression. However, it
+          is allowed <em>within</em> the grouping expression, index expression, and slice
+          expression, even if the expression is an element of a list such as an argument to a
+          function call.
+        </p>
+        <p>
+          Assignments, inferred variable declarations, return statements and the the expression
+          inside an index expression <code>[ … ]</code> <em>can</em> have whitespace around their
+          binary operators. The whitespace around the operators is optional, but it is often used to
+          improve the readability of the code, for example:
+        </p>
+        <pre><code class="language-evy">x := 5 + 3
 x = 7 - 2
 
 arr := [1 2 3]
@@ -1578,41 +1593,43 @@ end
 
 print x arr (fn)
 </code></pre>
-      <p>
-        More formally, horizontal whitespace <code>WS</code> between tokens or terminals as defined
-        in the grammar is ignored and can be used freely with the addition of the following rules:
-      </p>
-      <ol>
-        <li><code>WS</code> is not allowed around dot <code>.</code> in dot expressions.</li>
-        <li>
-          <code>WS</code> is not allowed before the <code>[</code> in index or slice expressions.
-        </li>
-        <li>
-          <code>WS</code> is not allowed following the unary operators <code>-</code> and
-          <code>!</code>.
-        </li>
-        <li><code>WS</code> is not allowed within arguments to a function call</li>
-        <li><code>WS</code> is not allowed within elements of an array literal</li>
-        <li>
-          <code>WS</code> is not allowed within the values of a map literal's key-value pairs.
-        </li>
-        <li>
-          <code>WS</code> is allowed within any grouping expression <code>(</code> … <code>)</code>.
-        </li>
-        <li>
-          <code>WS</code> is allowed within an index expression <code>[</code> … <code>]</code>.
-        </li>
-        <li>
-          <code>WS</code> is allowed within a slice expression <code>[</code> … <code>:</code> …
-          <code>]</code>.
-        </li>
-      </ol>
-      <p>
-        Here are some examples of incorrect uses of horizontal whitespace, along with their correct
-        uses.
-      </p>
-      <p>Invalid:</p>
-      <pre><code>print - 5
+        <p>
+          More formally, horizontal whitespace <code>WS</code> between tokens or terminals as
+          defined in the grammar is ignored and can be used freely with the addition of the
+          following rules:
+        </p>
+        <ol>
+          <li><code>WS</code> is not allowed around dot <code>.</code> in dot expressions.</li>
+          <li>
+            <code>WS</code> is not allowed before the <code>[</code> in index or slice expressions.
+          </li>
+          <li>
+            <code>WS</code> is not allowed following the unary operators <code>-</code> and
+            <code>!</code>.
+          </li>
+          <li><code>WS</code> is not allowed within arguments to a function call</li>
+          <li><code>WS</code> is not allowed within elements of an array literal</li>
+          <li>
+            <code>WS</code> is not allowed within the values of a map literal's key-value pairs.
+          </li>
+          <li>
+            <code>WS</code> is allowed within any grouping expression <code>(</code> …
+            <code>)</code>.
+          </li>
+          <li>
+            <code>WS</code> is allowed within an index expression <code>[</code> … <code>]</code>.
+          </li>
+          <li>
+            <code>WS</code> is allowed within a slice expression <code>[</code> … <code>:</code> …
+            <code>]</code>.
+          </li>
+        </ol>
+        <p>
+          Here are some examples of incorrect uses of horizontal whitespace, along with their
+          correct uses.
+        </p>
+        <p>Invalid:</p>
+        <pre><code>print - 5
 len &quot;a&quot; + &quot;b&quot;
 
 arr := [1 + 1]
@@ -1624,8 +1641,8 @@ map.  address = &quot;221B Baker Street&quot;
 
 print len map
 </code></pre>
-      <p>Valid:</p>
-      <pre><code class="language-evy">print -5
+        <p>Valid:</p>
+        <pre><code class="language-evy">print -5
 len &quot;a&quot;+&quot;b&quot;
 
 arr := [1+1]
@@ -1637,90 +1654,93 @@ map.address = &quot;221B Baker Street&quot;
 
 print (len map)
 </code></pre>
-      <h2><a id="functions" href="#functions" class="anchor">#</a>Functions</h2>
-      <p>
-        <strong>Functions</strong> are blocks of code that are used to perform a specific task. They
-        are often used to encapsulate code that is used repeatedly, so that it can be called from
-        different parts of a program.
-      </p>
-      <p>
-        A <strong>function definition</strong> binds an identifier, the function name, to a
-        function. As part of the function definition, the
-        <strong>function signature</strong> declares the number, order and types of input parameters
-        as well as the result or return type of the function. If the return type is left out, the
-        function does not return a value.
-      </p>
-      <p>
-        For example, the following code defines a function called <code>validate</code> that takes
-        two parameters, <code>s</code> and <code>maxl</code>, and returns a boolean result. The
-        <code>s</code> parameter is of type <code>string</code> and the <code>maxl</code> parameter
-        is of type <code>num</code>. The return type of the function is <code>bool</code>.
-      </p>
-      <pre><code class="language-evy">func validate:bool s:string maxl:num
+        <h2><a id="functions" href="#functions" class="anchor">#</a>Functions</h2>
+        <p>
+          <strong>Functions</strong> are blocks of code that are used to perform a specific task.
+          They are often used to encapsulate code that is used repeatedly, so that it can be called
+          from different parts of a program.
+        </p>
+        <p>
+          A <strong>function definition</strong> binds an identifier, the function name, to a
+          function. As part of the function definition, the
+          <strong>function signature</strong> declares the number, order and types of input
+          parameters as well as the result or return type of the function. If the return type is
+          left out, the function does not return a value.
+        </p>
+        <p>
+          For example, the following code defines a function called <code>validate</code> that takes
+          two parameters, <code>s</code> and <code>maxl</code>, and returns a boolean result. The
+          <code>s</code> parameter is of type <code>string</code> and the
+          <code>maxl</code> parameter is of type <code>num</code>. The return type of the function
+          is <code>bool</code>.
+        </p>
+        <pre><code class="language-evy">func validate:bool s:string maxl:num
     return (len s) &lt;= maxl
 end
 </code></pre>
-      <h3><a id="bare-returns" href="#bare-returns" class="anchor">#</a>Bare Returns</h3>
-      <p>
-        <strong>Bare returns</strong> are return statements without values. They can be used in
-        functions without result type. For example, the following code defines a function called
-        <code>reverse</code> that takes a string array as an argument and does not return a value.
-        The return statement in the if statement simply exits the function early.
-      </p>
-      <pre><code class="language-evy">func reverse arr:[]string
+        <h3><a id="bare-returns" href="#bare-returns" class="anchor">#</a>Bare Returns</h3>
+        <p>
+          <strong>Bare returns</strong> are return statements without values. They can be used in
+          functions without result type. For example, the following code defines a function called
+          <code>reverse</code> that takes a string array as an argument and does not return a value.
+          The return statement in the if statement simply exits the function early.
+        </p>
+        <pre><code class="language-evy">func reverse arr:[]string
     if arr == []
         return
     end
     // ...
 end
 </code></pre>
-      <p>
-        Function calls used as arguments to other function calls must be parenthesized to avoid
-        ambiguity, for example:
-      </p>
-      <pre><code class="language-evy">print &quot;length of abc:&quot; (len &quot;abc&quot;)
+        <p>
+          Function calls used as arguments to other function calls must be parenthesized to avoid
+          ambiguity, for example:
+        </p>
+        <pre><code class="language-evy">print &quot;length of abc:&quot; (len &quot;abc&quot;)
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:out">length of abc: 3
+        <p>Output</p>
+        <pre><code class="language-evy:out">length of abc: 3
 </code></pre>
-      <p>
-        Function names must be unique within an Evy program. This means that no two functions can
-        have the same name. Function names also cannot be the same as a variable name.
-      </p>
-      <h3><a id="function-names" href="#function-names" class="anchor">#</a>Function Names</h3>
-      <p>
-        Function names in Evy must start with a letter or underscore, and can contain any
-        combination of letters, numbers, and underscores. They cannot be the same as keywords, such
-        as <code>if</code>, <code>func</code>, or any built-in or other defined function names.
-      </p>
-      <h3>
-        <a id="anonymous-parameters" href="#anonymous-parameters" class="anchor">#</a>Anonymous
-        Parameters
-      </h3>
-      <p>
-        The anonymous parameter <code>_</code> is a special parameter in Evy that can be used as a
-        placeholder for a named parameter. It can be used for multiple parameters in a single
-        function, but it cannot be read. For example, the following code defines an event handler
-        for the pointer down event that only uses the <code>y</code> parameter:
-      </p>
-      <pre><code class="language-evy">on down _:num y:num
+        <p>
+          Function names must be unique within an Evy program. This means that no two functions can
+          have the same name. Function names also cannot be the same as a variable name.
+        </p>
+        <h3><a id="function-names" href="#function-names" class="anchor">#</a>Function Names</h3>
+        <p>
+          Function names in Evy must start with a letter or underscore, and can contain any
+          combination of letters, numbers, and underscores. They cannot be the same as keywords,
+          such as <code>if</code>, <code>func</code>, or any built-in or other defined function
+          names.
+        </p>
+        <h3>
+          <a id="anonymous-parameters" href="#anonymous-parameters" class="anchor">#</a>Anonymous
+          Parameters
+        </h3>
+        <p>
+          The anonymous parameter <code>_</code> is a special parameter in Evy that can be used as a
+          placeholder for a named parameter. It can be used for multiple parameters in a single
+          function, but it cannot be read. For example, the following code defines an event handler
+          for the pointer down event that only uses the <code>y</code> parameter:
+        </p>
+        <pre><code class="language-evy">on down _:num y:num
     print &quot;y:&quot; (round y)
 end
 </code></pre>
-      <h3>
-        <a id="variadic-functions" href="#variadic-functions" class="anchor">#</a>Variadic Functions
-      </h3>
-      <p>
-        <strong>Variadic functions</strong> in Evy are functions that can take zero or more
-        arguments of a specific type. The type of the variadic parameter is an array with the
-        element type of the parameter. The length of the array is the number of arguments passed to
-        the function.
-      </p>
-      <p>
-        For example, the following code defines a variadic function called <code>quote</code> that
-        can take any number of arguments of any type
-      </p>
-      <pre><code class="language-evy">func quote args:any...
+        <h3>
+          <a id="variadic-functions" href="#variadic-functions" class="anchor">#</a>Variadic
+          Functions
+        </h3>
+        <p>
+          <strong>Variadic functions</strong> in Evy are functions that can take zero or more
+          arguments of a specific type. The type of the variadic parameter is an array with the
+          element type of the parameter. The length of the array is the number of arguments passed
+          to the function.
+        </p>
+        <p>
+          For example, the following code defines a variadic function called <code>quote</code> that
+          can take any number of arguments of any type
+        </p>
+        <pre><code class="language-evy">func quote args:any...
     words:[]string
     for arg := range args
         word := sprintf &quot;«%v»&quot; arg
@@ -1731,35 +1751,35 @@ end
 
 quote &quot;Life, universe and everything?&quot; 42
 </code></pre>
-      <p>Output</p>
-      <pre><code class="language-evy:output">«Life, universe and everything?» «42»
+        <p>Output</p>
+        <pre><code class="language-evy:output">«Life, universe and everything?» «42»
 </code></pre>
-      <p>
-        Unlike other languages, arrays cannot be turned into variadic arguments in Evy. The call
-        arguments must be listed individually.
-      </p>
-      <h2>
-        <a id="break-and-return" href="#break-and-return" class="anchor">#</a>Break and Return
-      </h2>
-      <p>
-        <code>break</code> and <code>return</code> are <strong>terminating statements</strong> in
-        Evy. They interrupt the regular flow of control.
-      </p>
-      <ul>
-        <li>
-          <code>break</code> is used to exit from the innermost loop body. This means that it will
-          skip the rest of the loop body and continue with the next statement after the loop.
-        </li>
-        <li>
-          <code>return</code> is used to exit from a function. It can be followed by an expression
-          whose value is returned by the function call.
-        </li>
-      </ul>
-      <p>
-        For example, the following code shows how the <code>break</code> statement can be used to
-        exit from a loop:
-      </p>
-      <pre><code class="language-evy">for x := range 2
+        <p>
+          Unlike other languages, arrays cannot be turned into variadic arguments in Evy. The call
+          arguments must be listed individually.
+        </p>
+        <h2>
+          <a id="break-and-return" href="#break-and-return" class="anchor">#</a>Break and Return
+        </h2>
+        <p>
+          <code>break</code> and <code>return</code> are <strong>terminating statements</strong> in
+          Evy. They interrupt the regular flow of control.
+        </p>
+        <ul>
+          <li>
+            <code>break</code> is used to exit from the innermost loop body. This means that it will
+            skip the rest of the loop body and continue with the next statement after the loop.
+          </li>
+          <li>
+            <code>return</code> is used to exit from a function. It can be followed by an expression
+            whose value is returned by the function call.
+          </li>
+        </ul>
+        <p>
+          For example, the following code shows how the <code>break</code> statement can be used to
+          exit from a loop:
+        </p>
+        <pre><code class="language-evy">for x := range 2
     y := 0
     while y &lt; 10
         if y == 2
@@ -1773,8 +1793,8 @@ quote &quot;Life, universe and everything?&quot; 42
     print
 end
 </code></pre>
-      <p>This code will print the following output:</p>
-      <pre><code class="language-evy:output">no break 0
+        <p>This code will print the following output:</p>
+        <pre><code class="language-evy:output">no break 0
 no break 1
 break 2
 x 0 y 2
@@ -1785,13 +1805,15 @@ break 2
 x 1 y 2
 
 </code></pre>
-      <p>
-        As you can see, the <code>break</code> statement causes the loop to exit when the value of
-        <code>y</code> is equal to 2. The next statement after the loop is then executed. Note how
-        <code>break</code> only exits the innermost loop.
-      </p>
-      <p>The following code shows how the return statement can be used to exit from a function:</p>
-      <pre><code class="language-evy">func foo:string
+        <p>
+          As you can see, the <code>break</code> statement causes the loop to exit when the value of
+          <code>y</code> is equal to 2. The next statement after the loop is then executed. Note how
+          <code>break</code> only exits the innermost loop.
+        </p>
+        <p>
+          The following code shows how the return statement can be used to exit from a function:
+        </p>
+        <pre><code class="language-evy">func foo:string
     if (rand1) &lt; 0.7
         return &quot;bar&quot;
     else
@@ -1799,23 +1821,23 @@ x 1 y 2
     end
 end
 </code></pre>
-      <p>
-        This code will return the value of <code>&quot;bar&quot;</code> 70% of the time and
-        <code>&quot;baz&quot;</code> otherwise. The names
-        <a href="https://en.wikipedia.org/wiki/Foobar">foo, bar, and baz</a> are common placeholder
-        names used in code.
-      </p>
-      <h2><a id="typeof" href="#typeof" class="anchor">#</a>Typeof</h2>
-      <p>
-        The <code>typeof</code> function returns the concrete type of a value held by a variable as
-        a string. It returns a string that is the same as the type in an Evy program, such as
-        <code>&quot;num&quot;</code>, <code>&quot;bool&quot;</code>,
-        <code>&quot;string&quot;</code>, <code>&quot;[]num&quot;</code>,
-        <code>&quot;{}[]any&quot;</code>, etc. It is particularly useful to determine the concrete
-        type of an <code>any</code> variable together with type assertions.
-      </p>
-      <p>Here is an example of how the <code>typeof</code> function works</p>
-      <pre><code class="language-evy">print (typeof &quot;abc&quot;)
+        <p>
+          This code will return the value of <code>&quot;bar&quot;</code> 70% of the time and
+          <code>&quot;baz&quot;</code> otherwise. The names
+          <a href="https://en.wikipedia.org/wiki/Foobar">foo, bar, and baz</a> are common
+          placeholder names used in code.
+        </p>
+        <h2><a id="typeof" href="#typeof" class="anchor">#</a>Typeof</h2>
+        <p>
+          The <code>typeof</code> function returns the concrete type of a value held by a variable
+          as a string. It returns a string that is the same as the type in an Evy program, such as
+          <code>&quot;num&quot;</code>, <code>&quot;bool&quot;</code>,
+          <code>&quot;string&quot;</code>, <code>&quot;[]num&quot;</code>,
+          <code>&quot;{}[]any&quot;</code>, etc. It is particularly useful to determine the concrete
+          type of an <code>any</code> variable together with type assertions.
+        </p>
+        <p>Here is an example of how the <code>typeof</code> function works</p>
+        <pre><code class="language-evy">print (typeof &quot;abc&quot;)
 print (typeof true)
 print
 
@@ -1824,38 +1846,38 @@ print (typeof arr)
 print (typeof arr[0])
 print (typeof arr[1])
 </code></pre>
-      <p>The output of this code is</p>
-      <pre><code class="language-evy:output">string
+        <p>The output of this code is</p>
+        <pre><code class="language-evy:output">string
 bool
 
 []any
 string
 num
 </code></pre>
-      <p>
-        Empty composite literals, <code>[]</code> and <code>{}</code>, can be assigned to variables
-        or parameters of any subtype, such as <code>[]string</code> or <code>{}num</code>. This is
-        because empty composite literals are untyped, meaning that they can be matched to any
-        subtype.
-      </p>
-      <pre><code class="language-evy">func fn nums:[]num
+        <p>
+          Empty composite literals, <code>[]</code> and <code>{}</code>, can be assigned to
+          variables or parameters of any subtype, such as <code>[]string</code> or
+          <code>{}num</code>. This is because empty composite literals are untyped, meaning that
+          they can be matched to any subtype.
+        </p>
+        <pre><code class="language-evy">func fn nums:[]num
     print nums
 end
 
 fn []
 </code></pre>
-      <p>
-        The <code>typeof</code> functions will return <code>&quot;[]&quot;</code> or
-        <code>&quot;{}&quot;</code> for an empty composite literal.
-      </p>
-      <p>
-        An array literal, such as <code>[1 2 3]</code>, has a type of <code>[]num</code>. However,
-        it is possible to assign an array literal of any type to a variable of type
-        <code>[]any</code>. It is important to note that this only applies to array literals. A
-        variable of type <code>[]num</code> cannot be assigned to a variable of type
-        <code>[]any</code>.
-      </p>
-      <pre><code class="language-evy">x := [1 2 3]
+        <p>
+          The <code>typeof</code> functions will return <code>&quot;[]&quot;</code> or
+          <code>&quot;{}&quot;</code> for an empty composite literal.
+        </p>
+        <p>
+          An array literal, such as <code>[1 2 3]</code>, has a type of <code>[]num</code>. However,
+          it is possible to assign an array literal of any type to a variable of type
+          <code>[]any</code>. It is important to note that this only applies to array literals. A
+          variable of type <code>[]num</code> cannot be assigned to a variable of type
+          <code>[]any</code>.
+        </p>
+        <pre><code class="language-evy">x := [1 2 3]
 print &quot;x&quot; (typeof x)
 y:[]any
 y = [1 2 3]
@@ -1863,18 +1885,18 @@ print &quot;y&quot; (typeof y)
 // y = x // parse error
 // x = y // parse error
 </code></pre>
-      <p>will output</p>
-      <pre><code class="language-evy:output">x []num
+        <p>will output</p>
+        <pre><code class="language-evy:output">x []num
 y []any
 </code></pre>
-      <h2><a id="type-assertion" href="#type-assertion" class="anchor">#</a>Type Assertion</h2>
-      <p>
-        A type assertion <code>x.(TYPE)</code> asserts that the value of the variable
-        <code>x</code> is of the given <code>TYPE</code>. <code>TYPE</code> can be any basic or
-        composite type, such as <code>num</code> or <code>[]string</code>. If the assertion does not
-        hold, a <a href="#run-time-panics-and-recoverable-errors">run-time panic</a> occurs.
-      </p>
-      <pre><code class="language-evy">x:any
+        <h2><a id="type-assertion" href="#type-assertion" class="anchor">#</a>Type Assertion</h2>
+        <p>
+          A type assertion <code>x.(TYPE)</code> asserts that the value of the variable
+          <code>x</code> is of the given <code>TYPE</code>. <code>TYPE</code> can be any basic or
+          composite type, such as <code>num</code> or <code>[]string</code>. If the assertion does
+          not hold, a <a href="#run-time-panics-and-recoverable-errors">run-time panic</a> occurs.
+        </p>
+        <pre><code class="language-evy">x:any
 x = [1 2 3 4]
 num_array := x.([]num)
 print &quot;typeof x:&quot; (typeof x)
@@ -1886,200 +1908,203 @@ str := x.(string)
 print &quot;typeof x:&quot; (typeof x)
 print &quot;typeof str:&quot; (typeof str)
 </code></pre>
-      <p>Will generate the output</p>
-      <pre><code class="language-ev:output">typeof x: any
+        <p>Will generate the output</p>
+        <pre><code class="language-ev:output">typeof x: any
 typeof num_array: []num
 
 typeof x: any
 typeof str: string
 </code></pre>
-      <p>
-        Only values of type <code>any</code> can be type asserted. That means an array of type any,
-        <code>[]any</code>, <em>cannot</em> be type asserted to be an array of type
-        <code>[]num</code> or any other concrete type. However, the elements of an array of type
-        <code>[]any</code> can be type assert, for example <code>arr[0].(num)</code>,
-      </p>
-      <pre><code class="language-evy">x:[]any
+        <p>
+          Only values of type <code>any</code> can be type asserted. That means an array of type
+          any, <code>[]any</code>, <em>cannot</em> be type asserted to be an array of type
+          <code>[]num</code> or any other concrete type. However, the elements of an array of type
+          <code>[]any</code> can be type assert, for example <code>arr[0].(num)</code>,
+        </p>
+        <pre><code class="language-evy">x:[]any
 x = [1 2 3 true]
 x = [1 2 3]
 print &quot;x:&quot; x &quot;typeof x:&quot; (typeof x)
 // print x.([]num) // parse error
 // print x[0].(string) // run-time panic
 </code></pre>
-      <p>outputs</p>
-      <pre><code class="language-evy:output">x: [1 2 3] typeof x: []any
+        <p>outputs</p>
+        <pre><code class="language-evy:output">x: [1 2 3] typeof x: []any
 </code></pre>
-      <h2><a id="assignability" href="#assignability" class="anchor">#</a>Assignability</h2>
-      <p>
-        <strong>Assignability</strong> determines whether a value of one type can be assigned to a
-        variable of another type. This means that the variable <em>accepts</em> the value.
-        Assignability rules apply to:
-      </p>
-      <ul>
-        <li>assignments</li>
-        <li>function parameters</li>
-        <li>return values</li>
-      </ul>
-      <p>
-        In the assignment <code>target = val</code>, <code>val</code> can be a variable, a constant,
-        or an expression. A <em>constant</em> is either a literal of type <code>num</code>,
-        <code>string</code>, or <code>bool</code>, or it is a composite literal that does not
-        contain any variables. For example, <code>[1 2 {}]</code> is a constant, but
-        <code>[1 2 x]</code> is not. If <code>val</code> in <code>target = val</code> is an
-        expression that only contains constants, it is treated like a constant; otherwise, it is
-        treated like a variable.
-      </p>
-      <h3>
-        <a
-          id="assignability-of-variable-values"
-          href="#assignability-of-variable-values"
-          class="anchor"
-          >#</a
-        >Assignability of variable values
-      </h3>
-      <p>
-        If <code>target</code> is of type <code>t</code> and <code>val</code> is a
-        <em>variable</em> of type <code>t2</code>, <code>target</code> accepts <code>val</code> if:
-      </p>
-      <ul>
-        <li><code>t</code> and <code>t2</code> are identical, or</li>
-        <li><code>t</code> is of type <code>any</code></li>
-      </ul>
-      <h3>
-        <a
-          id="assignability-of-constant-values"
-          href="#assignability-of-constant-values"
-          class="anchor"
-          >#</a
-        >Assignability of constant values
-      </h3>
-      <p>
-        If <code>target</code> is of type <code>t</code> and <code>val</code> is a
-        <em>constant</em> of type <code>t2</code>, <code>target</code> accepts <code>val</code> if:
-      </p>
-      <ul>
-        <li><code>t</code> and <code>t2</code> are identical, or</li>
-        <li><code>t</code> is of type <code>any</code>, or</li>
-        <li>
-          <code>t</code> is a composite with basic subtype <code>any</code> and <code>t2</code> can
-          be <strong>converted</strong> to it.
-        </li>
-      </ul>
-      <p>
-        A constant of type <code>t2</code> can be <strong>converted</strong> to type
-        <code>t</code> if both types are composite types of the same structure and the final subtype
-        of <code>t</code> is <code>any</code>. This means, for instance, that the literal array
-        <code>[1 2 3]</code> of type <code>[]num</code> can be assigned to a variable of type
-        <code>[]any</code>.
-      </p>
-      <p>The following code:</p>
-      <pre><code class="language-evy">arr:[]{}any
+        <h2><a id="assignability" href="#assignability" class="anchor">#</a>Assignability</h2>
+        <p>
+          <strong>Assignability</strong> determines whether a value of one type can be assigned to a
+          variable of another type. This means that the variable <em>accepts</em> the value.
+          Assignability rules apply to:
+        </p>
+        <ul>
+          <li>assignments</li>
+          <li>function parameters</li>
+          <li>return values</li>
+        </ul>
+        <p>
+          In the assignment <code>target = val</code>, <code>val</code> can be a variable, a
+          constant, or an expression. A <em>constant</em> is either a literal of type
+          <code>num</code>, <code>string</code>, or <code>bool</code>, or it is a composite literal
+          that does not contain any variables. For example, <code>[1 2 {}]</code> is a constant, but
+          <code>[1 2 x]</code> is not. If <code>val</code> in <code>target = val</code> is an
+          expression that only contains constants, it is treated like a constant; otherwise, it is
+          treated like a variable.
+        </p>
+        <h3>
+          <a
+            id="assignability-of-variable-values"
+            href="#assignability-of-variable-values"
+            class="anchor"
+            >#</a
+          >Assignability of variable values
+        </h3>
+        <p>
+          If <code>target</code> is of type <code>t</code> and <code>val</code> is a
+          <em>variable</em> of type <code>t2</code>, <code>target</code> accepts
+          <code>val</code> if:
+        </p>
+        <ul>
+          <li><code>t</code> and <code>t2</code> are identical, or</li>
+          <li><code>t</code> is of type <code>any</code></li>
+        </ul>
+        <h3>
+          <a
+            id="assignability-of-constant-values"
+            href="#assignability-of-constant-values"
+            class="anchor"
+            >#</a
+          >Assignability of constant values
+        </h3>
+        <p>
+          If <code>target</code> is of type <code>t</code> and <code>val</code> is a
+          <em>constant</em> of type <code>t2</code>, <code>target</code> accepts
+          <code>val</code> if:
+        </p>
+        <ul>
+          <li><code>t</code> and <code>t2</code> are identical, or</li>
+          <li><code>t</code> is of type <code>any</code>, or</li>
+          <li>
+            <code>t</code> is a composite with basic subtype <code>any</code> and
+            <code>t2</code> can be <strong>converted</strong> to it.
+          </li>
+        </ul>
+        <p>
+          A constant of type <code>t2</code> can be <strong>converted</strong> to type
+          <code>t</code> if both types are composite types of the same structure and the final
+          subtype of <code>t</code> is <code>any</code>. This means, for instance, that the literal
+          array <code>[1 2 3]</code> of type <code>[]num</code> can be assigned to a variable of
+          type <code>[]any</code>.
+        </p>
+        <p>The following code:</p>
+        <pre><code class="language-evy">arr:[]{}any
 arr = [{a:1} {b:[1 2 {}]} {}]
 print (typeof arr)
 print (typeof arr[0])
 print (typeof arr[0].a)
 </code></pre>
-      <p>will output:</p>
-      <pre><code class="language-evy:output">[]{}any
+        <p>will output:</p>
+        <pre><code class="language-evy:output">[]{}any
 {}any
 num
 </code></pre>
-      <h3>
-        <a
-          id="assignability-of-empty-composite-literals"
-          href="#assignability-of-empty-composite-literals"
-          class="anchor"
-          >#</a
-        >Assignability of empty composite literals
-      </h3>
-      <p>
-        Empty composite literals <code>[]</code>, <code>{}</code>, or nested emtpy composite
-        literals of them, such as <code>[[]]</code>, follow the same rules as
-        <a href="#variables-and-declarations">inferred declarations</a>: <code>[]</code> gets
-        converted to type <code>[]any</code>, <code>{}</code> gets converted to type
-        <code>{}any</code> and <code>[[]]</code> to type <code>[][]any</code>.
-      </p>
-      <h2>
-        <a
-          id="run-time-panics-and-recoverable-errors"
-          href="#run-time-panics-and-recoverable-errors"
-          class="anchor"
-          >#</a
-        >Run-time Panics and Recoverable Errors
-      </h2>
-      <p>
-        <strong>Run-time panics</strong> are unrecoverable errors that can occur during the
-        execution of an Evy program. They can be caused by a variety of things, such as trying to
-        index an array out of bounds, accessing a map value for a key that does not exist, or a
-        failed type assertion. When a run-time panic occurs, the Evy program will stop and error
-        details will be printed. You can trigger a panic in your own code by calling the built-in
-        function <code>panic &quot;msg&quot;</code>.
-      </p>
-      <p>
-        <strong>Recoverable errors</strong> are errors that can be handled by the Evy program. They
-        are typically caused by user input or external factors that the Evy program cannot control.
-        Functions that can cause recoverable errors set the global <code>err</code> variable to
-        <code>true</code> and the string variable <code>errmsg</code> to a description of the error.
-        The Evy program can then check the value of <code>err</code> and handle the error
-        accordingly. You can trigger a recoverable error in your own code by setting
-        <code>err</code> and <code>errmsg</code>.
-      </p>
-      <p>
-        For more information on run-time panics and recoverable errors, see the built-in
-        documentation on the <a href="builtins.html#panic">panic function</a> and the
-        <a href="builtins.html#errors">errors section</a>.
-      </p>
-      <h2>
-        <a
-          id="execution-model-and-event-handlers"
-          href="#execution-model-and-event-handlers"
-          class="anchor"
-          >#</a
-        >Execution Model and Event Handlers
-      </h2>
-      <p>
-        Evy first executes all top-level code in the order it appears in the source code. If there
-        is at least one event handler, Evy then enters an event loop. In the event loop, Evy waits
-        for external events, such as a key press or a pointer down event. When an event occurs, Evy
-        calls the corresponding event handler function if it has been implemented. The event handler
-        function can optionally receive arguments, such as the key character or the pointer
-        coordinates. Once the event handler function has finished, Evy returns to the event loop and
-        waits for the next event.
-      </p>
-      <p>
-        Event handlers are declared using the <code>on</code> keyword. Only predefined events can be
-        handled: <code>key</code>, <code>down</code>, <code>up</code>, <code>move</code>,
-        <code>animate</code>, and <code>input</code>. The parameters to the event handlers must
-        match the expected signature. The parameters can be fully omitted or fully specified. If
-        only some parameters are needed, use the anonymous <code>_</code> parameter.
-      </p>
-      <p>
-        For more information on individual event handlers, see the
-        <a href="builtins.html#event-handlers">built-in documentation</a>.
-      </p>
-      <h2><a id="runtimes" href="#runtimes" class="anchor">#</a>Runtimes</h2>
-      <p>
-        Evy has two runtimes: the <strong>terminal runtime</strong> and the
-        <strong>browser runtime</strong>.
-      </p>
-      <p>
-        The browser runtime can be tried at <a href="/play">play.evy.dev</a>. It fully supports all
-        built-in functions and event handlers as described in the
-        <a href="builtin.html">built-in documentation</a>.
-      </p>
-      <p>To use the terminal runtime, first install Evy and then run</p>
-      <pre><code>evy run FILE.evy
+        <h3>
+          <a
+            id="assignability-of-empty-composite-literals"
+            href="#assignability-of-empty-composite-literals"
+            class="anchor"
+            >#</a
+          >Assignability of empty composite literals
+        </h3>
+        <p>
+          Empty composite literals <code>[]</code>, <code>{}</code>, or nested emtpy composite
+          literals of them, such as <code>[[]]</code>, follow the same rules as
+          <a href="#variables-and-declarations">inferred declarations</a>: <code>[]</code> gets
+          converted to type <code>[]any</code>, <code>{}</code> gets converted to type
+          <code>{}any</code> and <code>[[]]</code> to type <code>[][]any</code>.
+        </p>
+        <h2>
+          <a
+            id="run-time-panics-and-recoverable-errors"
+            href="#run-time-panics-and-recoverable-errors"
+            class="anchor"
+            >#</a
+          >Run-time Panics and Recoverable Errors
+        </h2>
+        <p>
+          <strong>Run-time panics</strong> are unrecoverable errors that can occur during the
+          execution of an Evy program. They can be caused by a variety of things, such as trying to
+          index an array out of bounds, accessing a map value for a key that does not exist, or a
+          failed type assertion. When a run-time panic occurs, the Evy program will stop and error
+          details will be printed. You can trigger a panic in your own code by calling the built-in
+          function <code>panic &quot;msg&quot;</code>.
+        </p>
+        <p>
+          <strong>Recoverable errors</strong> are errors that can be handled by the Evy program.
+          They are typically caused by user input or external factors that the Evy program cannot
+          control. Functions that can cause recoverable errors set the global
+          <code>err</code> variable to <code>true</code> and the string variable
+          <code>errmsg</code> to a description of the error. The Evy program can then check the
+          value of <code>err</code> and handle the error accordingly. You can trigger a recoverable
+          error in your own code by setting <code>err</code> and <code>errmsg</code>.
+        </p>
+        <p>
+          For more information on run-time panics and recoverable errors, see the built-in
+          documentation on the <a href="builtins.html#panic">panic function</a> and the
+          <a href="builtins.html#errors">errors section</a>.
+        </p>
+        <h2>
+          <a
+            id="execution-model-and-event-handlers"
+            href="#execution-model-and-event-handlers"
+            class="anchor"
+            >#</a
+          >Execution Model and Event Handlers
+        </h2>
+        <p>
+          Evy first executes all top-level code in the order it appears in the source code. If there
+          is at least one event handler, Evy then enters an event loop. In the event loop, Evy waits
+          for external events, such as a key press or a pointer down event. When an event occurs,
+          Evy calls the corresponding event handler function if it has been implemented. The event
+          handler function can optionally receive arguments, such as the key character or the
+          pointer coordinates. Once the event handler function has finished, Evy returns to the
+          event loop and waits for the next event.
+        </p>
+        <p>
+          Event handlers are declared using the <code>on</code> keyword. Only predefined events can
+          be handled: <code>key</code>, <code>down</code>, <code>up</code>, <code>move</code>,
+          <code>animate</code>, and <code>input</code>. The parameters to the event handlers must
+          match the expected signature. The parameters can be fully omitted or fully specified. If
+          only some parameters are needed, use the anonymous <code>_</code> parameter.
+        </p>
+        <p>
+          For more information on individual event handlers, see the
+          <a href="builtins.html#event-handlers">built-in documentation</a>.
+        </p>
+        <h2><a id="runtimes" href="#runtimes" class="anchor">#</a>Runtimes</h2>
+        <p>
+          Evy has two runtimes: the <strong>terminal runtime</strong> and the
+          <strong>browser runtime</strong>.
+        </p>
+        <p>
+          The browser runtime can be tried at <a href="/play">play.evy.dev</a>. It fully supports
+          all built-in functions and event handlers as described in the
+          <a href="builtin.html">built-in documentation</a>.
+        </p>
+        <p>To use the terminal runtime, first install Evy and then run</p>
+        <pre><code>evy run FILE.evy
 </code></pre>
-      <p>
-        in the terminal. This will execute the source code in the given file. You can also use the
-        evy command to format your source code with
-      </p>
-      <pre><code>evy fmt FILE.evy
+        <p>
+          in the terminal. This will execute the source code in the given file. You can also use the
+          evy command to format your source code with
+        </p>
+        <pre><code>evy fmt FILE.evy
 </code></pre>
-      <p>
-        For more details, run <code>evy run --help</code> or <code>evy fmt --help</code>. The
-        terminal runtime does not support event handlers or graphics functions.
-      </p>
+        <p>
+          For more details, run <code>evy run --help</code> or <code>evy fmt --help</code>. The
+          terminal runtime does not support event handlers or graphics functions.
+        </p>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/spec.html
+++ b/frontend/preview/spec.html
@@ -35,10 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
           <a href="index.html"><strong>Documentation</strong></a>
           <a href="/play">Playground</a>
           <button>About</button>

--- a/frontend/preview/syntax_by_example.html
+++ b/frontend/preview/syntax_by_example.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Syntax by Example</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/syntax_by_example.html
+++ b/frontend/preview/syntax_by_example.html
@@ -522,9 +522,9 @@
       </ul>
 
       <ul class="icons">
-        <li><a href="/discord" class="icon-discord"></a></li>
-        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
-        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+        <li><a href="/discord" class="icon-discord" target="_blank"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github" target="_blank"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email" target="_blank"></a></li>
       </ul>
     </nav>
 

--- a/frontend/preview/syntax_by_example.html
+++ b/frontend/preview/syntax_by_example.html
@@ -40,7 +40,7 @@
             <input type="text" placeholder="Search..." />
           </div>
           <a href="index.html"><strong>Documentation</strong></a>
-          <a href="contributing/index.html">Contributing</a>
+          <a href="/play">Playground</a>
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/syntax_by_example.html
+++ b/frontend/preview/syntax_by_example.html
@@ -35,10 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
           <a href="index.html"><strong>Documentation</strong></a>
           <a href="/play">Playground</a>
           <button>About</button>

--- a/frontend/preview/syntax_by_example.html
+++ b/frontend/preview/syntax_by_example.html
@@ -529,40 +529,41 @@
     </nav>
 
     <main>
-      <h1>Syntax by Example</h1>
-      <p>
-        The following examples will help you understand the syntax of Evy. For a more formal
-        definition of the syntax, see the <a href="spec.html">Language Specification</a>. Built-in
-        functions, such as <code>print</code> and <code>circle</code>, are documented in the<a
-          href="builtins.html"
-          >Built-ins section</a
-        >.
-      </p>
-      <h2><a id="comment" href="#comment" class="anchor">#</a>Comment</h2>
-      <pre><code>// This is a comment
+      <div class="max-width-wrapper">
+        <h1>Syntax by Example</h1>
+        <p>
+          The following examples will help you understand the syntax of Evy. For a more formal
+          definition of the syntax, see the <a href="spec.html">Language Specification</a>. Built-in
+          functions, such as <code>print</code> and <code>circle</code>, are documented in the<a
+            href="builtins.html"
+            >Built-ins section</a
+          >.
+        </p>
+        <h2><a id="comment" href="#comment" class="anchor">#</a>Comment</h2>
+        <pre><code>// This is a comment
 </code></pre>
-      <h2><a id="declaration" href="#declaration" class="anchor">#</a>Declaration</h2>
-      <pre><code>x:num     // declaration: num, string, bool, any, []num, {}string
+        <h2><a id="declaration" href="#declaration" class="anchor">#</a>Declaration</h2>
+        <pre><code>x:num     // declaration: num, string, bool, any, []num, {}string
 y := 1    // declaration through type inference (num)
 </code></pre>
-      <h2><a id="assignment" href="#assignment" class="anchor">#</a>Assignment</h2>
-      <pre><code>z = 5
+        <h2><a id="assignment" href="#assignment" class="anchor">#</a>Assignment</h2>
+        <pre><code>z = 5
 </code></pre>
-      <h2><a id="expression" href="#expression" class="anchor">#</a>Expression</h2>
-      <pre><code>x := 5 * (y + z)  - 2 / 7.6           // arithmetic number expression
+        <h2><a id="expression" href="#expression" class="anchor">#</a>Expression</h2>
+        <pre><code>x := 5 * (y + z)  - 2 / 7.6           // arithmetic number expression
 b := !trace and debug or level == &quot;&quot;  // bool expressions
 </code></pre>
-      <h2><a id="strings" href="#strings" class="anchor">#</a>Strings</h2>
-      <pre><code>s1 := &quot;quotation mark : \&quot; &quot;          // escaping
+        <h2><a id="strings" href="#strings" class="anchor">#</a>Strings</h2>
+        <pre><code>s1 := &quot;quotation mark : \&quot; &quot;          // escaping
 s2 := &quot;abc&quot; + &quot;🥪123&quot;                 // concatenation
 s3 := &quot;newline: \n indentation: \t&quot;
 s4 := s2[0]                           // &quot;a&quot;
 s5 := s2[1:5]                         // &quot;bc🥪1&quot;
 </code></pre>
-      <h2>
-        <a id="if-statements" href="#if-statements" class="anchor">#</a><code>if</code> statements
-      </h2>
-      <pre><code>if z &gt; 0 and x != 0
+        <h2>
+          <a id="if-statements" href="#if-statements" class="anchor">#</a><code>if</code> statements
+        </h2>
+        <pre><code>if z &gt; 0 and x != 0
     print &quot;block 1&quot;
 else if y != 0 or a == &quot;abc&quot;
     print &quot;block 2&quot;
@@ -570,8 +571,8 @@ else
     print &quot;block 3&quot;
 end
 </code></pre>
-      <h3><a id="nested-if" href="#nested-if" class="anchor">#</a>Nested <code>if</code></h3>
-      <pre><code>if z &gt; 0 and x != 0
+        <h3><a id="nested-if" href="#nested-if" class="anchor">#</a>Nested <code>if</code></h3>
+        <pre><code>if z &gt; 0 and x != 0
     if startswith str &quot;a&quot;
         print &quot;nested block 1&quot;
     else
@@ -579,19 +580,19 @@ end
     end
 end
 </code></pre>
-      <h2><a id="loop-statements" href="#loop-statements" class="anchor">#</a>Loop statements</h2>
-      <h3><a id="while-loop" href="#while-loop" class="anchor">#</a><code>while</code> loop</h3>
-      <pre><code>x := 0
+        <h2><a id="loop-statements" href="#loop-statements" class="anchor">#</a>Loop statements</h2>
+        <h3><a id="while-loop" href="#while-loop" class="anchor">#</a><code>while</code> loop</h3>
+        <pre><code>x := 0
 while x &lt; 10
     print x
     x = x + 1
 end
 </code></pre>
-      <h3>
-        <a id="for-range-number" href="#for-range-number" class="anchor">#</a><code>for</code> …
-        <code>range</code> number
-      </h3>
-      <pre><code>for x := range 5
+        <h3>
+          <a id="for-range-number" href="#for-range-number" class="anchor">#</a><code>for</code> …
+          <code>range</code> number
+        </h3>
+        <pre><code>for x := range 5
     print x           // 0 1 2 3 4
 end
 
@@ -607,25 +608,25 @@ for x := range -10
     print x        // nothing. step is 1 by default.
 end
 </code></pre>
-      <h3>
-        <a id="for-range-array" href="#for-range-array" class="anchor">#</a><code>for</code> …
-        <code>range</code> array
-      </h3>
-      <pre><code>for x := range [1 2 3]
+        <h3>
+          <a id="for-range-array" href="#for-range-array" class="anchor">#</a><code>for</code> …
+          <code>range</code> array
+        </h3>
+        <pre><code>for x := range [1 2 3]
     print x        // 1 2 3
 end
 </code></pre>
-      <h3>
-        <a id="for-range-map" href="#for-range-map" class="anchor">#</a><code>for</code> …
-        <code>range</code> map
-      </h3>
-      <pre><code>m := { name:&quot;Mali&quot; sport:&quot;climbing&quot; }
+        <h3>
+          <a id="for-range-map" href="#for-range-map" class="anchor">#</a><code>for</code> …
+          <code>range</code> map
+        </h3>
+        <pre><code>m := { name:&quot;Mali&quot; sport:&quot;climbing&quot; }
 for key := range m
     print key m[key]
 end
 </code></pre>
-      <h3><a id="break" href="#break" class="anchor">#</a><code>break</code></h3>
-      <pre><code>x := 0
+        <h3><a id="break" href="#break" class="anchor">#</a><code>break</code></h3>
+        <pre><code>x := 0
 while true
     print &quot;tick... &quot;
     sleep 1
@@ -636,34 +637,34 @@ while true
     x = x + 1
 end
 </code></pre>
-      <h2>
-        <a id="function-definition" href="#function-definition" class="anchor">#</a>Function
-        definition
-      </h2>
-      <pre><code>func add:num a:num b:num
+        <h2>
+          <a id="function-definition" href="#function-definition" class="anchor">#</a>Function
+          definition
+        </h2>
+        <pre><code>func add:num a:num b:num
     return a + b
 end
 </code></pre>
-      <h3><a id="no-return-type" href="#no-return-type" class="anchor">#</a>No return type</h3>
-      <pre><code>func foxprint s:string
+        <h3><a id="no-return-type" href="#no-return-type" class="anchor">#</a>No return type</h3>
+        <pre><code>func foxprint s:string
     print &quot;🦊 &quot; + s
 end
 </code></pre>
-      <h3><a id="variadic" href="#variadic" class="anchor">#</a>Variadic</h3>
-      <pre><code>func list args:any...
+        <h3><a id="variadic" href="#variadic" class="anchor">#</a>Variadic</h3>
+        <pre><code>func list args:any...
     for arg := range args[:-1]
         printf &quot;%v, &quot; arg
     end
     printf &quot;%v&quot; args[-1]
 end
 </code></pre>
-      <h3><a id="function-calls" href="#function-calls" class="anchor">#</a>Function calls</h3>
-      <pre><code>n := add 1 2        // 3
+        <h3><a id="function-calls" href="#function-calls" class="anchor">#</a>Function calls</h3>
+        <pre><code>n := add 1 2        // 3
 foxprint &quot;🐾&quot;       // 🦊 🐾
 list 2 true &quot;blue&quot;  // 2, true, blue
 </code></pre>
-      <h2><a id="array" href="#array" class="anchor">#</a>Array</h2>
-      <pre><code>a1:[]num
+        <h2><a id="array" href="#array" class="anchor">#</a>Array</h2>
+        <pre><code>a1:[]num
 a2:[][]string
 a1 = [1 2 3 4]              // type: num[]
 a2 = [[&quot;1&quot; &quot;2&quot;] [&quot;a&quot; &quot;b&quot;]]  // type: string[][]
@@ -673,29 +674,29 @@ a4 := [&quot;s1&quot;                 // line break allowed
 a5 := [&quot;chars&quot; 123]         // type: any[]
 a6:[]any                    // type: any[]
 </code></pre>
-      <h3>
-        <a id="array-element-access" href="#array-element-access" class="anchor">#</a>Array element
-        access
-      </h3>
-      <pre><code>a1 := [1 2 3 4]
+        <h3>
+          <a id="array-element-access" href="#array-element-access" class="anchor">#</a>Array
+          element access
+        </h3>
+        <pre><code>a1 := [1 2 3 4]
 a2 := [[&quot;1&quot; &quot;2&quot;] [&quot;a&quot; &quot;b&quot;]]
 print a1[1]                  // 2
 print a2[1][0]               // &quot;a&quot;
 print a1[-1]                  // 4
 </code></pre>
-      <h3><a id="concatenation" href="#concatenation" class="anchor">#</a>Concatenation</h3>
-      <pre><code>a := [1 2 3 4]
+        <h3><a id="concatenation" href="#concatenation" class="anchor">#</a>Concatenation</h3>
+        <pre><code>a := [1 2 3 4]
 a = a + [ 100 ]          // [1 2 3 4 100]; optional extra whitespace
 a = [0] + a + [101 102]  // [0 1 2 3 4 100 101 102]
 </code></pre>
-      <h3><a id="slicing" href="#slicing" class="anchor">#</a>Slicing</h3>
-      <pre><code>a := [1 2 3]
+        <h3><a id="slicing" href="#slicing" class="anchor">#</a>Slicing</h3>
+        <pre><code>a := [1 2 3]
 b := a[:2]         // [1 2]
 b = a[1:2]         // [2]
 b = a[-2:]         // [2 3]
 </code></pre>
-      <h2><a id="map" href="#map" class="anchor">#</a>Map</h2>
-      <pre><code>m1:{}any // keys used in literals or with `.` must be identifiers.
+        <h2><a id="map" href="#map" class="anchor">#</a>Map</h2>
+        <pre><code>m1:{}any // keys used in literals or with `.` must be identifiers.
 m1.name = &quot;fox&quot;
 m1.age = 42
 m1[&quot;key with space&quot;] = &quot;🔑🪐&quot;
@@ -711,29 +712,29 @@ m5.digits = [1 2 3]
 m6:{}num
 //m6.x = &quot;y&quot;                      // invalid, only num values allowed
 </code></pre>
-      <h3>
-        <a id="map-value-access" href="#map-value-access" class="anchor">#</a>Map value access
-      </h3>
-      <pre><code>m := {letters:&quot;abc&quot; name:&quot;Jill&quot;}
+        <h3>
+          <a id="map-value-access" href="#map-value-access" class="anchor">#</a>Map value access
+        </h3>
+        <pre><code>m := {letters:&quot;abc&quot; name:&quot;Jill&quot;}
 s := &quot;letters&quot;
 print m.letters    // abc
 print m[s]         // abc
 print m[&quot;letters&quot;] // abc
 </code></pre>
-      <h2><a id="any" href="#any" class="anchor">#</a><code>any</code></h2>
-      <pre><code>x:any     // any type, default value: false
+        <h2><a id="any" href="#any" class="anchor">#</a><code>any</code></h2>
+        <pre><code>x:any     // any type, default value: false
 m1:{}any  // map with any value type
 m2 := { letter:&quot;a&quot; number:1 }
 arr1:[]any
 arr2 := [ &quot;b&quot; 2 ]
 </code></pre>
-      <h2><a id="type-assertion" href="#type-assertion" class="anchor">#</a>Type assertion</h2>
-      <pre><code>x:any
+        <h2><a id="type-assertion" href="#type-assertion" class="anchor">#</a>Type assertion</h2>
+        <pre><code>x:any
 x = [ 1 2 3 4 ]  // concrete type num[]
 s := x.([]num)
 </code></pre>
-      <h2><a id="type-reflection" href="#type-reflection" class="anchor">#</a>Type reflection</h2>
-      <pre><code>typeof &quot;abc&quot;          // &quot;string&quot;
+        <h2><a id="type-reflection" href="#type-reflection" class="anchor">#</a>Type reflection</h2>
+        <pre><code>typeof &quot;abc&quot;          // &quot;string&quot;
 typeof true           // &quot;bool&quot;
 typeof [ 1 2 ]        // &quot;[]num&quot;
 typeof [[1 2] [3 4]]  // &quot;[][]num&quot;
@@ -746,24 +747,28 @@ if (typeof v) == &quot;string&quot;
     print s+s       // 🐐🐐
 end
 </code></pre>
-      <h2><a id="event-handling" href="#event-handling" class="anchor">#</a>Event handling</h2>
-      <pre><code>on key
+        <h2><a id="event-handling" href="#event-handling" class="anchor">#</a>Event handling</h2>
+        <pre><code>on key
     print &quot;key pressed&quot;
 end
 </code></pre>
-      <p>
-        Evy can only handle a limited set of events, such as key presses, pointer movements, or
-        periodic screen redraws.
-      </p>
-      <h3>
-        <a id="event-handlers-with-parameters" href="#event-handlers-with-parameters" class="anchor"
-          >#</a
-        >Event handlers with parameters
-      </h3>
-      <pre><code>on key k:string
+        <p>
+          Evy can only handle a limited set of events, such as key presses, pointer movements, or
+          periodic screen redraws.
+        </p>
+        <h3>
+          <a
+            id="event-handlers-with-parameters"
+            href="#event-handlers-with-parameters"
+            class="anchor"
+            >#</a
+          >Event handlers with parameters
+        </h3>
+        <pre><code>on key k:string
     printf &quot;%q pressed\n&quot; k
 end
 </code></pre>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/talks/index.html
+++ b/frontend/preview/talks/index.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Talks</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/talks/index.html
+++ b/frontend/preview/talks/index.html
@@ -59,14 +59,16 @@
     </header>
 
     <main>
-      <h1>Talks</h1>
-      <ul>
-        <li>
-          <a href="https://www.youtube.com/watch?v=QFpneG6SVxw"
-            >Building a Beginner's Programming Language with Go</a
-          >, GopherConAU 2023
-        </li>
-      </ul>
+      <div class="max-width-wrapper">
+        <h1>Talks</h1>
+        <ul>
+          <li>
+            <a href="https://www.youtube.com/watch?v=QFpneG6SVxw"
+              >Building a Beginner's Programming Language with Go</a
+            >, GopherConAU 2023
+          </li>
+        </ul>
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/talks/index.html
+++ b/frontend/preview/talks/index.html
@@ -35,11 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
-
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/usage.html
+++ b/frontend/preview/usage.html
@@ -522,9 +522,9 @@
       </ul>
 
       <ul class="icons">
-        <li><a href="/discord" class="icon-discord"></a></li>
-        <li><a href="https://github.com/evylang/evy" class="icon-github"></a></li>
-        <li><a href="mailto:evy@evy.dev" class="icon-email"></a></li>
+        <li><a href="/discord" class="icon-discord" target="_blank"></a></li>
+        <li><a href="https://github.com/evylang/evy" class="icon-github" target="_blank"></a></li>
+        <li><a href="mailto:evy@evy.dev" class="icon-email" target="_blank"></a></li>
       </ul>
     </nav>
 

--- a/frontend/preview/usage.html
+++ b/frontend/preview/usage.html
@@ -31,7 +31,7 @@
         </a>
       </div>
       <div class="mobile center">
-        <span class="mobile">Overview</span>
+        <span class="mobile">Command Line Usage</span>
       </div>
       <div class="right">
         <nav class="docs-nav">

--- a/frontend/preview/usage.html
+++ b/frontend/preview/usage.html
@@ -529,27 +529,28 @@
     </nav>
 
     <main>
-      <h1>Command Line Usage</h1>
-      <p>
-        The <code>evy</code> toolchain is a set of tools that can be used to parse, run, and format
-        Evy source code. It can also be used to serve the Evy web contents locally. You can
-        <a href="../index.html#-installation">install</a> the Evy toolchain locally and run it from
-        your command line. The command-line interface for Evy supports all built-in functions except
-        for graphics functions and event handlers. Only the web interface on
-        <a href="/play">play.evy.dev</a> supports graphics and events.
-      </p>
-      <p>The Evy toolchain has three subcommands:</p>
-      <ul>
-        <li><code>evy run</code>: Parse and run Evy source code.</li>
-        <li><code>evy fmt</code>: Format Evy source code.</li>
-        <li><code>evy serve</code>: Serve Evy website(s) locally.</li>
-      </ul>
-      <p>
-        You can also get help for each subcommand by running it with the <code>--help</code> flag.
-      </p>
-      <h3><a id="evy-help" href="#evy-help" class="anchor">#</a>evy --help</h3>
-      <!-- gen:evy --help -->
-      <pre><code>Usage: evy &lt;command&gt;
+      <div class="max-width-wrapper">
+        <h1>Command Line Usage</h1>
+        <p>
+          The <code>evy</code> toolchain is a set of tools that can be used to parse, run, and
+          format Evy source code. It can also be used to serve the Evy web contents locally. You can
+          <a href="../index.html#-installation">install</a> the Evy toolchain locally and run it
+          from your command line. The command-line interface for Evy supports all built-in functions
+          except for graphics functions and event handlers. Only the web interface on
+          <a href="/play">play.evy.dev</a> supports graphics and events.
+        </p>
+        <p>The Evy toolchain has three subcommands:</p>
+        <ul>
+          <li><code>evy run</code>: Parse and run Evy source code.</li>
+          <li><code>evy fmt</code>: Format Evy source code.</li>
+          <li><code>evy serve</code>: Serve Evy website(s) locally.</li>
+        </ul>
+        <p>
+          You can also get help for each subcommand by running it with the <code>--help</code> flag.
+        </p>
+        <h3><a id="evy-help" href="#evy-help" class="anchor">#</a>evy --help</h3>
+        <!-- gen:evy --help -->
+        <pre><code>Usage: evy &lt;command&gt;
 
 evy is a tool for managing evy source code.
 
@@ -572,10 +573,10 @@ Commands:
 
 Run &quot;evy &lt;command&gt; --help&quot; for more information on a command.
 </code></pre>
-      <!-- genend -->
-      <h3><a id="evy-run-help" href="#evy-run-help" class="anchor">#</a>evy run --help</h3>
-      <!-- gen:evy run --help -->
-      <pre><code>Usage: evy run [&lt;source&gt;]
+        <!-- genend -->
+        <h3><a id="evy-run-help" href="#evy-run-help" class="anchor">#</a>evy run --help</h3>
+        <!-- gen:evy run --help -->
+        <pre><code>Usage: evy run [&lt;source&gt;]
 
 Run Evy program.
 
@@ -588,10 +589,10 @@ Flags:
 
       --skip-sleep    skip evy sleep command ($EVY_SKIP_SLEEP)
 </code></pre>
-      <!-- genend -->
-      <h3><a id="evy-fmt-help" href="#evy-fmt-help" class="anchor">#</a>evy fmt --help</h3>
-      <!-- gen:evy fmt --help -->
-      <pre><code>Usage: evy fmt [&lt;files&gt; ...]
+        <!-- genend -->
+        <h3><a id="evy-fmt-help" href="#evy-fmt-help" class="anchor">#</a>evy fmt --help</h3>
+        <!-- gen:evy fmt --help -->
+        <pre><code>Usage: evy fmt [&lt;files&gt; ...]
 
 Format Evy files.
 
@@ -605,13 +606,13 @@ Flags:
   -w, --write      update .evy file
   -c, --check      check if already formatted
 </code></pre>
-      <!-- genend -->
-      <h3>
-        <a id="evy-serve-start-help" href="#evy-serve-start-help" class="anchor">#</a>evy serve
-        [start] --help
-      </h3>
-      <!-- gen:evy serve start --help -->
-      <pre><code>Usage: evy serve start
+        <!-- genend -->
+        <h3>
+          <a id="evy-serve-start-help" href="#evy-serve-start-help" class="anchor">#</a>evy serve
+          [start] --help
+        </h3>
+        <!-- gen:evy serve start --help -->
+        <pre><code>Usage: evy serve start
 
 Start web server, default for &quot;evy serve&quot;.
 
@@ -626,13 +627,13 @@ Flags:
       --root=DIR          Directory to use as root for serving, subdirectory of
                           DIR if given, eg &quot;play&quot;, &quot;docs&quot;
 </code></pre>
-      <!-- genend -->
-      <h3>
-        <a id="evy-serve-export-help" href="#evy-serve-export-help" class="anchor">#</a>evy serve
-        export --help
-      </h3>
-      <!-- gen:evy serve export --help -->
-      <pre><code>Usage: evy serve export &lt;dir&gt;
+        <!-- genend -->
+        <h3>
+          <a id="evy-serve-export-help" href="#evy-serve-export-help" class="anchor">#</a>evy serve
+          export --help
+        </h3>
+        <!-- gen:evy serve export --help -->
+        <pre><code>Usage: evy serve export &lt;dir&gt;
 
 Export embedded content.
 
@@ -645,7 +646,8 @@ Flags:
 
   -f, --force      Use non-empty directory
 </code></pre>
-      <!-- genend -->
+        <!-- genend -->
+      </div>
     </main>
   </body>
 </html>

--- a/frontend/preview/usage.html
+++ b/frontend/preview/usage.html
@@ -40,7 +40,7 @@
             <input type="text" placeholder="Search..." />
           </div>
           <a href="index.html"><strong>Documentation</strong></a>
-          <a href="contributing/index.html">Contributing</a>
+          <a href="/play">Playground</a>
           <button>About</button>
           <label class="theme switch">
             <input type="checkbox" id="dark-theme" />

--- a/frontend/preview/usage.html
+++ b/frontend/preview/usage.html
@@ -35,10 +35,6 @@
       </div>
       <div class="right">
         <nav class="docs-nav">
-          <div class="search">
-            <div class="icon-search"></div>
-            <input type="text" placeholder="Search..." />
-          </div>
           <a href="index.html"><strong>Documentation</strong></a>
           <a href="/play">Playground</a>
           <button>About</button>


### PR DESCRIPTION
Fix various styling issues issues on the docs site:

- center main content
- inline and block `code` styles in light theme
- Spacing between <p> and <pre?
- Footer icons in new tab (also in playground)

Update header contents:

- Link to `/play` rather than `Contributing` <header> section.
- Fix page title in <header> on mobile