### PR TITLE
parser: Improve error message for variadic

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -457,7 +457,7 @@ func (p *parser) parseFuncDefSignature() *FuncDefStmt {
 			fd.Params = nil
 			fd.VariadicParamType = &Type{Name: ARRAY, Sub: fd.VariadicParam.Type()}
 		} else {
-			p.appendError("invalid variadic parameter, must be used with single type")
+			p.appendError("variadic parameter cannot be used with other parameters")
 		}
 	}
 	p.assertEOL()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -277,6 +277,23 @@ fox 1 2 3`,
 	}
 }
 
+func TestVariadicFuncDefErr(t *testing.T) {
+	inputs := map[string]string{
+		`
+func fox n:num nums:num...
+  print n nums
+end
+
+fox 1 2 3`: "line 2 column 27: variadic parameter cannot be used with other parameters",
+	}
+	for input, wantErr := range inputs {
+		parser := newParser(input, testBuiltins())
+		assertParseError(t, parser, input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error())
+	}
+}
+
 func TestReturn(t *testing.T) {
 	inputs := []string{
 		`


### PR DESCRIPTION
Improve error message for invalid variadic parameters, where a non-variadic
and a variadic parameters are combined. Previously it said

	invalid variadic parameter, must be used with single type

now it says:

	variadic parameter cannot be used with other parameters