### PR TITLE
parser/eval: Move StepRange defaults to parser

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -503,15 +503,15 @@ func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, error) {
 }
 
 func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (ranger, error) {
-	start, err := e.numValWithDefault(r.Start, 0.0)
+	start, err := e.evalNum(r.GetStart())
 	if err != nil {
 		return nil, err
 	}
-	stop, err := e.numVal(r.Stop)
+	stop, err := e.evalNum(r.GetStop())
 	if err != nil {
 		return nil, err
 	}
-	step, err := e.numValWithDefault(r.Step, 1.0)
+	step, err := e.evalNum(r.GetStep())
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (rang
 	return sRange, nil
 }
 
-func (e *Evaluator) numVal(n parser.Node) (float64, error) {
+func (e *Evaluator) evalNum(n parser.Node) (float64, error) {
 	v, err := e.eval(n)
 	if err != nil {
 		return 0, err
@@ -542,13 +542,6 @@ func (e *Evaluator) numVal(n parser.Node) (float64, error) {
 		return 0, newErr(n, fmt.Errorf("%w: expected number, found %v", ErrType, v))
 	}
 	return numVal.V, nil
-}
-
-func (e *Evaluator) numValWithDefault(n parser.Node, defaultVal float64) (float64, error) {
-	if n == nil {
-		return defaultVal, nil
-	}
-	return e.numVal(n)
 }
 
 func (e *Evaluator) evalConditionalBlock(condBlock *parser.ConditionalBlock) (value, bool, error) {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -883,6 +883,31 @@ func (s *StepRange) Type() *Type {
 	return NUM_TYPE
 }
 
+// GetStart returns the start value of the step range, returning the default 0
+// if s.Start == nil.
+func (s *StepRange) GetStart() Node {
+	if s.Start == nil {
+		return &NumLiteral{Value: 0}
+	}
+	return s.Start
+}
+
+// GetStop returns the stop value of the step range. This is always s.Stop as
+// there is no default for this as there is for start and step, but we have
+// this method for symmetry.
+func (s *StepRange) GetStop() Node {
+	return s.Stop
+}
+
+// GetStep returns the step value of the step range, returning the default 1
+// if s.Step == nil.
+func (s *StepRange) GetStep() Node {
+	if s.Step == nil {
+		return &NumLiteral{Value: 1}
+	}
+	return s.Step
+}
+
 // Var is an AST node that represents a variable, its name and type but
 // not its value.
 //


### PR DESCRIPTION
Add methods to `StepRange` to return the start, stop and step values,
returning the default value (as a `NumLiteral`) if the value wanted is a
default value (0 for start and 1 for step). Update the evaluator to use
these methods instead of deciding the defaults for itself.

This puts the defaults in one place for when there are multiple
consumers of the AST; the evaluator and the bytecode compiler.
