### PR TITLE
Define and implement an array repetition operator

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,7 +33,7 @@ To get an intuitive understanding of Evy, you can either look at its
 12. [**Maps**](#maps)
 13. [**Index and Slice**](#index-and-slice)
 14. [**Operators and Expressions**](#operators-and-expressions)  
-    [Arithmetic and Concatenation Operators](#arithmetic-and-concatenation-operators), [Logical Operators](#logical-operators), [Comparison Operators](#comparison-operators), [Unary Operators](#unary-operators)
+    [Arithmetic, Concatenation and Repetition Operators](#arithmetic,-concatenation-and-repetition-operators), [Logical Operators](#logical-operators), [Comparison Operators](#comparison-operators), [Unary Operators](#unary-operators)
 15. [**Precedence**](#precedence)
 16. [**Statements**](#statements)
 17. [**Whitespace**](#whitespace)  
@@ -588,6 +588,13 @@ If you try to concatenate two literals of different types such as
 `arr := [1 2] + ["a" "b"]`, you will get a parse error. Use
 `arr := [1 2 "a" "b"]` instead.
 
+Arrays can be repeated with the `*` operator, for example `[0] * 5`
+results in `[0 0 0 0 0]`. `["hello" "world"] * 2` results in `["hello"
+"world" "hello" "world"]`. An array repeated zero times results in an
+empty array of the same type as the array. The number on the right hand
+side of the `*` operator must be an non-negative integer value. Using a
+non-integer or negative value will result in an error.
+
 The elements of an array can be accessed via index starting at `0`. In
 the example `arr := ["abc" 123]` the first element in the array
 `arr[0]` is `"abc"`.
@@ -787,21 +794,23 @@ no automated type conversion of operands.
 There are a variety of binary operators: arithmetic, concatenation,
 logical, and comparison operators.
 
-| Operator            | Operands  | Result   | Description   |
-| ------------------- | --------- | -------- | ------------- |
-| `+` `-` `*` `/` `%` | `num`     | `num`    | arithmetic    |
-| `+`                 | `string`  | `string` | concatenation |
-| `+`                 | array     | array    | concatenation |
-| `and` `or`          | `bool`    | `bool`   | logical       |
-| `<` `<=` `>` `>=`   | `num`     | `bool`   | comparison    |
-| `<` `<=` `>` `>=`   | `string`  | `bool`   | comparison    |
-| `==` `!=`           | all types | `bool`   | comparison    |
+| Operator            | Operands        | Result   | Description   |
+| ------------------- | --------------- | -------- | ------------- |
+| `+` `-` `*` `/` `%` | `num`           | `num`    | arithmetic    |
+| `+`                 | `string`        | `string` | concatenation |
+| `+`                 | array           | array    | concatenation |
+| `*`                 | array `*` `num` | array    | repetition    |
+| `and` `or`          | `bool`          | `bool`   | logical       |
+| `<` `<=` `>` `>=`   | `num`           | `bool`   | comparison    |
+| `<` `<=` `>` `>=`   | `string`        | `bool`   | comparison    |
+| `==` `!=`           | all types       | `bool`   | comparison    |
 
-### Arithmetic and Concatenation Operators
+### Arithmetic, Concatenation and Repetition Operators
 
 The **arithmetic operators** `+`, `-`, `*`, `/`, and `%` stand for addition,
 subtraction, multiplication, division, and the [modulo operator]. The
-symbol `+` can also be used to concatenate strings and arrays.
+symbol `+` can also be used to concatenate strings and arrays. The `*` symbol
+can be used to repeat an array a number of times.
 
 The **modulo operator** `%`, also known as the remainder operator, returns the
 remainder of a division operation. For example, `10 % 3` results in
@@ -810,6 +819,10 @@ remainder of a division operation. For example, `10 % 3` results in
 The **concatenation operator** `+`, combines two strings or two arrays
 together. For example, `"fire"` + `"engine"` combines into the string
 `"fireengine"`.
+
+The **repetition operator** `*`, repeats an array a number of times. The number
+must be a non-negative integer value. An array repeated zero times is an empty
+array.
 
 [modulo operator]: https://en.wikipedia.org/wiki/Modulo_operation
 

--- a/docs/syntax_by_example.md
+++ b/docs/syntax_by_example.md
@@ -255,6 +255,16 @@ a = a + [100] // [1 2 3 4 100]; optional extra whitespace
 a = [0] + a + [101 102] // [0 1 2 3 4 100 101 102]
 ```
 
+### Repetition
+
+```evy
+a := [0] * 5 // [0 0 0 0 0]
+a = [1 2] * 2 + a + [3] * 3 // [1 2 1 2 0 0 0 0 0 3 3 3]
+n := 3
+b := ["hello"] * n
+print b // ["hello" "hello" "hello"]
+```
+
 ### Slicing
 
 ```evy

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -116,6 +116,7 @@
                   <a href="syntax_by_example.html#array-element-access">Array element access</a>
                 </li>
                 <li><a href="syntax_by_example.html#concatenation">Concatenation</a></li>
+                <li><a href="syntax_by_example.html#repetition">Repetition</a></li>
                 <li><a href="syntax_by_example.html#slicing">Slicing</a></li>
               </ul>
             </li>
@@ -429,8 +430,8 @@
               <div class="expander"></div>
               <ul>
                 <li>
-                  <a href="spec.html#arithmetic-and-concatenation-operators"
-                    >Arithmetic and Concatenation Operators</a
+                  <a href="spec.html#arithmetic-concatenation-and-repetition-operators"
+                    >Arithmetic, Concatenation and Repetition Operators</a
                   >
                 </li>
                 <li><a href="spec.html#logical-operators">Logical Operators</a></li>

--- a/frontend/docs/index.html
+++ b/frontend/docs/index.html
@@ -116,6 +116,7 @@
                   <a href="syntax_by_example.html#array-element-access">Array element access</a>
                 </li>
                 <li><a href="syntax_by_example.html#concatenation">Concatenation</a></li>
+                <li><a href="syntax_by_example.html#repetition">Repetition</a></li>
                 <li><a href="syntax_by_example.html#slicing">Slicing</a></li>
               </ul>
             </li>
@@ -429,8 +430,8 @@
               <div class="expander"></div>
               <ul>
                 <li>
-                  <a href="spec.html#arithmetic-and-concatenation-operators"
-                    >Arithmetic and Concatenation Operators</a
+                  <a href="spec.html#arithmetic-concatenation-and-repetition-operators"
+                    >Arithmetic, Concatenation and Repetition Operators</a
                   >
                 </li>
                 <li><a href="spec.html#logical-operators">Logical Operators</a></li>

--- a/frontend/docs/spec.html
+++ b/frontend/docs/spec.html
@@ -116,6 +116,7 @@
                   <a href="syntax_by_example.html#array-element-access">Array element access</a>
                 </li>
                 <li><a href="syntax_by_example.html#concatenation">Concatenation</a></li>
+                <li><a href="syntax_by_example.html#repetition">Repetition</a></li>
                 <li><a href="syntax_by_example.html#slicing">Slicing</a></li>
               </ul>
             </li>
@@ -429,8 +430,8 @@
               <div class="expander"></div>
               <ul>
                 <li>
-                  <a href="spec.html#arithmetic-and-concatenation-operators"
-                    >Arithmetic and Concatenation Operators</a
+                  <a href="spec.html#arithmetic-concatenation-and-repetition-operators"
+                    >Arithmetic, Concatenation and Repetition Operators</a
                   >
                 </li>
                 <li><a href="spec.html#logical-operators">Logical Operators</a></li>
@@ -1082,6 +1083,15 @@ print &quot;Type of arr:&quot; (typeof arr)
           <code>arr := [1 2 &quot;a&quot; &quot;b&quot;]</code> instead.
         </p>
         <p>
+          Arrays can be repeated with the <code>*</code> operator, for example
+          <code>[0] * 5</code> results in <code>[0 0 0 0 0]</code>.
+          <code>[&quot;hello&quot; &quot;world&quot;] * 2</code> results in
+          <code>[&quot;hello&quot; &quot;world&quot; &quot;hello&quot; &quot;world&quot;]</code>. An
+          array repeated zero times results in an empty array of the same type as the array. The
+          number on the right hand side of the <code>*</code> operator must be an non-negative
+          integer value. Using a non-integer or negative value will result in an error.
+        </p>
+        <p>
           The elements of an array can be accessed via index starting at <code>0</code>. In the
           example <code>arr := [&quot;abc&quot; 123]</code> the first element in the array
           <code>arr[0]</code> is <code>&quot;abc&quot;</code>.
@@ -1294,6 +1304,12 @@ print 5 s[:-1]
               <td>concatenation</td>
             </tr>
             <tr>
+              <td><code>*</code></td>
+              <td>array <code>*</code> <code>num</code></td>
+              <td>array</td>
+              <td>repetition</td>
+            </tr>
+            <tr>
               <td><code>and</code> <code>or</code></td>
               <td><code>bool</code></td>
               <td><code>bool</code></td>
@@ -1321,18 +1337,19 @@ print 5 s[:-1]
         </table>
         <h3>
           <a
-            id="arithmetic-and-concatenation-operators"
-            href="#arithmetic-and-concatenation-operators"
+            id="arithmetic-concatenation-and-repetition-operators"
+            href="#arithmetic-concatenation-and-repetition-operators"
             class="anchor"
             >#</a
-          >Arithmetic and Concatenation Operators
+          >Arithmetic, Concatenation and Repetition Operators
         </h3>
         <p>
           The <strong>arithmetic operators</strong> <code>+</code>, <code>-</code>, <code>*</code>,
           <code>/</code>, and <code>%</code> stand for addition, subtraction, multiplication,
           division, and the
           <a href="https://en.wikipedia.org/wiki/Modulo_operation">modulo operator</a>. The symbol
-          <code>+</code> can also be used to concatenate strings and arrays.
+          <code>+</code> can also be used to concatenate strings and arrays. The
+          <code>*</code> symbol can be used to repeat an array a number of times.
         </p>
         <p>
           The <strong>modulo operator</strong> <code>%</code>, also known as the remainder operator,
@@ -1345,6 +1362,11 @@ print 5 s[:-1]
           arrays together. For example, <code>&quot;fire&quot;</code> +
           <code>&quot;engine&quot;</code> combines into the string
           <code>&quot;fireengine&quot;</code>.
+        </p>
+        <p>
+          The <strong>repetition operator</strong> <code>*</code>, repeats an array a number of
+          times. The number must be a non-negative integer value. An array repeated zero times is an
+          empty array.
         </p>
         <h3>
           <a id="logical-operators" href="#logical-operators" class="anchor">#</a>Logical Operators

--- a/frontend/docs/syntax_by_example.html
+++ b/frontend/docs/syntax_by_example.html
@@ -116,6 +116,7 @@
                   <a href="syntax_by_example.html#array-element-access">Array element access</a>
                 </li>
                 <li><a href="syntax_by_example.html#concatenation">Concatenation</a></li>
+                <li><a href="syntax_by_example.html#repetition">Repetition</a></li>
                 <li><a href="syntax_by_example.html#slicing">Slicing</a></li>
               </ul>
             </li>
@@ -429,8 +430,8 @@
               <div class="expander"></div>
               <ul>
                 <li>
-                  <a href="spec.html#arithmetic-and-concatenation-operators"
-                    >Arithmetic and Concatenation Operators</a
+                  <a href="spec.html#arithmetic-concatenation-and-repetition-operators"
+                    >Arithmetic, Concatenation and Repetition Operators</a
                   >
                 </li>
                 <li><a href="spec.html#logical-operators">Logical Operators</a></li>
@@ -729,6 +730,13 @@ print a1[-1] // 4
         <pre><code class="language-evy">a := [1 2 3 4]
 a = a + [100] // [1 2 3 4 100]; optional extra whitespace
 a = [0] + a + [101 102] // [0 1 2 3 4 100 101 102]
+</code></pre>
+        <h3><a id="repetition" href="#repetition" class="anchor">#</a>Repetition</h3>
+        <pre><code class="language-evy">a := [0] * 5 // [0 0 0 0 0]
+a = [1 2] * 2 + a + [3] * 3 // [1 2 1 2 0 0 0 0 0 3 3 3]
+n := 3
+b := [&quot;hello&quot;] * n
+print b // [&quot;hello&quot; &quot;hello&quot; &quot;hello&quot;]
 </code></pre>
         <h3><a id="slicing" href="#slicing" class="anchor">#</a>Slicing</h3>
         <pre><code class="language-evy">a := [1 2 3]

--- a/frontend/docs/usage.html
+++ b/frontend/docs/usage.html
@@ -116,6 +116,7 @@
                   <a href="syntax_by_example.html#array-element-access">Array element access</a>
                 </li>
                 <li><a href="syntax_by_example.html#concatenation">Concatenation</a></li>
+                <li><a href="syntax_by_example.html#repetition">Repetition</a></li>
                 <li><a href="syntax_by_example.html#slicing">Slicing</a></li>
               </ul>
             </li>
@@ -429,8 +430,8 @@
               <div class="expander"></div>
               <ul>
                 <li>
-                  <a href="spec.html#arithmetic-and-concatenation-operators"
-                    >Arithmetic and Concatenation Operators</a
+                  <a href="spec.html#arithmetic-concatenation-and-repetition-operators"
+                    >Arithmetic, Concatenation and Repetition Operators</a
                   >
                 </li>
                 <li><a href="spec.html#logical-operators">Logical Operators</a></li>

--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -75,6 +75,9 @@ const (
 	// OpArrayConcatenate represents a + operator used to concatenate two
 	// arrays.
 	OpArrayConcatenate
+	// OpArrayRepeat represents a * operator used to repeat an array a
+	// number of times.
+	OpArrayRepeat
 	// OpMap represents a map literal, the operand N is the length of
 	// the map multiplied by 2. This length N represents the total length
 	// of the flattened map in the stack, where keys and values have been
@@ -150,6 +153,7 @@ var definitions = map[Opcode]*OpDefinition{
 	// This operand width only allows arrays up to 65535 elements in length.
 	OpArray:            {"OpArray", []int{2}},
 	OpArrayConcatenate: {"OpArrayConcatenate", nil},
+	OpArrayRepeat:      {"OpArrayRepeat", nil},
 	// This operand width only allows maps of up to 32767 pairs, as the map doubles in length
 	// to 65535 when it is flattened onto the stack.
 	OpMap:         {"OpMap", []int{2}},

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -183,6 +183,9 @@ func (c *Compiler) compileBinaryExpression(expr *parser.BinaryExpression) error 
 	if expr.Left.Type().Name == parser.ARRAY && expr.Right.Type().Name == parser.ARRAY && expr.Op == parser.OP_PLUS {
 		return c.emit(OpArrayConcatenate)
 	}
+	if expr.Left.Type().Name == parser.ARRAY && expr.Right.Type() == parser.NUM_TYPE && expr.Op == parser.OP_ASTERISK {
+		return c.emit(OpArrayRepeat)
+	}
 	return fmt.Errorf("%w: %s with types %s %s", ErrUnsupportedExpression,
 		expr, expr.Left.Type(), expr.Right.Type())
 }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -614,6 +614,62 @@ print "2 arr5" arr5
 	}
 }
 
+func TestArrayRepetition(t *testing.T) {
+	prog := `
+arr1 := [0] * 3
+arr2 := [1 "b" true] * 2
+arr3 := [4 5 6] * 0
+arr4 := [1 2] * 2 + [3] * 3 + [4 5] * 1
+n := 2
+arr5 := arr1 * n
+print "arr1" arr1
+print "arr2" arr2
+print "arr3" arr3
+print "arr4" arr4
+print "arr5" arr5
+`
+	out := run(prog)
+	want := []string{
+		"arr1 [0 0 0]",
+		"arr2 [1 b true 1 b true]",
+		"arr3 []",
+		"arr4 [1 2 1 2 3 3 3 4 5]",
+		"arr5 [0 0 0 0 0 0]",
+		"",
+	}
+	got := strings.Split(out, "\n")
+	assert.Equal(t, len(want), len(got), out)
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestArrayRepetitionErr(t *testing.T) {
+	tests := []struct {
+		name string
+		prog string
+		want string
+	}{
+		{
+			name: "non-integer",
+			prog: `a := [1 2 3] * 4.5`,
+			want: `line 1 column 14: panic: bad repetition count: not an integer: 4.5`,
+		},
+		{
+			name: "negative",
+			prog: `a := [1 2 3] * -1`,
+			want: `line 1 column 14: panic: bad repetition count: negative count: -1`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := run(tt.prog + "\nprint a")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestArraySlice(t *testing.T) {
 	prog := `
 arr := [1 2 3]

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -350,7 +350,7 @@ func (p *parser) validateBinaryType(binaryExp *BinaryExpression) {
 
 	leftType := binaryExp.Left.Type()
 	rightType := binaryExp.Right.Type()
-	if !leftType.matches(rightType) {
+	if !(leftType.matches(rightType) || (leftType.Name == ARRAY && op == OP_ASTERISK)) {
 		msg := fmt.Sprintf("mismatched type for %s: %s, %s", op, leftType, rightType)
 		p.appendErrorForToken(msg, tok)
 		return
@@ -361,7 +361,15 @@ func (p *parser) validateBinaryType(binaryExp *BinaryExpression) {
 		if leftType != NUM_TYPE && leftType != STRING_TYPE && leftType.Name != ARRAY {
 			p.appendErrorForToken(`"+" takes num, string or array type, found `+leftType.String(), tok)
 		}
-	case OP_MINUS, OP_SLASH, OP_ASTERISK, OP_PERCENT:
+	case OP_ASTERISK:
+		if leftType != NUM_TYPE && leftType.Name != ARRAY {
+			msg := fmt.Sprintf(`"*" takes num or array type, found %s`, leftType)
+			p.appendErrorForToken(msg, tok)
+		} else if leftType.Name == ARRAY && rightType != NUM_TYPE {
+			msg := fmt.Sprintf(`array repetition ("*") takes num on right, found %s`, rightType)
+			p.appendErrorForToken(msg, tok)
+		}
+	case OP_MINUS, OP_SLASH, OP_PERCENT:
 		if leftType != NUM_TYPE {
 			msg := fmt.Sprintf("%q takes num type, found %s", op, leftType)
 			p.appendErrorForToken(msg, tok)

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -152,6 +152,13 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"[[1]]+[[]]":           "([[1]]+[[]])",
 		"[[]]+[[1]]":           "([[]]+[[1]])",
 
+		// Array repetition
+		"[1] * 2":  "([1]*2)",
+		"[] * 0":   "([]*0)",
+		"[1] * n1": "([1]*n1)",
+		"arr * 2":  "(arr*2)",
+		"arr * n1": "(arr*n1)",
+
 		// Slices
 		"arr[1:2]": "(arr[1:2])",
 		"arr[1:]":  "(arr[1:])",
@@ -229,6 +236,7 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		"1 and 2":      `line 1 column 3: "and" takes bool type, found num`,
 		"1 + false":    `line 1 column 3: mismatched type for +: num, bool`,
 		"false + 1":    `line 1 column 7: mismatched type for +: bool, num`,
+		"[1] * true":   `line 1 column 5: array repetition ("*") takes num on right, found bool`,
 		"(1+2":         `line 1 column 5: expected ")", got end of input`,
 		"(1+2\n)":      `line 1 column 5: expected ")", got end of line`,
 		"(1+)2":        `line 1 column 4: unexpected ")"`,


### PR DESCRIPTION
Define the `array * num` operator to repeat `array` `num` number of
times. This allows for easy initialisation of variable sized arrays
without needing to use a loop to do so.

Update the spec with a definition of the operator. Update
`syntax_by_example.md` to give some basic examples.

Implement this in the evaluator and the bytecode compiler/vm.

Issue: https://github.com/evylang/todo/issues/101