### PR TITLE
bytecode: Implement if statements

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -95,6 +95,13 @@ const (
 	// optional and unspecified such as the start and end value of a
 	// slice index, or the values in a step range.
 	OpNone
+	// OpJump will force the virtual machine to jump to the instruction
+	// address within its operand.
+	OpJump
+	// OpJumpOnFalse will pop the top element of the stack as a
+	// boolean and evaluate it. It will jump to the instruction address
+	// in its operand if the condition evaluates to false.
+	OpJumpOnFalse
 )
 
 var (
@@ -145,11 +152,13 @@ var definitions = map[Opcode]*OpDefinition{
 	OpArrayConcatenate: {"OpArrayConcatenate", nil},
 	// This operand width only allows maps of up to 32767 pairs, as the map doubles in length
 	// to 65535 when it is flattened onto the stack.
-	OpMap:      {"OpMap", []int{2}},
-	OpIndex:    {"OpIndex", nil},
-	OpSetIndex: {"OpSetIndex", nil},
-	OpSlice:    {"OpSlice", nil},
-	OpNone:     {"OpNone", nil},
+	OpMap:         {"OpMap", []int{2}},
+	OpIndex:       {"OpIndex", nil},
+	OpSetIndex:    {"OpSetIndex", nil},
+	OpSlice:       {"OpSlice", nil},
+	OpNone:        {"OpNone", nil},
+	OpJump:        {"OpJump", []int{2}},
+	OpJumpOnFalse: {"OpJumpOnFalse", []int{2}},
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/instructions.go
+++ b/pkg/bytecode/instructions.go
@@ -2,6 +2,7 @@ package bytecode
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 )
 
@@ -38,4 +39,11 @@ func fmtInstruction(def *OpDefinition, operands []int) string {
 	default:
 		return fmt.Sprintf("ERROR: unhandled operandCount for %s\n", def.Name)
 	}
+}
+
+// changeOperand overwrites the first operand of a single-operand
+// instruction at opPosition with the given operand.
+// The width of the operand must be 2.
+func (ins Instructions) changeOperand(opPosition int, operand int) {
+	binary.BigEndian.PutUint16(ins[opPosition+1:], uint16(operand))
 }


### PR DESCRIPTION
Add two new opcodes (`OpJumpOnFalse`, `OpJump`) that give the vm the
ability to skip instructions. Add the `ChangeOperand` function to
`Instructions`, which allows the jump operand to be rewritten after
further instructions have been emitted to the bytecode (this process is
known as backfilling). The alternative to backfilling is a two-pass
compiler, which we discarded as too complex for now.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: pgmitche <pgmitche@users.noreply.github.com>