### PR TITLE
builtins: Add `abs` function

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -34,7 +34,7 @@ see [syntax by example](syntax_by_example.md).
 8. [**Random**](#random)  
    [rand](#rand), [rand1](#rand1)
 9. [**Math**](#math)  
-   [min](#min), [max](#max), [floor](#floor), [ceil](#ceil), [round](#round), [pow](#pow), [log](#log), [sqrt](#sqrt), [sin](#sin), [cos](#cos), [atan2](#atan2)
+   [min](#min), [max](#max), [abs](#abs), [floor](#floor), [ceil](#ceil), [round](#round), [pow](#pow), [log](#log), [sqrt](#sqrt), [sin](#sin), [cos](#cos), [atan2](#atan2)
 10. [**Graphics**](#graphics)  
     [move](#move), [line](#line), [rect](#rect), [circle](#circle), [color](#color), [colour](#colour), [width](#width), [clear](#clear), [grid](#grid), [gridn](#gridn), [poly](#poly), [ellipse](#ellipse), [stroke](#stroke), [fill](#fill), [dash](#dash), [linecap](#linecap), [text](#text), [font](#font)
 11. [**Event Handlers**](#event-handlers)  
@@ -1123,6 +1123,31 @@ Output
 
 The `max` function returns the greater of the two given number
 arguments.
+
+### `abs`
+
+`abs` returns the absolute value of a number.
+
+#### Example
+
+```evy
+print (abs 3)
+print (abs -2.5)
+```
+
+Output
+
+```evy:output
+3
+2.5
+```
+
+#### Reference
+
+    abs:num n:num
+
+The `abs` function returns the absolute value of a number, which is its
+magnitude without regard to its sign.
 
 ### `floor`
 

--- a/examples/human-eval/000.evy
+++ b/examples/human-eval/000.evy
@@ -16,13 +16,6 @@ func hasCloseElements:bool numbers:[]num threshold:num
     return false
 end
 
-func abs:num x:num
-    if x < 0
-        return -x
-    end
-    return x
-end
-
 func test
     assert true (hasCloseElements [1 2 3.9 4 5 2.2] 0.3)
     assert false (hasCloseElements [1 2 3.9 4 5 2.2] 0.05)

--- a/examples/human-eval/002.evy
+++ b/examples/human-eval/002.evy
@@ -13,13 +13,6 @@ func test
     assert true (((abs (truncateNumber (123.456 - 0.456))) < 0.000001))
 end
 
-func abs:num x:num
-    if x < 0
-        return -x
-    end
-    return x
-end
-
 // Test boilerplate
 fails := 0
 total := 0

--- a/examples/human-eval/004.evy
+++ b/examples/human-eval/004.evy
@@ -20,13 +20,6 @@ func sum:num numbers:[]num
     return total
 end
 
-func abs:num x:num
-    if x < 0
-        return -x
-    end
-    return x
-end
-
 func test
     assert true ((abs ((meanAbsoluteDeviation [1 2 3]) - 2 / 3)) < 0.000001)
     assert true ((abs ((meanAbsoluteDeviation [1 2 3 4]) - 1)) < 0.000001)

--- a/examples/human-eval/008.evy
+++ b/examples/human-eval/008.evy
@@ -20,13 +20,6 @@ func test
     assert [10 10] (sumProduct [10])
 end
 
-func abs:num x:num
-    if x < 0
-        return -x
-    end
-    return x
-end
-
 fails := 0
 total := 0
 

--- a/examples/human-eval/020.evy
+++ b/examples/human-eval/020.evy
@@ -27,13 +27,6 @@ func findClosest:[]num nums:[]num
     return result
 end
 
-func abs:num n:num
-    if n >= 0
-        return n
-    end
-    return -n
-end
-
 func test
     assert [3.9 4] (findClosest [1 2 3.9 4 5 2.2])
     assert [5 5.9] (findClosest [1 2 5.9 4 5])

--- a/examples/human-eval/116.evy
+++ b/examples/human-eval/116.evy
@@ -41,13 +41,6 @@ func binOnes:num n:num
     return result
 end
 
-func abs:num n:num
-    if n < 0
-        return -n
-    end
-    return n
-end
-
 func test
     assert [1 2 4 3 5] (binSort [1 5 2 3 4])
     assert [-4 -2 -6 -5 -3] (binSort [-2 -3 -4 -5 -6])

--- a/examples/human-eval/128.evy
+++ b/examples/human-eval/128.evy
@@ -21,13 +21,6 @@ func signedAbsSum:any nums:[]num
     return s * sum
 end
 
-func abs:num n:num
-    if n < 0
-        return -n
-    end
-    return n
-end
-
 func sign:num n:num
     if n < 0
         return -1

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -287,6 +287,9 @@
                   <a href="builtins.html#max"><code>max</code></a>
                 </li>
                 <li>
+                  <a href="builtins.html#abs"><code>abs</code></a>
+                </li>
+                <li>
                   <a href="builtins.html#floor"><code>floor</code></a>
                 </li>
                 <li>
@@ -1485,6 +1488,23 @@ print (rand1)
         <pre><code>max:num n1:num n2:num
 </code></pre>
         <p>The <code>max</code> function returns the greater of the two given number arguments.</p>
+        <h3><a id="abs" href="#abs" class="anchor">#</a><code>abs</code></h3>
+        <p><code>abs</code> returns the absolute value of a number.</p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">print (abs 3)
+print (abs -2.5)
+</code></pre>
+        <p>Output</p>
+        <pre><code class="language-evy-output">3
+2.5
+</code></pre>
+        <h4>Reference</h4>
+        <pre><code>abs:num n:num
+</code></pre>
+        <p>
+          The <code>abs</code> function returns the absolute value of a number, which is its
+          magnitude without regard to its sign.
+        </p>
         <h3><a id="floor" href="#floor" class="anchor">#</a><code>floor</code></h3>
         <p>
           <code>floor</code> returns the greatest integer value less than or equal to the given

--- a/frontend/docs/index.html
+++ b/frontend/docs/index.html
@@ -287,6 +287,9 @@
                   <a href="builtins.html#max"><code>max</code></a>
                 </li>
                 <li>
+                  <a href="builtins.html#abs"><code>abs</code></a>
+                </li>
+                <li>
                   <a href="builtins.html#floor"><code>floor</code></a>
                 </li>
                 <li>

--- a/frontend/docs/spec.html
+++ b/frontend/docs/spec.html
@@ -287,6 +287,9 @@
                   <a href="builtins.html#max"><code>max</code></a>
                 </li>
                 <li>
+                  <a href="builtins.html#abs"><code>abs</code></a>
+                </li>
+                <li>
                   <a href="builtins.html#floor"><code>floor</code></a>
                 </li>
                 <li>

--- a/frontend/docs/syntax_by_example.html
+++ b/frontend/docs/syntax_by_example.html
@@ -287,6 +287,9 @@
                   <a href="builtins.html#max"><code>max</code></a>
                 </li>
                 <li>
+                  <a href="builtins.html#abs"><code>abs</code></a>
+                </li>
+                <li>
                   <a href="builtins.html#floor"><code>floor</code></a>
                 </li>
                 <li>

--- a/frontend/docs/usage.html
+++ b/frontend/docs/usage.html
@@ -287,6 +287,9 @@
                   <a href="builtins.html#max"><code>max</code></a>
                 </li>
                 <li>
+                  <a href="builtins.html#abs"><code>abs</code></a>
+                </li>
+                <li>
                   <a href="builtins.html#floor"><code>floor</code></a>
                 </li>
                 <li>

--- a/frontend/module/highlight.js
+++ b/frontend/module/highlight.js
@@ -16,6 +16,7 @@ function escapeHTML(unsafe) {
 }
 
 const builtins = new Set([
+  "abs",
   "atan2",
   "ceil",
   "circle",

--- a/frontend/play/samples/tour/math.evy
+++ b/frontend/play/samples/tour/math.evy
@@ -6,9 +6,10 @@ print "rand 10" (rand 10)
 print
 print "min 3 2:" (min 3 2)
 print "max 3 2:" (max 3 2)
+print "abs -2.5:" (abs -2.5)
 print
 print "floor 2.6:" (floor 2.6)
-print "ceil 2.4:" (floor 2.4)
+print "ceil 2.4:" (ceil 2.4)
 print "round 2.6:" (round 2.6)
 print
 print "pow 2 3:" (pow 2 3)

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -82,6 +82,7 @@ func newBuiltins(rt Runtime) builtins {
 
 		"min":   xyRetBuiltin("min", math.Min),
 		"max":   xyRetBuiltin("max", math.Max),
+		"abs":   numRetBuiltin("abs", math.Abs),
 		"floor": numRetBuiltin("floor", math.Floor),
 		"ceil":  numRetBuiltin("ceil", math.Ceil),
 		"round": numRetBuiltin("round", math.Round),


### PR DESCRIPTION
Add `abs` function for the absolute value of a number. When converting the
human-eval samples I had to manually implement this function one too many
times.