### PR TITLE
bytecode: Remove bytecode test assertions

### DIFF
--- a/pkg/bytecode/vm_test.go
+++ b/pkg/bytecode/vm_test.go
@@ -15,8 +15,6 @@ type testCase struct {
 	input string
 	// wantStackTop is the expected last popped element of the stack in the vm.
 	wantStackTop value
-	// wantBytecode is the bytecode expected from the compiler.
-	wantBytecode *Bytecode
 }
 
 func TestVMGlobals(t *testing.T) {
@@ -25,13 +23,6 @@ func TestVMGlobals(t *testing.T) {
 			name:         "inferred declaration",
 			input:        "x := 1",
 			wantStackTop: makeValue(t, 1),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "assignment",
@@ -40,25 +31,6 @@ func TestVMGlobals(t *testing.T) {
 			y = x + 1
 			y = y`,
 			wantStackTop: makeValue(t, 2),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 1),
-				Instructions: makeInstructions(
-					// x := 1
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					// y := x
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 1),
-					// y = x + 1
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpAdd),
-					mustMake(t, OpSetGlobal, 1),
-					// y = y
-					mustMake(t, OpGetGlobal, 1),
-					mustMake(t, OpSetGlobal, 1),
-				),
-			},
 		},
 		{
 			name: "index assignment",
@@ -67,34 +39,6 @@ func TestVMGlobals(t *testing.T) {
 			x[2] = 1
 			x = x`,
 			wantStackTop: makeValue(t, []any{3, 2, 1}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 2, 0, 1, 2),
-				Instructions: makeInstructions(
-					// x := [1 2 3]
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpSetGlobal, 0),
-					// x[2]
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpIndex),
-					// x[0]
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpSetIndex),
-					// 1
-					mustMake(t, OpConstant, 5),
-					// x[2]
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 6),
-					mustMake(t, OpSetIndex),
-					// x = x
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "nested index assignment",
@@ -102,40 +46,11 @@ func TestVMGlobals(t *testing.T) {
 			x[0][0] = x[0][1]
 			x = x`,
 			wantStackTop: makeValue(t, []any{[]any{2, 2}, []any{3, 4}}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 4, 0, 1, 0, 0),
-				Instructions: makeInstructions(
-					// x := [[1 2] [3 4]]
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpSetGlobal, 0),
-					// x[0][0] = x[0][1]
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpIndex),
-					mustMake(t, OpConstant, 5),
-					mustMake(t, OpIndex),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 6),
-					mustMake(t, OpIndex),
-					mustMake(t, OpConstant, 7),
-					mustMake(t, OpSetIndex),
-					// x = x
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -179,65 +94,31 @@ func TestBoolExpressions(t *testing.T) {
 			name:         "literal true",
 			input:        "x := true",
 			wantStackTop: makeValue(t, true),
-			wantBytecode: &Bytecode{
-				Instructions: makeInstructions(
-					mustMake(t, OpTrue),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
-		}, {
+		},
+		{
 			name:         "literal false",
 			input:        "x := false",
 			wantStackTop: makeValue(t, false),
-			wantBytecode: &Bytecode{
-				Instructions: makeInstructions(
-					mustMake(t, OpFalse),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
-		}, {
+		},
+		{
 			name:         "not operator",
 			input:        "x := !true",
 			wantStackTop: makeValue(t, false),
-			wantBytecode: &Bytecode{
-				Instructions: makeInstructions(
-					mustMake(t, OpTrue),
-					mustMake(t, OpNot),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
-		}, {
+		},
+		{
 			name:         "equal operator",
 			input:        "x := 1 == 1",
 			wantStackTop: makeValue(t, true),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpEqual),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
-		}, {
+		},
+		{
 			name:         "not operator",
 			input:        "x := 1 != 1",
 			wantStackTop: makeValue(t, false),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNotEqual),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -254,204 +135,71 @@ func TestNumOperations(t *testing.T) {
 			name:         "addition",
 			input:        "x := 2 + 1",
 			wantStackTop: makeValue(t, 3),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 2, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpAdd),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "subtraction",
 			input:        "x := 2 - 1",
 			wantStackTop: makeValue(t, 1),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 2, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpSubtract),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "multiplication",
 			input:        "x := 2 * 1",
 			wantStackTop: makeValue(t, 2),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 2, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpMultiply),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "division",
 			input:        "x := 2 / 1",
 			wantStackTop: makeValue(t, 2),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 2, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpDivide),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "modulo",
 			input:        "x := 2 % 1",
 			wantStackTop: makeValue(t, 0),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 2, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpModulo),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "float modulo",
 			input:        "x := 2.5 % 1.3",
 			wantStackTop: makeValue(t, 1.2),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 2.5, 1.3),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpModulo),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "minus operator",
 			input:        "x := -1",
 			wantStackTop: makeValue(t, -1),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpMinus),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "all operators",
 			input:        "x := 1 + 2 - 3 * 4 / 5 % 6",
 			wantStackTop: makeValue(t, 1+2-math.Mod(3.0*4.0/5.0, 6.0)),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 4, 5, 6),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpAdd),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpMultiply),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpDivide),
-					mustMake(t, OpConstant, 5),
-					mustMake(t, OpModulo),
-					mustMake(t, OpSubtract),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "grouped expressions",
 			input:        "x := (1 + 2 - 3) * 4 / 5 % 6",
 			wantStackTop: makeValue(t, (1+2-3)*4/math.Mod(5.0, 6.0)),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 4, 5, 6),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpAdd),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpSubtract),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpMultiply),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpDivide),
-					mustMake(t, OpConstant, 5),
-					mustMake(t, OpModulo),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "less than",
 			input:        "x := 1 < 2",
 			wantStackTop: makeValue(t, true),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumLessThan),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "less than or equal",
 			input:        "x := 1 <= 2",
 			wantStackTop: makeValue(t, true),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumLessThanEqual),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "greater than",
 			input:        "x := 1 > 2",
 			wantStackTop: makeValue(t, false),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumGreaterThan),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "greater than or equal",
 			input:        "x := 1 >= 2",
 			wantStackTop: makeValue(t, false),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumGreaterThanEqual),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -467,195 +215,71 @@ func TestStringExpressions(t *testing.T) {
 			name:         "assignment",
 			input:        `x := "a"`,
 			wantStackTop: makeValue(t, "a"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a"),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "concatenate",
 			input:        `x := "a" + "b"`,
 			wantStackTop: makeValue(t, "ab"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a", "b"),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpStringConcatenate),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "less than",
 			input:        `x := "a" < "b"`,
 			wantStackTop: makeValue(t, true),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a", "b"),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpStringLessThan),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "less than or equal",
 			input:        `x := "a" <= "b"`,
 			wantStackTop: makeValue(t, true),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a", "b"),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpStringLessThanEqual),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "greater than",
 			input:        `x := "a" > "b"`,
 			wantStackTop: makeValue(t, false),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a", "b"),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpStringGreaterThan),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "greater than or equal",
 			input:        `x := "a" >= "b"`,
 			wantStackTop: makeValue(t, false),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a", "b"),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpStringGreaterThanEqual),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "index",
 			input:        `x := "abc"[0]`,
 			wantStackTop: makeValue(t, "a"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "abc", 0),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpIndex),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "negative index",
 			input:        `x := "abc"[-1]`,
 			wantStackTop: makeValue(t, "c"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "abc", 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpMinus),
-					mustMake(t, OpIndex),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice",
 			input:        `x := "abc"[1:3]`,
 			wantStackTop: makeValue(t, "bc"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "abc", 1, 3),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "negative slice",
 			input:        `x := "abc"[-3:-1]`,
 			wantStackTop: makeValue(t, "ab"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "abc", 3, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpMinus),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpMinus),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice default start",
 			input:        `x := "abc"[:1]`,
 			wantStackTop: makeValue(t, "a"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "abc", 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpNone),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice default end",
 			input:        `x := "abc"[1:]`,
 			wantStackTop: makeValue(t, "bc"),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "abc", 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNone),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice start equals length",
 			input:        `x := "abc"[3:]`,
 			wantStackTop: makeValue(t, ""),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "abc", 3),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNone),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -665,85 +289,32 @@ func TestStringExpressions(t *testing.T) {
 	}
 }
 
-//nolint:maintidx // This function is not complex by any measure.
 func TestArrays(t *testing.T) {
 	tests := []testCase{
 		{
 			name:         "empty assignment",
 			input:        "x := []",
 			wantStackTop: makeValue(t, []any{}),
-			wantBytecode: &Bytecode{
-				Constants: nil,
-				Instructions: makeInstructions(
-					mustMake(t, OpArray, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "assignment",
 			input:        "x := [1 2 3]",
 			wantStackTop: makeValue(t, []any{1, 2, 3}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "concatenate",
 			input:        "x := [1 2] + [3 4]",
 			wantStackTop: makeValue(t, []any{1, 2, 3, 4}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 4),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpArrayConcatenate),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "repetition",
 			input:        `x := [1 2] * 3`,
 			wantStackTop: makeValue(t, []any{1, 2, 1, 2, 1, 2}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArrayRepeat),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "zero repetition",
 			input:        `x := [1 2] * 0`,
 			wantStackTop: makeValue(t, []any{}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 0),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArrayRepeat),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "concatenate preserve original",
@@ -752,152 +323,41 @@ func TestArrays(t *testing.T) {
 			y = x + y
 			x = x`,
 			wantStackTop: makeValue(t, []any{1, 2}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 4),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpArray, 2),
-					mustMake(t, OpSetGlobal, 1),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpGetGlobal, 1),
-					mustMake(t, OpArrayConcatenate),
-					mustMake(t, OpSetGlobal, 1),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "index",
 			input:        `x := [1 2 3][0]`,
 			wantStackTop: makeValue(t, 1),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 0),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpIndex),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "negative index",
 			input:        `x := [1 2 3][-1]`,
 			wantStackTop: makeValue(t, 3),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpMinus),
-					mustMake(t, OpIndex),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice",
 			input:        `x := [1 2 3][1:3]`,
 			wantStackTop: makeValue(t, []any{2, 3}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 1, 3),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "negative slice",
 			input:        `x := [1 2 3][-3:-1]`,
 			wantStackTop: makeValue(t, []any{1, 2}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 3, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpMinus),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpMinus),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice default start",
 			input:        `x := [1 2 3][:1]`,
 			wantStackTop: makeValue(t, []any{1}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpNone),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice default end",
 			input:        `x := [1 2 3][1:]`,
 			wantStackTop: makeValue(t, []any{2, 3}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpNone),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "slice start equals length",
 			input:        `x := [1 2 3][3:]`,
 			wantStackTop: makeValue(t, []any{}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 3),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpNone),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "slice preserve original",
@@ -906,37 +366,11 @@ func TestArrays(t *testing.T) {
 			y[0] = 8
 			x = x`,
 			wantStackTop: makeValue(t, []any{1, 2, 3}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 1, 8, 0),
-				Instructions: makeInstructions(
-					// x := [1 2 3]
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpArray, 3),
-					mustMake(t, OpSetGlobal, 0),
-					// y := x[1:]
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpNone),
-					mustMake(t, OpSlice),
-					mustMake(t, OpSetGlobal, 1),
-					// y[0] = 8
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpGetGlobal, 1),
-					mustMake(t, OpConstant, 5),
-					mustMake(t, OpSetIndex),
-					// x = x
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -1064,53 +498,21 @@ func TestMap(t *testing.T) {
 			name:         "empty",
 			input:        "x := {}",
 			wantStackTop: makeValue(t, map[string]any{}),
-			wantBytecode: &Bytecode{
-				Constants: nil,
-				Instructions: makeInstructions(
-					mustMake(t, OpMap, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "assignment",
 			input:        "x := {a: 1 b: 2}",
 			wantStackTop: makeValue(t, map[string]any{"a": 1, "b": 2}),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a", 1, "b", 2),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpMap, 4),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name:         "index",
 			input:        `x := {a: 1 b: 2}["b"]`,
 			wantStackTop: makeValue(t, 2),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, "a", 1, "b", 2, "b"),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpMap, 4),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpIndex),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -1137,20 +539,6 @@ func TestIf(t *testing.T) {
 				x = 2
 			end`,
 			wantStackTop: makeValue(t, 2),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 1, 2),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpEqual),
-					mustMake(t, OpJumpOnFalse, 25),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 25),
-				),
-			},
 		},
 		{
 			name: "if else",
@@ -1161,22 +549,6 @@ func TestIf(t *testing.T) {
 				x = 5
 			end`,
 			wantStackTop: makeValue(t, 5),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 10, 5, 20, 5),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumLessThan),
-					mustMake(t, OpJumpOnFalse, 25),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 31),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "else if else",
@@ -1189,29 +561,6 @@ func TestIf(t *testing.T) {
 				x = 1
 			end`,
 			wantStackTop: makeValue(t, 5),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 10, 10, 10, 5, 5, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumGreaterThan),
-					mustMake(t, OpJumpOnFalse, 25),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 50),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpNumGreaterThan),
-					mustMake(t, OpJumpOnFalse, 44),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 50),
-					mustMake(t, OpConstant, 5),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "many elseif",
@@ -1226,36 +575,6 @@ func TestIf(t *testing.T) {
 					x = 14
 				end`,
 			wantStackTop: makeValue(t, 13),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 3, 1, 11, 2, 12, 3, 13, 14),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpEqual),
-					mustMake(t, OpJumpOnFalse, 25),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 69),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpEqual),
-					mustMake(t, OpJumpOnFalse, 44),
-					mustMake(t, OpConstant, 4),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 69),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 5),
-					mustMake(t, OpEqual),
-					mustMake(t, OpJumpOnFalse, 63),
-					mustMake(t, OpConstant, 6),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 69),
-					mustMake(t, OpConstant, 7),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "no matching if",
@@ -1269,36 +588,11 @@ func TestIf(t *testing.T) {
 			end
 			x = x`,
 			wantStackTop: makeValue(t, 1),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 1, 2, 3, 4),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpFalse),
-					mustMake(t, OpJumpOnFalse, 19),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 45),
-					mustMake(t, OpFalse),
-					mustMake(t, OpJumpOnFalse, 32),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 45),
-					mustMake(t, OpFalse),
-					mustMake(t, OpJumpOnFalse, 45),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 45),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -1318,24 +612,6 @@ func TestWhile(t *testing.T) {
 			end
 			x = x`,
 			wantStackTop: makeValue(t, 5),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 0, 5, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumLessThan),
-					mustMake(t, OpJumpOnFalse, 29),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpAdd),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 6),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "skip loop",
@@ -1345,24 +621,6 @@ func TestWhile(t *testing.T) {
 			end
 			x = x`,
 			wantStackTop: makeValue(t, 0),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 0, 5, 1),
-				Instructions: makeInstructions(
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumGreaterThan),
-					mustMake(t, OpJumpOnFalse, 29),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpAdd),
-					mustMake(t, OpSetGlobal, 0),
-					mustMake(t, OpJump, 6),
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "break loop",
@@ -1375,38 +633,6 @@ func TestWhile(t *testing.T) {
 			end
 			x = x`,
 			wantStackTop: makeValue(t, 3),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 0, 5, 1, 3),
-				Instructions: makeInstructions(
-					// x := 0
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					// while x < 5
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpNumLessThan),
-					mustMake(t, OpJumpOnFalse, 45),
-					// 		x = x + 1
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 2),
-					mustMake(t, OpAdd),
-					mustMake(t, OpSetGlobal, 0),
-					// 		if x == 3
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 3),
-					mustMake(t, OpEqual),
-					mustMake(t, OpJumpOnFalse, 42),
-					// 			break
-					mustMake(t, OpJump, 45),
-					// 		end
-					mustMake(t, OpJump, 42),
-					// end
-					mustMake(t, OpJump, 6),
-					// x = x
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 		{
 			name: "nested loops and breaks",
@@ -1421,42 +647,11 @@ func TestWhile(t *testing.T) {
 			end
 			x = x`,
 			wantStackTop: makeValue(t, 1),
-			wantBytecode: &Bytecode{
-				Constants: makeValues(t, 0, 1),
-				Instructions: makeInstructions(
-					// x := 0
-					mustMake(t, OpConstant, 0),
-					mustMake(t, OpSetGlobal, 0),
-					// while true
-					mustMake(t, OpTrue),
-					mustMake(t, OpJumpOnFalse, 36),
-					// 		while true
-					mustMake(t, OpTrue),
-					mustMake(t, OpJumpOnFalse, 20),
-					// 			break
-					mustMake(t, OpJump, 20),
-					// 		end
-					mustMake(t, OpJump, 10),
-					// 		x = x + 1
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpConstant, 1),
-					mustMake(t, OpAdd),
-					mustMake(t, OpSetGlobal, 0),
-					// 		break
-					mustMake(t, OpJump, 36),
-					// end
-					mustMake(t, OpJump, 6),
-					// x = x
-					mustMake(t, OpGetGlobal, 0),
-					mustMake(t, OpSetGlobal, 0),
-				),
-			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bytecode := compileBytecode(t, tt.input)
-			assertBytecode(t, tt.wantBytecode, bytecode)
 			vm := NewVM(bytecode)
 			err := vm.Run()
 			assert.NoError(t, err, "runtime error")
@@ -1513,18 +708,4 @@ func makeValues(t *testing.T, in ...any) []value {
 		out[i] = makeValue(t, a)
 	}
 	return out
-}
-
-func makeInstructions(in ...Instructions) Instructions {
-	out := Instructions{}
-	for _, instruction := range in {
-		out = append(out, instruction...)
-	}
-	return out
-}
-
-func assertBytecode(t *testing.T, want, got *Bytecode) {
-	t.Helper()
-	msg := "\nwant instructions:\n%s\ngot instructions:\n%s"
-	assert.Equal(t, want, got, msg, want.Instructions, got.Instructions)
 }


### PR DESCRIPTION
These assertions are proving laborious to write as the tests in
this package grow more mature and complex. The team has agreed
that since they had add little value for the effort, it is safe
to remove them.