### PR TITLE
Let fmt package call String() on arguments

### DIFF
--- a/pkg/bytecode/value.go
+++ b/pkg/bytecode/value.go
@@ -185,7 +185,7 @@ func (m mapVal) Type() *parser.Type {
 func (m mapVal) String() string {
 	pairs := []string{}
 	for k, v := range m {
-		pairs = append(pairs, fmt.Sprintf("%s: %s", k, v.String()))
+		pairs = append(pairs, fmt.Sprintf("%s: %s", k, v))
 	}
 	return "{" + strings.Join(pairs, ", ") + "}"
 }

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -240,7 +240,7 @@ func (t *Token) setLiteral(literal string) *Token {
 func (t *Token) String() string {
 	switch t.Type {
 	case COMMENT, IDENT, NUM_LIT, STRING_LIT:
-		return fmt.Sprintf("%s %q", t.Type.String(), t.Literal)
+		return fmt.Sprintf("%s %q", t.Type, t.Literal)
 	case ILLEGAL:
 		return fmt.Sprintf("ILLEGAL 💥 %q at %s", t.Literal, t.Location())
 	}

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -127,7 +127,7 @@ func (p *parser) parseUnaryExpr() Node {
 	unaryExp := &UnaryExpression{token: tok, Op: op(tok)}
 	p.advance() // advance past operator
 	if p.lookAt(p.pos-1).Type == lexer.WS {
-		msg := fmt.Sprintf("unexpected whitespace after %q", unaryExp.Op.String())
+		msg := fmt.Sprintf("unexpected whitespace after %q", unaryExp.Op)
 		p.appendErrorForToken(msg, tok)
 	}
 	unaryExp.Right = p.parseExpr(unaryPrec)
@@ -301,7 +301,7 @@ func (p *parser) parseTypeAssertion(left Node) Node {
 	t := p.parseType()
 	switch t {
 	case nil:
-		msg := fmt.Sprintf("invalid type in type assertion of %q", left.String())
+		msg := fmt.Sprintf("invalid type in type assertion of %q", left)
 		p.appendErrorForToken(msg, tok)
 	case ANY_TYPE:
 		p.appendErrorForToken("cannot type assert to type any", tok)
@@ -351,7 +351,7 @@ func (p *parser) validateBinaryType(binaryExp *BinaryExpression) {
 	leftType := binaryExp.Left.Type()
 	rightType := binaryExp.Right.Type()
 	if !leftType.matches(rightType) {
-		msg := fmt.Sprintf("mismatched type for %s: %s, %s", op.String(), leftType.String(), rightType.String())
+		msg := fmt.Sprintf("mismatched type for %s: %s, %s", op, leftType, rightType)
 		p.appendErrorForToken(msg, tok)
 		return
 	}
@@ -363,17 +363,17 @@ func (p *parser) validateBinaryType(binaryExp *BinaryExpression) {
 		}
 	case OP_MINUS, OP_SLASH, OP_ASTERISK, OP_PERCENT:
 		if leftType != NUM_TYPE {
-			msg := fmt.Sprintf("%q takes num type, found %s", op.String(), leftType.String())
+			msg := fmt.Sprintf("%q takes num type, found %s", op, leftType)
 			p.appendErrorForToken(msg, tok)
 		}
 	case OP_LT, OP_GT, OP_LTEQ, OP_GTEQ:
 		if leftType != NUM_TYPE && leftType != STRING_TYPE {
-			msg := fmt.Sprintf("%q takes num or string type, found %s", op.String(), leftType.String())
+			msg := fmt.Sprintf("%q takes num or string type, found %s", op, leftType)
 			p.appendErrorForToken(msg, tok)
 		}
 	case OP_AND, OP_OR:
 		if leftType != BOOL_TYPE {
-			msg := fmt.Sprintf("%q takes bool type, found %s", op.String(), leftType.String())
+			msg := fmt.Sprintf("%q takes bool type, found %s", op, leftType)
 			p.appendErrorForToken(msg, tok)
 		}
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -385,7 +385,7 @@ func (p *parser) parseAssignmentStatement() Node {
 		return nil
 	}
 	if !target.Type().accepts(value.Type()) {
-		msg := fmt.Sprintf("%q accepts values of type %s, found %s", target.String(), target.Type().String(), value.Type().String())
+		msg := fmt.Sprintf("%q accepts values of type %s, found %s", target, target.Type(), value.Type())
 		p.appendErrorForToken(msg, tok)
 	} else {
 		value = wrapAny(value, target.Type())
@@ -579,7 +579,7 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 		for i, arg := range args {
 			argType := arg.Type()
 			if !paramType.accepts(argType) {
-				msg := fmt.Sprintf("%q takes variadic arguments of type %s, found %s", funcName, paramType.String(), argType.String())
+				msg := fmt.Sprintf("%q takes variadic arguments of type %s, found %s", funcName, paramType, argType)
 				p.appendErrorForToken(msg, arg.Token())
 			} else {
 				args[i] = wrapAny(arg, paramType)
@@ -600,7 +600,7 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 		paramType := decl.Params[i].Type()
 		argType := arg.Type()
 		if !paramType.accepts(argType) {
-			msg := fmt.Sprintf("%q takes %s argument of type %s, found %s", funcName, ordinalize(i+1), paramType.String(), argType.String())
+			msg := fmt.Sprintf("%q takes %s argument of type %s, found %s", funcName, ordinalize(i+1), paramType, argType)
 			p.appendErrorForToken(msg, arg.Token())
 		} else {
 			args[i] = wrapAny(arg, paramType)


### PR DESCRIPTION
Remove the call to the `String()` method on arguments to the printf
family of functions where those functions would call `String()` anyway,
according to the rules documented in the overview of the `fmt` package.

This makes for less verbose and slightly cleaner code.