### PR TITLE
bytecode: Implement for loops

### DIFF
--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -79,9 +79,8 @@ const (
 	// number of times.
 	OpArrayRepeat
 	// OpMap represents a map literal, the operand N is the length of
-	// the map multiplied by 2. This length N represents the total length
-	// of the flattened map in the stack, where keys and values have been
-	// pushed sequentially (k1, v1, k2, v2...).
+	// the map. The keys and values are read sequentially from the
+	// stack (e.g. k1, v1, k2, v2...).
 	OpMap
 	// OpIndex represents an index operator used on an array, map or
 	// string variable.
@@ -154,8 +153,7 @@ var definitions = map[Opcode]*OpDefinition{
 	OpArray:            {"OpArray", []int{2}},
 	OpArrayConcatenate: {"OpArrayConcatenate", nil},
 	OpArrayRepeat:      {"OpArrayRepeat", nil},
-	// This operand width only allows maps of up to 32767 pairs, as the map doubles in length
-	// to 65535 when it is flattened onto the stack.
+	// This operand width only allows maps up to 65535 elements in length.
 	OpMap:         {"OpMap", []int{2}},
 	OpIndex:       {"OpIndex", nil},
 	OpSetIndex:    {"OpSetIndex", nil},

--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -16,6 +16,8 @@ const (
 	// OpSetGlobal adds a symbol to the specified index in the symbol
 	// table.
 	OpSetGlobal
+	// OpDrop pops and discards the top N elements of the stack.
+	OpDrop
 	// OpAdd instructs the virtual machine to perform an addition.
 	OpAdd
 	// OpSubtract instructs the virtual machine to perform a subtraction.
@@ -104,6 +106,14 @@ const (
 	// boolean and evaluate it. It will jump to the instruction address
 	// in its operand if the condition evaluates to false.
 	OpJumpOnFalse
+	// OpStepRange represents a range over a numeric start, stop and step.
+	// It has one operand that specifies if the loop range assigns to a
+	// loop variable.
+	OpStepRange
+	// OpIterRange represents a range over an iterable structure (a string,
+	// array or map). It has one operand that specifies if the loop range
+	// assigns to a loop variable.
+	OpIterRange
 )
 
 var (
@@ -126,6 +136,7 @@ var definitions = map[Opcode]*OpDefinition{
 	OpConstant:  {"OpConstant", []int{2}},
 	OpGetGlobal: {"OpGetGlobal", []int{2}},
 	OpSetGlobal: {"OpSetGlobal", []int{2}},
+	OpDrop:      {"OpDrop", []int{2}},
 	// Operations like OpAdd have no operand width because the virtual
 	// machine is expected to pop the values from the stack when reading
 	// this instruction.
@@ -161,6 +172,8 @@ var definitions = map[Opcode]*OpDefinition{
 	OpNone:        {"OpNone", nil},
 	OpJump:        {"OpJump", []int{2}},
 	OpJumpOnFalse: {"OpJumpOnFalse", []int{2}},
+	OpStepRange:   {"OpStepRange", []int{2}}, // operand: hasLoopVar
+	OpIterRange:   {"OpIterRange", []int{2}}, // operand: hasLoopVar
 }
 
 // OpDefinition defines a name and expected operand width for each OpCode.

--- a/pkg/bytecode/compiler.go
+++ b/pkg/bytecode/compiler.go
@@ -112,7 +112,7 @@ func (c *Compiler) Compile(node parser.Node) error {
 				return err
 			}
 		}
-		if err := c.emit(OpMap, len(node.Pairs)*2); err != nil {
+		if err := c.emit(OpMap, len(node.Pairs)); err != nil {
 			return err
 		}
 	}

--- a/pkg/bytecode/vm.go
+++ b/pkg/bytecode/vm.go
@@ -173,12 +173,15 @@ func (vm *VM) Run() error {
 		case OpMap:
 			mapLen := int(ReadUint16(vm.instructions[ip+1:]))
 			ip += 2
-
-			m := make(mapVal, 0)
-			for i := 0; i < mapLen; i += 2 {
+			m := mapVal{
+				order: make([]stringVal, mapLen),
+				m:     make(map[stringVal]value, mapLen),
+			}
+			for i := mapLen - 1; i >= 0; i-- {
 				val := vm.pop()
 				key := vm.popStringVal()
-				m[string(key)] = val
+				m.m[key] = val
+				m.order[i] = key
 			}
 			err = vm.push(m)
 		case OpIndex:
@@ -197,7 +200,9 @@ func (vm *VM) Run() error {
 			val := vm.pop()
 			switch left := left.(type) {
 			case mapVal:
-				left[string(index.(stringVal))] = val
+				key := index.(stringVal)
+				left.m[key] = val
+				left.order = append(left.order, key)
 			case arrayVal:
 				err = left.Set(index, val)
 			}

--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -667,6 +667,301 @@ func TestWhile(t *testing.T) {
 	}
 }
 
+func TestStepRange(t *testing.T) {
+	tests := []testCase{
+		{
+			name: "for range default start and step",
+			input: `x := 0
+			for range 10
+				x = x + 1
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 10),
+		},
+		{
+			name: "for range default step",
+			input: `x := 0
+			for range 2 10
+				x = x + 1
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 8),
+		},
+		{
+			name: "for range var",
+			input: `x := 0
+			for i := range 10
+				x = i
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 9),
+		},
+		{
+			name: "for range step",
+			input: `x := 0
+			for i := range 0 10 4
+				x = i
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 8),
+		},
+		{
+			name: "for range negative step",
+			input: `x := 0
+			for i := range 10 0 -1
+				x = i
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 1),
+		},
+		{
+			name: "for range invalid stop",
+			input: `x := 0
+			for range -10
+				x = x + 1
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 0),
+		},
+		{
+			name: "for break",
+			input: `x := 0
+			for range 5
+				x = x + 1
+				if x == 3
+					break
+				end
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 3),
+		},
+		{
+			name: "for break stack reset",
+			input: `x := 0
+			for range 5
+				x = x + 1
+				if x == 3
+					break
+				end
+			end`,
+			// The last element popped off the stack should be the stop value
+			// for the step range, which is the first thing pushed when compiling
+			// the for step range bytecode.
+			wantStackTop: makeValue(t, 5),
+		},
+		{
+			name: "nested step range",
+			input: `x := 0
+			for range 5
+				for range 3
+					x = x + 1
+				end
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 15),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytecode := compileBytecode(t, tt.input)
+			vm := NewVM(bytecode)
+			err := vm.Run()
+			assert.NoError(t, err, "runtime error")
+			got := vm.lastPoppedStackElem()
+			assert.Equal(t, tt.wantStackTop, got)
+		})
+	}
+}
+
+func TestArrayRange(t *testing.T) {
+	tests := []testCase{
+		{
+			name: "for range array",
+			input: `x := 0
+			for e := range [1 2 3]
+				x = e
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 3),
+		},
+		{
+			name: "for range array no loopvar",
+			input: `x := 0
+			for range [1 2 3]
+				x = x + 1
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 3),
+		},
+		{
+			name: "for range array variable",
+			input: `x := 0
+			y := [1 2 3]
+			for e := range y
+				x = e
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 3),
+		},
+		{
+			name: "for range array break",
+			input: `x := 0
+			for x := range [1 2 3]
+				if x == 2
+					break
+				end
+			end
+			x = x`,
+			wantStackTop: makeValue(t, 2),
+		},
+		{
+			name: "for break stack reset",
+			input: `x := 0
+			for x := range [1 2 3]
+				if x == 2
+					break
+				end
+			end`,
+			// The last element popped off the stack should be the array being
+			// iterated, which is the first thing pushed when compiling
+			// the for array range bytecode.
+			wantStackTop: makeValue(t, []any{1, 2, 3}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytecode := compileBytecode(t, tt.input)
+			vm := NewVM(bytecode)
+			err := vm.Run()
+			assert.NoError(t, err, "runtime error")
+			got := vm.lastPoppedStackElem()
+			assert.Equal(t, tt.wantStackTop, got)
+		})
+	}
+}
+
+func TestMapRange(t *testing.T) {
+	tests := []testCase{
+		{
+			name: "map range",
+			input: `x := ""
+			for e := range {a:22 b:44}
+				x = e
+			end
+			x = x
+			`,
+			wantStackTop: makeValue(t, "b"),
+		},
+		{
+			name: "map range variable",
+			input: `x := ""
+			y := {a:22 b:44}
+			for e := range y
+				x = e
+			end
+			x = x
+			`,
+			wantStackTop: makeValue(t, "b"),
+		},
+		{
+			name: "map range break",
+			input: `x := ""
+			for x := range {a:22 b:44}
+				if x == "a"
+					break
+				end
+			end
+			x = x
+			`,
+			wantStackTop: makeValue(t, "a"),
+		},
+		{
+			name: "for break stack reset",
+			input: `x := ""
+			for x := range {a:22 b:44}
+				if x == "a"
+					break
+				end
+			end`,
+			// The last element popped off the stack should be the map being
+			// iterated, which is the first thing pushed when compiling
+			// the for map range bytecode.
+			wantStackTop: makeValue(t, []pair{{"a", 22}, {"b", 44}}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytecode := compileBytecode(t, tt.input)
+			vm := NewVM(bytecode)
+			err := vm.Run()
+			assert.NoError(t, err, "runtime error")
+			got := vm.lastPoppedStackElem()
+			assert.Equal(t, tt.wantStackTop, got)
+		})
+	}
+}
+
+func TestStringRange(t *testing.T) {
+	tests := []testCase{
+		{
+			name: "string range",
+			input: `x := ""
+			for e := range "hello world"
+				x = e
+			end
+			x = x
+			`,
+			wantStackTop: makeValue(t, "d"),
+		},
+		{
+			name: "string range variable",
+			input: `x := ""
+			y := "hello world"
+			for e := range y
+				x = e
+			end
+			x = x
+			`,
+			wantStackTop: makeValue(t, "d"),
+		},
+		{
+			name: "string range break",
+			input: `x := ""
+			for x := range "hello world"
+				if x == "o"
+					break
+				end
+			end
+			x = x
+			`,
+			wantStackTop: makeValue(t, "o"),
+		},
+		{
+			name: "for break stack reset",
+			input: `x := ""
+			for x := range "hello world"
+				if x == "o"
+					break
+				end
+			end`,
+			// The last element popped off the stack should be the string being
+			// iterated, which is the first thing pushed when compiling
+			// the for string range bytecode.
+			wantStackTop: makeValue(t, "hello world"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytecode := compileBytecode(t, tt.input)
+			vm := NewVM(bytecode)
+			err := vm.Run()
+			assert.NoError(t, err, "runtime error")
+			got := vm.lastPoppedStackElem()
+			assert.Equal(t, tt.wantStackTop, got)
+		})
+	}
+}
+
 type pair struct {
 	k string
 	v any


### PR DESCRIPTION
Add OpStepRange and OpIterRange which push the result of evaluating 
the condition of the loop onto the stack to be evaluated by OpJumpOnFalse. 
These operations update the iteration state on the stack and also push the
current value if there is a loop variable so the bytecode can assign that value
to the variable.

Co-authored-by: joshcarp <joshcarp@users.noreply.github.com>
Co-authored-by: Cam Hutchison <camh@xdna.net>