### PR TITLE
Add evy test command

### DIFF
--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -264,5 +264,5 @@ func (t *Token) Format() string {
 // Location returns a string representation of a token's start location
 // in the form of: "line <line number> column <column number>".
 func (t *Token) Location() string {
-	return "line " + strconv.Itoa(t.Line) + " column " + strconv.Itoa(t.Col)
+	return strconv.Itoa(t.Line) + ":" + strconv.Itoa(t.Col)
 }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -562,6 +562,14 @@ type FuncCall struct {
 	FuncDef   *FuncDefStmt
 }
 
+func NewFuncCallBuiltin(name string, funcdef *FuncDefStmt) *FuncCall {
+	return &FuncCall{
+		Name:    name,
+		token:   funcdef.Token(),
+		FuncDef: funcdef,
+	}
+}
+
 // String returns a string representation of the FuncCall node.
 func (f *FuncCall) String() string {
 	s := make([]string, len(f.Arguments))

--- a/test/test.evy
+++ b/test/test.evy
@@ -1,0 +1,31 @@
+func separate_paren_groups:[]string paren_string:string
+    result:[]string
+        current_string:string
+        current_depth:num
+        current_depth = 0
+
+        for c := range (len paren_string)
+            if paren_string[c] == "("
+                current_depth = current_depth + 1
+                current_string = current_string + paren_string[c]
+            else if paren_string[c] == ")"
+                current_depth = current_depth - 1
+                current_string = current_string + paren_string[c]
+
+                if current_depth == 0
+                    result = result + [current_string]
+                    current_string = ""
+                end
+            end
+        end
+
+        return result
+end
+func test
+    assertEqual ["(()())" "((()))" "()" "((())()())"] (separate_paren_groups "(()()) ((())) () ((())()())")
+    assertEqual ["()" "(())" "((()))" "(((())))"] (separate_paren_groups "() (()) ((())) (((())))")
+    assertEqual ["(()(())((())))"] (separate_paren_groups "(()(())((())))")
+    assertEqual ["()" "(())" "(()())"] (separate_paren_groups "( ) (( )) (( )( ))")
+end
+
+


### PR DESCRIPTION
Opening as draft PR incase there's any interest. I'm not looking for feedback on this PR because it's just an instrumental feature that will speed up some of the work i'm doing at the moment

- `evy test` will run any functions that start with `test` 
- adds builtin `assert` and `assertEqual` functions
- status of the asserts will be printed out on completion of the test function
- Changes the error print out to include the filename so that IDEs can link to the failing test

Motivation: I'm doing a lot of translation from other programming languages at the moment and being able to quickly test without needing to add custom `assert` functions every time is nice. 


```
$ evy test test/test.evy                         
4 of 4 asserts passed
```

```
$ evy test test/test.evy
assert failed: [() (()) (()()) ] != [() (()) (()())]
test/test.evy:24:1: 1 of 4 asserts FAILED
```
<img width="436" alt="image" src="https://github.com/evylang/evy/assets/32605850/f2b2de79-9378-44ac-b549-2a97ee609791">
