### PR TITLE
make: Rework full and slim builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,7 @@
+builds:
+  - tags:
+      - full
+
 brews:
   - repository:
       owner: evylang

--- a/build-tools/default-embed/index.html
+++ b/build-tools/default-embed/index.html
@@ -32,8 +32,8 @@
     </p>
     <ul>
       <li><code>make release</code></li>
-      <li><code>make install</code></li>
-      <li><code>make build-go</code></li>
+      <li><code>make install-full</code></li>
+      <li><code>make build-full</code></li>
     </ul>
   </body>
 </html>

--- a/main-full.go
+++ b/main-full.go
@@ -1,0 +1,39 @@
+//go:build !tinygo && full
+
+// This file contains the embed directives of the full Evy web content used in
+// Evy releases and with the "full" build tag. It is accessed with
+//
+//	evy serve
+//
+// The default web content, initialized in main.go, is a placeholder
+// index.html with installation and build instructions for the full build.
+//
+// The full build depends on the evy.wasm file, which needs to be pre-built
+// with TinyGo. We don't track the evy.wasm binary in the evy repository and
+// its build is comparatively slow, so it's not included in the default
+// build. The evy.wasm-dependency-free default build also allows for a
+// generic go install to work with
+//
+//	go install evylang.dev/evy@latest .
+//
+// To include the full Evy web contents pre-built to the out/embed directory,
+// use the 'full' build tag:
+//
+//	go build -tags full
+//	go install -tags full
+//
+// A full clean build regenerating evy.wasm and out/embed can be executed with:
+//
+//	make build-full
+//	make install-full
+package main
+
+import "embed"
+
+//go:embed out/embed
+var fullContent embed.FS
+
+func init() {
+	content = fullContent
+	contentDir = "out/embed"
+}

--- a/main.go
+++ b/main.go
@@ -56,15 +56,23 @@ import (
 	"github.com/alecthomas/kong"
 )
 
+// Globals overridden by linker flags on release build.
 var (
-	version         = "v0.0.0"
+	version = "v0.0.0"
+)
+
+// Errors returned by the Evy tool.
+var (
 	errBadWriteFlag = errors.New("cannot use -w without files")
 	errNotFormatted = errors.New("not formatted")
 	errParse        = errors.New("parse error")
 )
 
-//go:embed out/embed
-var content embed.FS
+var (
+	//go:embed build-tools/default-embed
+	content    embed.FS
+	contentDir = "build-tools/default-embed"
+)
 
 const description = `
 evy is a tool for managing evy source code.
@@ -268,7 +276,7 @@ func (c *startCmd) rootDir() (http.FileSystem, error) {
 		dir := filepath.Join(c.Dir, c.Root)
 		return http.Dir(dir), nil
 	}
-	dir := filepath.Join("out/embed", c.Root)
+	dir := filepath.Join(contentDir, c.Root)
 	root, err := fs.Sub(content, dir)
 	if err != nil {
 		return nil, err
@@ -280,7 +288,7 @@ func (c *exportCmd) Run() error {
 	if err := validateExportDir(c.Force, c.Dir); err != nil {
 		return err
 	}
-	fsys, err := fs.Sub(content, "out/embed")
+	fsys, err := fs.Sub(content, contentDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Move the build default slim for faster builds with `go build` and also to re-enable

	go install evylang.dev/evy@latest

Embeds related to evy.wasm and full build dependency have been moved to
main-full.go which is included via the `-tags=full` flag. Update Makefile and
goreleaser config.