### PR TITLE
docs: Fix max reference

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -1108,13 +1108,13 @@ arguments.
 #### Example
 
 ```evy
-print (min 3 1)
+print (max 3 1)
 ```
 
 Output
 
 ```evy:output
-1
+3
 ```
 
 #### Reference

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -1476,10 +1476,10 @@ print (rand1)
         <h3><a id="max" href="#max" class="anchor">#</a><code>max</code></h3>
         <p><code>max</code> returns the greater of the two given numbers.</p>
         <h4>Example</h4>
-        <pre><code class="language-evy">print (min 3 1)
+        <pre><code class="language-evy">print (max 3 1)
 </code></pre>
         <p>Output</p>
-        <pre><code class="language-evy-output">1
+        <pre><code class="language-evy-output">3
 </code></pre>
         <h4>Reference</h4>
         <pre><code>max:num n1:num n2:num


### PR DESCRIPTION
Fix `max` reference example which had a copy-paste error showing the use of
`min`.