### PR TITLE
firebase: Update config to auto-redirect URLs without extension

### DIFF
--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -39,11 +39,13 @@
     },
     {
       "target": "docs",
-      "public": "public/docs"
+      "public": "public/docs",
+      "cleanUrls": true
     },
     {
       "target": "learn",
-      "public": "public/learn"
+      "public": "public/learn",
+      "cleanUrls": true
     },
     {
       "target": "play",


### PR DESCRIPTION
Update config to auto-redirect URLs without extension which so that we can optionally
refer to the spec as

	https://docs.evy.dev/spec

rather than

	https://docs.evy.dev/spec.html

Docs: https://firebase.google.com/docs/hosting/full-config#control_html_extensions

---

✅ https://docs.evy.dev/spec.html
❌ https://docs.evy.dev/spec
✅ https://evy-lang-stage-docs--344-42d1o10d.web.app/spec
✅ https://evy-lang-stage-docs--344-42d1o10d.web.app/spec.html

