### PR TITLE
docsite: Fix sidebar expansion for "cleanUrls"

### DIFF
--- a/frontend/docs/index.js
+++ b/frontend/docs/index.js
@@ -83,6 +83,9 @@ function normalizedHref() {
   if (href.endsWith("/")) {
     href = href + "index.html"
   }
+  if (!href.endsWith(".html")) {
+    href = href + ".html"
+  }
   return href + hash
 }
 


### PR DESCRIPTION
Fix sidebar expansion for "cleanUrls", which is firebase config setting that
allows to load URLs without the ".html" extension. This looks neat in the
address bar but unfortunately broke the sidebar expansion on site reload or
even navigation within the page the a different anchor/hash. With this fix we
have sidebar expand correctly with and without the cleanURL setting.

---

Note how things are broken for:
https://docs.evy.dev/builtins#program-control (sidebar not expanded)

but now works for:
https://docs.evytest.dev/builtins#program-control (sidebar expanded, manually deployed)
and the PR deployemebnt:
https://evy-lang-stage-docs--349-g58dboht.web.app/builtins#program-control