### PR TITLE
playsite: Add theme.js for preferred theme

### DIFF
--- a/frontend/play/index.html
+++ b/frontend/play/index.html
@@ -21,7 +21,8 @@
         "imports": {
           "./module/confetti.js": "./module/confetti.js",
           "./module/editor.js": "./module/editor.js",
-          "./module/highlight.js": "./module/highlight.js"
+          "./module/highlight.js": "./module/highlight.js",
+          "./module/theme.js": "./module/theme.js"
         }
       }
     </script>

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -1,6 +1,7 @@
 "use strict"
 import Editor from "./module/editor.js"
 import highlightEvy from "./module/highlight.js"
+import initThemeToggle from "./module/theme.js"
 import showConfetti from "./module/confetti.js"
 
 // --- Globals ---------------------------------------------------------
@@ -22,6 +23,7 @@ let errors = false
 await initWasm()
 initUI()
 initCanvas()
+initThemeToggle("#dark-theme", "theme")
 
 // --- Wasm ------------------------------------------------------------
 

--- a/frontend/play/module/theme.js
+++ b/frontend/play/module/theme.js
@@ -1,0 +1,1 @@
+../../module/theme.js


### PR DESCRIPTION
Add theme.js for preferred theme to play.evy.dev so that user doesn't have to
reset preferred theme on each visit. This has already been done on
docs.evy.dev, it was just not moved across to the playsite when themes were
added.