### PR TITLE
evaluator: Refactor value to remove Type() method

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -436,7 +436,7 @@ var typeofDecl = &parser.FuncDefStmt{
 }
 
 func typeofFunc(_ *scope, args []value) (value, error) {
-	t := args[0].(*anyVal).V.Type()
+	t := args[0].(*anyVal).T
 	return &stringVal{V: t.String()}, nil
 }
 
@@ -455,7 +455,7 @@ func lenFunc(_ *scope, args []value) (value, error) {
 	case *stringVal:
 		return &numVal{V: float64(len(arg.runes()))}, nil
 	}
-	return nil, fmt.Errorf(`%w: "len" takes 1 argument of type "string", array "[]" or map "{}" not %s`, ErrBadArguments, args[0].(*anyVal).V.Type())
+	return nil, fmt.Errorf(`%w: "len" takes 1 argument of type "string", array "[]" or map "{}" not %s`, ErrBadArguments, args[0].(*anyVal).T)
 }
 
 var hasDecl = &parser.FuncDefStmt{
@@ -709,7 +709,7 @@ func parseFontProps(arg *mapVal) (map[string]any, error) {
 			}
 			props[key] = v.V
 		default:
-			return nil, fmt.Errorf("%w: expected property %q of type %s, found %s", ErrBadArguments, key, propType, val.(*anyVal).V.Type())
+			return nil, fmt.Errorf("%w: expected property %q of type %s, found %s", ErrBadArguments, key, propType, val.(*anyVal).T)
 		}
 	}
 	return props, nil

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -436,10 +436,7 @@ var typeofDecl = &parser.FuncDefStmt{
 }
 
 func typeofFunc(_ *scope, args []value) (value, error) {
-	t := args[0].Type()
-	if a, ok := args[0].(*anyVal); ok {
-		t = a.V.Type()
-	}
+	t := args[0].(*anyVal).V.Type()
 	return &stringVal{V: t.String()}, nil
 }
 
@@ -458,7 +455,7 @@ func lenFunc(_ *scope, args []value) (value, error) {
 	case *stringVal:
 		return &numVal{V: float64(len(arg.runes()))}, nil
 	}
-	return nil, fmt.Errorf(`%w: "len" takes 1 argument of type "string", array "[]" or map "{}" not %s`, ErrBadArguments, args[0].Type())
+	return nil, fmt.Errorf(`%w: "len" takes 1 argument of type "string", array "[]" or map "{}" not %s`, ErrBadArguments, args[0].(*anyVal).V.Type())
 }
 
 var hasDecl = &parser.FuncDefStmt{
@@ -671,7 +668,7 @@ func dashFunc(dashFn func([]float64)) builtinFunc {
 
 var fontDecl = &parser.FuncDefStmt{
 	Name:       "font",
-	Params:     []*parser.Var{{Name: "properties", T: parser.GENERIC_MAP}},
+	Params:     []*parser.Var{{Name: "properties", T: &parser.Type{Name: parser.MAP, Sub: parser.ANY_TYPE}}},
 	ReturnType: parser.NONE_TYPE,
 }
 
@@ -691,10 +688,7 @@ func parseFontProps(arg *mapVal) (map[string]any, error) {
 		if !ok {
 			return nil, fmt.Errorf("%w: unknown property %q", ErrBadArguments, key)
 		}
-		if a, ok := val.(*anyVal); ok {
-			val = a.V
-		}
-		switch v := val.(type) {
+		switch v := val.(*anyVal).V.(type) {
 		case *stringVal:
 			if propType != "string" {
 				return nil, fmt.Errorf("%w: expected property %q of type %s, found string", ErrBadArguments, key, propType)
@@ -715,7 +709,7 @@ func parseFontProps(arg *mapVal) (map[string]any, error) {
 			}
 			props[key] = v.V
 		default:
-			return nil, fmt.Errorf("%w: expected property %q of type %s, found %s", ErrBadArguments, key, propType, v.Type().String())
+			return nil, fmt.Errorf("%w: expected property %q of type %s, found %s", ErrBadArguments, key, propType, val.(*anyVal).V.Type())
 		}
 	}
 	return props, nil

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -268,7 +268,7 @@ func splitFunc(_ *scope, args []value) (value, error) {
 	for i, s := range slice {
 		elements[i] = &stringVal{V: s}
 	}
-	return &arrayVal{Elements: &elements, T: stringArrayType}, nil
+	return &arrayVal{Elements: &elements}, nil
 }
 
 var upperDecl = &parser.FuncDefStmt{

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -332,7 +332,7 @@ func (e *Evaluator) evalAny(a *parser.Any) (value, error) {
 	if _, ok := val.(*anyVal); ok {
 		panic("nested any value " + a.String())
 	}
-	return &anyVal{V: val}, nil
+	return &anyVal{V: val, T: a.Value.Type()}, nil
 }
 
 func (e *Evaluator) evalArrayLiteral(arr *parser.ArrayLiteral) (value, error) {
@@ -767,7 +767,7 @@ func (e *Evaluator) evalIndexExpr(expr *parser.IndexExpression, forAssign bool) 
 		}
 		val, err = l.Get(strIndex.V)
 	default:
-		err = fmt.Errorf("%w: expected array, string or map with index, found %v", ErrType, left.Type())
+		err = fmt.Errorf("%w: expected array, string or map with index, found %v", ErrType, expr.Left.Type())
 	}
 	if err != nil {
 		return nil, newErr(expr, err)
@@ -837,8 +837,8 @@ func (e *Evaluator) evalTypeAssertion(ta *parser.TypeAssertion) (value, error) {
 	if !ok {
 		return nil, newErr(ta, fmt.Errorf("%w: not an any", ErrAnyConversion))
 	}
-	if !a.V.Type().Equals(ta.T) {
-		return nil, newErr(ta, fmt.Errorf("%w: expected %v, found %v", ErrAnyConversion, ta.T, a.V.Type()))
+	if !a.T.Equals(ta.T) {
+		return nil, newErr(ta, fmt.Errorf("%w: expected %v, found %v", ErrAnyConversion, ta.T, a.T))
 	}
 	return a.V, nil
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -340,7 +340,7 @@ func (e *Evaluator) evalArrayLiteral(arr *parser.ArrayLiteral) (value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &arrayVal{Elements: &elements, T: arr.T}, nil
+	return &arrayVal{Elements: &elements}, nil
 }
 
 func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) (value, error) {
@@ -354,7 +354,7 @@ func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) (value, error) {
 	}
 	order := make([]string, len(m.Order))
 	copy(order, m.Order)
-	return &mapVal{Pairs: pairs, Order: &order, T: m.T}, nil
+	return &mapVal{Pairs: pairs, Order: &order}, nil
 }
 
 func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (value, error) {
@@ -379,7 +379,7 @@ func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (value, error) {
 		e.scope.set(param.Name, args[i])
 	}
 	if fd.VariadicParam != nil {
-		varArg := &arrayVal{Elements: &args, T: fd.VariadicParamType}
+		varArg := &arrayVal{Elements: &args}
 		e.scope.set(fd.VariadicParam.Name, varArg)
 	}
 
@@ -644,7 +644,7 @@ func (e *Evaluator) evalBinaryExpr(expr *parser.BinaryExpression) (value, error)
 	case *boolVal:
 		val, err = evalBinaryBoolExpr(op, l, right.(*boolVal))
 	case *arrayVal:
-		val, err = evalBinaryArrayExpr(op, l, right.(*arrayVal), expr.Type())
+		val, err = evalBinaryArrayExpr(op, l, right.(*arrayVal))
 	default:
 		err = fmt.Errorf("%w (binary): %v", ErrOperation, expr)
 	}
@@ -718,12 +718,11 @@ func evalBinaryBoolExpr(op parser.Operator, left, right *boolVal) (value, error)
 	return nil, fmt.Errorf("%w (bool): %v", ErrOperation, op.String())
 }
 
-func evalBinaryArrayExpr(op parser.Operator, left, right *arrayVal, t *parser.Type) (value, error) {
+func evalBinaryArrayExpr(op parser.Operator, left, right *arrayVal) (value, error) {
 	if op != parser.OP_PLUS {
 		return nil, fmt.Errorf("%w (array): %v", ErrOperation, op.String())
 	}
 	result := left.Copy()
-	result.T = t
 	rightElemnts := *right.Copy().Elements
 	*result.Elements = append(*result.Elements, rightElemnts...)
 	return result, nil

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -148,11 +148,11 @@ func (a *anyVal) Equals(v value) bool {
 }
 
 func (a *anyVal) Set(v value) {
-	if a2, ok := v.(*anyVal); ok {
-		a.V = copyOrRef(a2.V)
-	} else {
-		a.V = copyOrRef(v)
+	a2, ok := v.(*anyVal)
+	if !ok {
+		panic("internal error: Any.Set called with non-Any value")
 	}
+	a.V = copyOrRef(a2.V)
 }
 
 func (n *noneVal) Type() *parser.Type  { return parser.NONE_TYPE }


### PR DESCRIPTION
Refactor the `value` interface and the concrete implementations to
remove the `Type()` method from `value`. As evy is a statically typed
language except for `any`, type information should only be needed when
working with `any` values. Removing type information from other values
simplifies the implementation.

There are three steps to the refactor:
* Tidy up some old code in builtins where they used to get concrete
  types instead of `anyVal` types but now always get `anyVal` due to the
  signature.
* Add a type field to `anyVal` and use only that and the AST type
  information where type information is needed.
* Remove the unused `Type()` method and type fields from `arrayVal` and
  `mapVal`.