### PR TITLE
ux: Tweak playground and docs site

### DIFF
--- a/frontend/docs/index.js
+++ b/frontend/docs/index.js
@@ -30,6 +30,8 @@ expanders.map((el) => (el.onclick = expanderClick))
 highlightCurrent()
 window.addEventListener("hashchange", highlightCurrent)
 
+preventReloadOnSelfLink()
+
 // Utilities
 function showSidebar() {
   sidebar.classList.add("show")
@@ -102,4 +104,18 @@ function getShowing(item) {
     n = n.parentElement
   }
   return parents
+}
+
+function preventReloadOnSelfLink() {
+  let href = normalizedHref()
+  const last = href.split("/").pop()
+  const nodes = document.querySelectorAll(`#sidebar a[href$="${last}"]`)
+  const selfLink = [...nodes].find((n) => n.href === href)
+  if (selfLink) {
+    selfLink.onclick = (e) => {
+      e.preventDefault()
+      document.querySelector("body>main").scrollTo(0, 0)
+      window.history.pushState("", "", window.location.pathname)
+    }
+  }
 }

--- a/frontend/play/index.html
+++ b/frontend/play/index.html
@@ -133,11 +133,11 @@
       </header>
       <ul>
         <li><button id="sidebar-about">About Evy</button></li>
-        <li><a href="/docs">Docs</a></li>
-        <li><a href="/discord">Discord</a></li>
-        <li><a href="https://github.com/evylang/evy">GitHub</a></li>
-        <li><a href="https://github.com/evylang/evy/wiki/gallery">Gallery</a></li>
-        <li><a href="https://github.com/sponsors/evylang">Sponsor</a></li>
+        <li><a href="/docs" target="_blank">Docs</a></li>
+        <li><a href="/discord" target="_blank">Discord</a></li>
+        <li><a href="https://github.com/evylang/evy" target="_blank">GitHub</a></li>
+        <li><a href="https://github.com/evylang/evy/wiki/gallery" target="_blank">Gallery</a></li>
+        <li><a href="https://github.com/sponsors/evylang" target="_blank">Sponsor</a></li>
         <li class="mobile"><button id="sidebar-share">Share</button></li>
       </ul>
       <ul class="icons">


### PR DESCRIPTION
- Prevent page reload on navigation to self-URL on docs-site
- Open _all_ sidebar links in new tab in playground.

Fixes: https://github.com/evylang/todo/issues/100
Fixes: https://github.com/evylang/todo/issues/99