### PR TITLE
bytecode: Implement index operator

### DIFF
--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -3,10 +3,21 @@
 package assert
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 )
+
+// Error immediately fails a test function if err does not contain
+// the target error in its tree.
+func Error(t *testing.T, want, got error) {
+	t.Helper()
+	if errors.Is(got, want) {
+		return
+	}
+	t.Fatalf("want != got\n%v\n%v", want, got)
+}
 
 // NoError immediately fails a test function if err is not nil. It
 // prints an optional formatted message with arguments.

--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -80,6 +80,12 @@ const (
 	// of the flattened map in the stack, where keys and values have been
 	// pushed sequentially (k1, v1, k2, v2...).
 	OpMap
+	// OpIndex represents an index operator used on an array, map or
+	// string variable.
+	OpIndex
+	// OpSetIndex represents an index operator on the left hand side of
+	// an assignment.
+	OpSetIndex
 )
 
 var (
@@ -130,7 +136,9 @@ var definitions = map[Opcode]*OpDefinition{
 	OpArrayConcatenate: {"OpArrayConcatenate", nil},
 	// This operand width only allows maps of up to 32767 pairs, as the map doubles in length
 	// to 65535 when it is flattened onto the stack.
-	OpMap: {"OpMap", []int{2}},
+	OpMap:      {"OpMap", []int{2}},
+	OpIndex:    {"OpIndex", nil},
+	OpSetIndex: {"OpSetIndex", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -163,6 +163,27 @@ func (vm *VM) Run() error {
 			if err := vm.push(m); err != nil {
 				return err
 			}
+		case OpIndex:
+			index := vm.pop()
+			left := vm.pop()
+			indexed := left.(indexable)
+			val, err := indexed.Index(index)
+			if err != nil {
+				return err
+			}
+			if err := vm.push(val); err != nil {
+				return err
+			}
+		case OpSetIndex:
+			index := vm.pop()
+			left := vm.pop()
+			val := vm.pop()
+			switch left := left.(type) {
+			case mapVal:
+				left[string(index.(stringVal))] = val
+			case arrayVal:
+				err = left.Set(index, val)
+			}
 		}
 		if err != nil {
 			return err

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -1,7 +1,6 @@
 package bytecode
 
 import (
-	"errors"
 	"math"
 	"testing"
 
@@ -740,7 +739,7 @@ func TestErrBounds(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
 			vm := NewVM(bytecode)
 			err := vm.Run()
-			assert.Equal(t, true, errors.Is(err, ErrBounds))
+			assert.Error(t, ErrBounds, err)
 		})
 	}
 }
@@ -812,7 +811,7 @@ func TestErrMapKey(t *testing.T) {
 	bytecode := compileBytecode(t, input)
 	vm := NewVM(bytecode)
 	err := vm.Run()
-	assert.Equal(t, true, errors.Is(err, ErrMapKey))
+	assert.Error(t, ErrMapKey, err)
 }
 
 func compileBytecode(t *testing.T, input string) *Bytecode {


### PR DESCRIPTION
Adds indexing of maps, arrays and strings. Negative indexing
is supported for arrays and strings. Adds OpSetIndex to
represent an index expression used on the left hand side
of an assignment.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>