### PR TITLE
e2e: Attempt to fix flaky tests

### DIFF
--- a/e2e/docs/test.js
+++ b/e2e/docs/test.js
@@ -17,14 +17,12 @@ for (const baseURL of baseURLs) {
 
     test("docs about", async ({ page, baseURL }, testInfo) => {
       await page.goto(baseURL)
-      await page.waitForLoadState("networkidle")
       await expect(page).toHaveScreenshot("start.png")
       if (page.viewportSize().width <= 767) {
         return // no theme toggle on mobile
       }
 
       await page.getByRole("button", { name: "About" }).click()
-      await page.waitForLoadState("networkidle")
       await expect(page).toHaveScreenshot("dialog.png")
 
       await page.getByRole("button", { name: "Done" }).click()
@@ -34,7 +32,6 @@ for (const baseURL of baseURLs) {
       await expect(page).toHaveScreenshot("start-theme.png")
 
       await page.getByRole("button", { name: "About" }).click()
-      await page.waitForLoadState("networkidle")
       await expect(page).toHaveScreenshot("dialog-theme.png")
     })
 

--- a/e2e/play/test.js
+++ b/e2e/play/test.js
@@ -19,7 +19,7 @@ for (const baseURL of baseURLs) {
       await page.goto(baseURL)
       await page.waitForLoadState("networkidle")
       await page.getByRole("button", { name: "Run" }).click()
-      await new Promise((resolve) => setTimeout(resolve, 200)) // wait for animation to finish.
+      await new Promise((resolve) => setTimeout(resolve, 300)) // wait for animation to finish.
       await expect(page.locator("#console")).toContainText("x: 12 🍦 big x")
       await expect(page).toHaveScreenshot("console-output.png")
     })


### PR DESCRIPTION
Attempt to fix flaky tests, which is really hard as they are not reproducible
on either local run or PR deployments. The await for `networkidle` timed out
a couple of times on the docs tests, so I've attempted to just remove it. It
was added in the first place because the dialog loads an image
asynchronously, but maybe there is no need for an extra wait here.

We've also had a failure in the playground tests where that I saw in the same
way before I added the delay for the animation which should only take 200ms,
but maybe 300ms as enough extra little wiggle room.

---

just deployed manually against evytest.dev and it ran e2e against it which worked as expected, but who knows....