### PR TITLE
parser: Report error for quoted map keys

### DIFF
--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -143,7 +143,7 @@ var tokenStrings = map[TokenType]tokenString{
 	COMMENT:    {string: "COMMENT", format: ""},
 	IDENT:      {string: "IDENT", format: ""},
 	NUM_LIT:    {string: "NUM_LIT", format: ""},
-	STRING_LIT: {string: "STRING_LIT", format: "string"},
+	STRING_LIT: {string: "STRING_LIT", format: ""},
 	DECLARE:    {string: "DECLARE", format: ":="},
 	ASSIGN:     {string: "ASSIGN", format: "="},
 	PLUS:       {string: "PLUS", format: "+"},

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1473,11 +1473,9 @@ end
 
 func TestMapLitErr(t *testing.T) {
 	inputs := map[string]string{
-		`
-func fnm:{}any
-    return {a:1{b:2}}
-end
-`: `line 3 column 16: expected map key, found "{"`,
+		`print {a:1{b:2}}`:    `line 1 column 11: expected map key, found "{"`,
+		`print {"x": true}`:   `line 1 column 8: expected map key, found "x"`,
+		`print {"end": true}`: `line 1 column 8: expected map key, found "end"`,
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())


### PR DESCRIPTION
Report parse error for quoted map keys in map literals.
Before the following code did NOT report an error:

	m := {"a": true}
	print m

Now it does. The issue was that we accidentally printed `string` for string
literals in the parser which doubled up with the `string` keyword and made
AsIdent() work incorrectly for string literals which it now just passes
through.

Fixes: https://github.com/evylang/evy/issues/338