### PR TITLE
deploy: Fix per PR deploys

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: ./bin/make deploy-prod
+      - run: ./bin/make deploy ENV=prod CHANNEL=live
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
       - run: ./bin/make e2e USE_DOCKER=1

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: ./bin/make deploy-stage
+      - run: ./bin/make deploy ENV=stage CHANNEL= # empty channel becomes PR-NUM or "live"
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -255,28 +255,16 @@ $(NODELIB):
 .PHONY: check-prettier e2e prettier serve
 
 # --- deploy -----------------------------------------------------------------
+CHANNEL = live
+ENV = test
 
-## Deploy to live channel on firebase prod, use with care!
-## `firebase login` for first time local usage
-deploy-prod: build-tiny
-	./build-tools/firebase-deploy prod live
-
-## Deploy to live channel on firebase stage.
-## `firebase login` for first time local usage
-deploy-stage: build-tiny
-	./build-tools/firebase-deploy stage live
-
-## Deploy to live channel on firebase test.
-## `firebase login` for first time local usage
-deploy-test: build-tiny
-	./build-tools/firebase-deploy test live
-
-## Deploy to dev (or other) channel on firebase test.
-## `firebase login` for first time local usage
+## Deploy to firebase ENV on CHANNEL. ENV: test (default), stage, prod. CHANNEL live (default), ...
 deploy: build-tiny
-	./build-tools/firebase-deploy test
+	# Empty channel becomes to "dev" locally.
+	# Empty channel becomes PR-NUM or "live" on CI.
+	./build-tools/firebase-deploy $(ENV) $(CHANNEL)
 
-.PHONY: deploy deploy-prod deploy-stage deploy-test
+.PHONY: deploy
 
 # --- scripts ------------------------------------------------------------------
 SCRIPTS = build-tools/firebase-deploy .github/scripts/app_token


### PR DESCRIPTION
Fix and simplify deployment which got broken when we introduced evytest.dev.
We now just have a single Makefile target `deploy` that takes the make
variables `CHANNEL` and `ENV`.


