### PR TITLE
build-tools: Rewrite the hrefs starting with / to apex

### DIFF
--- a/build-tools/site-gen/main.go
+++ b/build-tools/site-gen/main.go
@@ -234,6 +234,7 @@ func copyFile(src, dest string) error {
 
 var (
 	subdomainRE = regexp.MustCompile(`(href|value)="/(discord|docs|learn|play)`)
+	apexRE      = regexp.MustCompile(`(href|value)="/`) // Needs to come *after* subdomainRE replacements.
 	jscssRefRE  = regexp.MustCompile(`(href|src)="(.*\.(?:css|js))"`)
 	importmapRE = regexp.MustCompile(`"(.*\.js)": "(.*\.js)"`)
 	wasmmapRE   = regexp.MustCompile(`"(.*\.wasm)": "(.*\.wasm)"`)
@@ -260,6 +261,7 @@ func (a *app) updateHTMLFile(w io.Writer, r io.Reader, filename string) error {
 		// Rewrite top-level path to subdomain reference
 		if a.Domain != "" {
 			line = subdomainRE.ReplaceAllString(line, `$1="https://$2.`+a.Domain)
+			line = apexRE.ReplaceAllString(line, `$1="https://`+a.Domain+"/")
 		}
 
 		if a.CacheBust {


### PR DESCRIPTION
Rewrite the hrefs starting with / to apex. This only applies to "domain"
deployments to "evy.dev" or "evystage.dev" and not per PR preview
deployments. We are already re-writing the hrefs to /docs, /discord etc. to
https://docs.[DOMAIN], https://discord.[DOMAIN].

Now we are re-writing the hrefs starting with / to apex domains
(e.g. https://evy.dev/).