### PR TITLE
bytecode: Implement slice expressions 

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -86,6 +86,15 @@ const (
 	// OpSetIndex represents an index operator on the left hand side of
 	// an assignment.
 	OpSetIndex
+	// OpSlice represents a slice operator used on an array or string. The top
+	// three elements are read from the stack and are the end index, start index
+	// and the data structure being operated on. OpNone is used as a default
+	// when the start or end are not specified by the user program.
+	OpSlice
+	// OpNone represents an unspecified value used where values are
+	// optional and unspecified such as the start and end value of a
+	// slice index, or the values in a step range.
+	OpNone
 )
 
 var (
@@ -139,6 +148,8 @@ var definitions = map[Opcode]*OpDefinition{
 	OpMap:      {"OpMap", []int{2}},
 	OpIndex:    {"OpIndex", nil},
 	OpSetIndex: {"OpSetIndex", nil},
+	OpSlice:    {"OpSlice", nil},
+	OpNone:     {"OpNone", nil},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -51,6 +51,8 @@ func (c *Compiler) Compile(node parser.Node) error {
 		return c.compileAssignment(node)
 	case *parser.BinaryExpression:
 		return c.compileBinaryExpression(node)
+	case *parser.SliceExpression:
+		return c.compileSliceExpression(node)
 	case *parser.UnaryExpression:
 		return c.compileUnaryExpression(node)
 	case *parser.GroupExpression:
@@ -201,6 +203,29 @@ func (c *Compiler) compileStringBinaryExpression(expr *parser.BinaryExpression) 
 	default:
 		return fmt.Errorf("%w %s", ErrUnknownOperator, expr.Op)
 	}
+}
+
+func (c *Compiler) compileSliceExpression(expr *parser.SliceExpression) error {
+	var err error
+	if err = c.Compile(expr.Left); err != nil {
+		return err
+	}
+	if err = c.compileOrEmitNone(expr.Start); err != nil {
+		return err
+	}
+	if err = c.compileOrEmitNone(expr.End); err != nil {
+		return err
+	}
+	return c.emit(OpSlice)
+}
+
+// compilerOrEmitNone will emit OpNone if the provided parser node is
+// nil. If the node is not nil then it will be compiled as normal.
+func (c *Compiler) compileOrEmitNone(node parser.Node) error {
+	if node != nil {
+		return c.Compile(node)
+	}
+	return c.emit(OpNone)
 }
 
 func (c *Compiler) compileUnaryExpression(expr *parser.UnaryExpression) error {

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -160,9 +160,7 @@ func (vm *VM) Run() error {
 				key := vm.popStringVal()
 				m[string(key)] = val
 			}
-			if err := vm.push(m); err != nil {
-				return err
-			}
+			err = vm.push(m)
 		case OpIndex:
 			index := vm.pop()
 			left := vm.pop()
@@ -184,6 +182,19 @@ func (vm *VM) Run() error {
 			case arrayVal:
 				err = left.Set(index, val)
 			}
+		case OpSlice:
+			end := vm.pop()
+			start := vm.pop()
+			left := vm.pop()
+			sliced := left.(sliceable)
+			var val value
+			val, err = sliced.Slice(start, end)
+			if err != nil {
+				return err
+			}
+			err = vm.push(val)
+		case OpNone:
+			err = vm.push(noneVal{})
 		}
 		if err != nil {
 			return err

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -574,6 +574,83 @@ func TestStringExpressions(t *testing.T) {
 				),
 			},
 		},
+		{
+			name:         "slice",
+			input:        `x := "abc"[1:3]`,
+			wantStackTop: makeValue(t, "bc"),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, "abc", 1, 3),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "negative slice",
+			input:        `x := "abc"[-3:-1]`,
+			wantStackTop: makeValue(t, "ab"),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, "abc", 3, 1),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpMinus),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpMinus),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "slice default start",
+			input:        `x := "abc"[:1]`,
+			wantStackTop: makeValue(t, "a"),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, "abc", 1),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpNone),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "slice default end",
+			input:        `x := "abc"[1:]`,
+			wantStackTop: makeValue(t, "bc"),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, "abc", 1),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpNone),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "slice start equals length",
+			input:        `x := "abc"[3:]`,
+			wantStackTop: makeValue(t, ""),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, "abc", 3),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpNone),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -697,6 +774,131 @@ func TestArrays(t *testing.T) {
 				),
 			},
 		},
+		{
+			name:         "slice",
+			input:        `x := [1 2 3][1:3]`,
+			wantStackTop: makeValue(t, []any{2, 3}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 1, 3),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpArray, 3),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpConstant, 4),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "negative slice",
+			input:        `x := [1 2 3][-3:-1]`,
+			wantStackTop: makeValue(t, []any{1, 2}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 3, 1),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpArray, 3),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpMinus),
+					mustMake(t, OpConstant, 4),
+					mustMake(t, OpMinus),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "slice default start",
+			input:        `x := [1 2 3][:1]`,
+			wantStackTop: makeValue(t, []any{1}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 1),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpArray, 3),
+					mustMake(t, OpNone),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "slice default end",
+			input:        `x := [1 2 3][1:]`,
+			wantStackTop: makeValue(t, []any{2, 3}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 1),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpArray, 3),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpNone),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name:         "slice start equals length",
+			input:        `x := [1 2 3][3:]`,
+			wantStackTop: makeValue(t, []any{}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 3),
+				Instructions: makeInstructions(
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpArray, 3),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpNone),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
+		{
+			name: "slice preserve original",
+			input: `x := [1 2 3]
+			y := x[1:]
+			y[0] = 8
+			x = x`,
+			wantStackTop: makeValue(t, []any{1, 2, 3}),
+			wantBytecode: &Bytecode{
+				Constants: makeValues(t, 1, 2, 3, 1, 8, 0),
+				Instructions: makeInstructions(
+					// x := [1 2 3]
+					mustMake(t, OpConstant, 0),
+					mustMake(t, OpConstant, 1),
+					mustMake(t, OpConstant, 2),
+					mustMake(t, OpArray, 3),
+					mustMake(t, OpSetGlobal, 0),
+					// y := x[1:]
+					mustMake(t, OpGetGlobal, 0),
+					mustMake(t, OpConstant, 3),
+					mustMake(t, OpNone),
+					mustMake(t, OpSlice),
+					mustMake(t, OpSetGlobal, 1),
+					// y[0] = 8
+					mustMake(t, OpConstant, 4),
+					mustMake(t, OpGetGlobal, 1),
+					mustMake(t, OpConstant, 5),
+					mustMake(t, OpSetIndex),
+					// x = x
+					mustMake(t, OpGetGlobal, 0),
+					mustMake(t, OpSetGlobal, 0),
+				),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -740,6 +942,31 @@ func TestErrBounds(t *testing.T) {
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.Error(t, ErrBounds, err)
+		})
+	}
+}
+
+func TestErrSlice(t *testing.T) {
+	type boundsTest struct {
+		name  string
+		input string
+	}
+	tests := []boundsTest{
+		{
+			name:  "string invalid slice",
+			input: `x := "abc"[2:1]`,
+		},
+		{
+			name:  "array invalid slice",
+			input: `x := [1 2 3][2:1]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytecode := compileBytecode(t, tt.input)
+			vm := NewVM(bytecode)
+			err := vm.Run()
+			assert.Error(t, ErrSlice, err)
 		})
 	}
 }


### PR DESCRIPTION
Support positive and negative slices in the compiler, introduce
OpNone to allow passing empty values for the start or end of a
slice to signal the vm to default the value. The vm will return
a new user error named ErrSlice if the start index of a slice
is greater than the end index.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>