### PR TITLE
evaluator: Fix some funny names from previous refactor

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -389,8 +389,8 @@ func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (value, error) {
 	if err != nil {
 		return nil, err
 	}
-	if returnValalue, ok := funcResult.(*returnVal); ok {
-		return returnValalue.V, nil
+	if returnValue, ok := funcResult.(*returnVal); ok {
+		return returnValue.V, nil
 	}
 	return &noneVal{}, nil
 }
@@ -492,7 +492,7 @@ func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, error) {
 	case *mapVal:
 		order := make([]string, len(*v.Order))
 		copy(order, *v.Order)
-		mapRange := &mapRange{mapValal: v, cur: 0, order: order}
+		mapRange := &mapRange{mapVal: v, cur: 0, order: order}
 		if f.LoopVar != nil {
 			mapRange.loopVar = &stringVal{}
 			e.scope.set(f.LoopVar.Name, mapRange.loopVar)
@@ -503,15 +503,15 @@ func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, error) {
 }
 
 func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (ranger, error) {
-	start, err := e.numValalWithDefault(r.Start, 0.0)
+	start, err := e.numValWithDefault(r.Start, 0.0)
 	if err != nil {
 		return nil, err
 	}
-	stop, err := e.numValal(r.Stop)
+	stop, err := e.numVal(r.Stop)
 	if err != nil {
 		return nil, err
 	}
-	step, err := e.numValalWithDefault(r.Step, 1.0)
+	step, err := e.numValWithDefault(r.Step, 1.0)
 	if err != nil {
 		return nil, err
 	}
@@ -532,23 +532,23 @@ func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (rang
 	return sRange, nil
 }
 
-func (e *Evaluator) numValal(n parser.Node) (float64, error) {
+func (e *Evaluator) numVal(n parser.Node) (float64, error) {
 	v, err := e.eval(n)
 	if err != nil {
 		return 0, err
 	}
-	numValal, ok := v.(*numVal)
+	numVal, ok := v.(*numVal)
 	if !ok {
 		return 0, newErr(n, fmt.Errorf("%w: expected number, found %v", ErrType, v))
 	}
-	return numValal.V, nil
+	return numVal.V, nil
 }
 
-func (e *Evaluator) numValalWithDefault(n parser.Node, defaultVal float64) (float64, error) {
+func (e *Evaluator) numValWithDefault(n parser.Node, defaultVal float64) (float64, error) {
 	if n == nil {
 		return defaultVal, nil
 	}
-	return e.numValal(n)
+	return e.numVal(n)
 }
 
 func (e *Evaluator) evalConditionalBlock(condBlock *parser.ConditionalBlock) (value, bool, error) {

--- a/pkg/evaluator/ranger.go
+++ b/pkg/evaluator/ranger.go
@@ -18,10 +18,10 @@ type arrayRange struct {
 }
 
 type mapRange struct {
-	loopVar  value
-	cur      int // index of Map.Order slice of keys
-	mapValal *mapVal
-	order    []string // copy of order in case map entry gets deleted during iteration
+	loopVar value
+	cur     int // index of Map.Order slice of keys
+	mapVal  *mapVal
+	order   []string // copy of order in case map entry gets deleted during iteration
 }
 
 type stringRange struct {
@@ -62,7 +62,7 @@ func (m *mapRange) next() bool {
 	for m.cur < len(m.order) {
 		key := m.order[m.cur]
 		m.cur++
-		if _, ok := m.mapValal.Pairs[key]; ok { // ensure value hasn't been deleted
+		if _, ok := m.mapVal.Pairs[key]; ok { // ensure value hasn't been deleted
 			if m.loopVar != nil {
 				m.loopVar.(*stringVal).V = key
 			}


### PR DESCRIPTION
Fix some funny names - "Valal" instead of "Val". It looks like a
previous refactor that made values private was a little off in the
substitutions used to rename some vars.