### PR TITLE
eval: Error on non-integer index and slice expressions

### DIFF
--- a/pkg/bytecode/value.go
+++ b/pkg/bytecode/value.go
@@ -11,6 +11,8 @@ import (
 var (
 	// ErrBounds reports an index out of bounds in an array or string.
 	ErrBounds = fmt.Errorf("%w: index out of bounds", ErrPanic)
+	// ErrIndexValue reports an index value error if the index is not an integer, e.g. 1.1.
+	ErrIndexValue = fmt.Errorf("%w: index not an integer", ErrPanic)
 	// ErrMapKey reports that no value was found for a specific key
 	// used in a map index.
 	ErrMapKey = fmt.Errorf("%w: no value for map key", ErrPanic)
@@ -240,6 +242,9 @@ func normalizeIndex(idx value, length int, indexType indexType) (int, error) {
 	index := idx.(numVal)
 	i := int(index)
 
+	if float64(index) != float64(i) {
+		return 0, fmt.Errorf("%w: %v", ErrIndexValue, index)
+	}
 	if i < -length || i > limit {
 		return 0, fmt.Errorf("%w: %d", ErrBounds, i)
 	}

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -1004,6 +1004,35 @@ func TestErrBounds(t *testing.T) {
 	}
 }
 
+func TestErrIndex(t *testing.T) {
+	type boundsTest struct {
+		name  string
+		input string
+	}
+	tests := []boundsTest{
+		{
+			name:  "string index not an integer",
+			input: `x := "abc"[1.1]`,
+		},
+		{
+			name:  "array index not an integer",
+			input: `x := [1 2 3][1.1]`,
+		},
+		{
+			name:  "array invalid slice type",
+			input: `x := [1 2 3][1.1:2.1]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytecode := compileBytecode(t, tt.input)
+			vm := NewVM(bytecode)
+			err := vm.Run()
+			assert.Error(t, ErrIndexValue, err)
+		})
+	}
+}
+
 func TestErrSlice(t *testing.T) {
 	type boundsTest struct {
 		name  string

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -17,6 +17,7 @@ var (
 	ErrStopped = errors.New("stopped")
 
 	ErrPanic         = errors.New("panic")
+	ErrIndexValue    = fmt.Errorf("%w: index not an integer", ErrPanic)
 	ErrBounds        = fmt.Errorf("%w: index out of bounds", ErrPanic)
 	ErrRangevalue    = fmt.Errorf("%w: bad range value", ErrPanic)
 	ErrMapKey        = fmt.Errorf("%w: no value for map key", ErrPanic)

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -496,8 +496,9 @@ func TestDoubleIndex(t *testing.T) {
 func TestIndexErr(t *testing.T) {
 	tests := map[string]string{
 		// x := ["a","b","c"]; x = "abc"
-		"print x[3]":  "line 2 column 8: panic: index out of bounds: 3",
-		"print x[-4]": "line 2 column 8: panic: index out of bounds: -4",
+		"print x[3]":   "line 2 column 8: panic: index out of bounds: 3",
+		"print x[-4]":  "line 2 column 8: panic: index out of bounds: -4",
+		"print x[1.1]": "line 2 column 8: panic: index not an integer: 1.1",
 		`m := {}
 		print m[x[1]]`: `line 3 column 10: panic: no value for map key: "b"`,
 	}

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -359,6 +359,10 @@ func normalizeIndex(idx value, length int, indexType indexType) (int, error) {
 
 	index := idx.(*numVal)
 	i := int(index.V)
+
+	if index.V != float64(i) {
+		return 0, fmt.Errorf("%w: %v", ErrIndexValue, index.V)
+	}
 	if i < -length || i > limit {
 		return 0, fmt.Errorf("%w: %d", ErrBounds, i)
 	}


### PR DESCRIPTION
Error on non-integer index and slice expressions as it doesn't make much sense
to use it, e.g. in arr[1.1]. We are reusing the nice error message wording
that was introduced in with the ErrBadRepetion. We have also copied the way
we do normalizeSlices indices from evaluator, basing it on normalizeIndex.

Fixes https://github.com/evylang/evy/issues/317