### PR TITLE
builtins: Add variadic assert command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: build-full test lint
 
 test: test-go test-tiny test-cli check-coverage
 
-lint: lint-go lint-sh check-prettier check-style check-fmt-evy
+lint: lint-go lint-sh check-prettier check-style check-fmt-evy conform
 
 ## Full clean build and up-to-date checks as run on CI
 ci: clean check-uptodate all
@@ -135,7 +135,14 @@ fmt-evy:
 check-fmt-evy:
 	go run . fmt --check $(EVY_FILES)
 
-.PHONY: check-fmt-evy fmt-evy lint-go
+## Conform runs evy over an example suite with asserts.
+conform: install
+	for n in examples/human-eval/*.evy; do \
+	  printf "%s " "$${n##*/}"; \
+	  evy run "$$n"; \
+	done
+
+.PHONY: check-fmt-evy conform fmt-evy lint-go
 
 # --- Docs ---------------------------------------------------------------------
 doc: doctest godoc toc usage

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -24,7 +24,7 @@ see [syntax by example](syntax_by_example.md).
 3. [**Map**](#map)  
    [has](#has), [del](#del)
 4. [**Program control**](#program-control)  
-   [sleep](#sleep), [exit](#exit), [panic](#panic)
+   [sleep](#sleep), [exit](#exit), [panic](#panic), [assert](#assert)
 5. [**Conversion**](#conversion)  
    [str2num](#str2num), [str2bool](#str2bool)
 6. [**Errors**](#errors)  
@@ -507,6 +507,77 @@ line 4 column 5: scale must be positive
 
 The `panic` function takes a single argument, which is the error message
 that the program will print before it terminates with exit status 1.
+
+### `assert`
+
+`assert` is used to check if a condition is true or two values – `want` and
+`got` – are the same. If the condition is not true or the two values are not
+the same, the program will print the failed assertion and terminate with exit
+status 1.
+
+`assert` optionally takes a message or a formatted message with arguments to
+print along with the failed assertion as a third and following arguments:
+
+#### Example
+
+```evy:err
+answer := 6 * 9
+assert 42 answer "answer is 42 not %v" answer
+```
+
+Output
+
+```evy:output
+❌ 1 failed assertion
+✔️ 0 passed assertions
+line 2 column 11: failed assertion: want != got: 42 != 54 (answer is 42 not 54)
+```
+
+#### Reference
+
+    assert cond:bool
+    assert want:any got:any [msg:string [argsany...]]
+
+The `assert` function takes either a single boolean argument `cond`
+and ensures it is `true`, or two arguments `want` and `got`, in that order,
+and ensures they are the same.
+
+In the case of the single argument, the argument must be of type `bool`.
+`assert` verifies that this argument has the value `true`. If `cond` is false,
+`assert` terminates the program execution and prints the failed assertion.
+
+In the case of two arguments, `want` and `got`, `assert` verifies
+the arguments are the same. If they are not the same `assert` terminates the
+program execution and prints the failed assertion.
+
+**Sameness** of `want` and `got` means either `want == got` or `want` and
+`got` are composite values, arrays or maps, containing the same values.
+`want` can be of a more _specific_ type than `got` as long as their values
+are the same. For example, the following assertion holds true even though
+`want` is of type `[][]num` and `got` is of type `[]any`.
+
+```evy
+got:[]any
+got = [[1] [2 3]]
+assert [[1] [2 3]] got
+```
+
+In the case of three arguments, the third argument is a message of type
+`string` that is printed if the assertion fails.
+
+In case of four or more arguments, the third argument is a _format string_
+with _specifiers_. The remaining arguments are the arguments are used to
+replace these specifiers, see [`sprintf`](#sprintf) for details on
+formatting. This means the following two assertions are equivalent.
+
+```evy
+val := 2
+assert 1 val "val is %v" val
+assert 1 val (sprintf "val is %v" val)
+```
+
+Using `assert` with four or more arguments is a convenience compared to adding
+an inline call to `sprintf`.
 
 ## Conversion
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,15 +57,18 @@ You can also get help for each subcommand by running it with the
     Run Evy program.
 
     Arguments:
-      [<source>]    Source file. Default stdin
+      [<source>]    Source file. Default: stdin.
 
     Flags:
-      -h, --help               Show context-sensitive help.
-      -V, --version            Print version information
+      -h, --help                    Show context-sensitive help.
+      -V, --version                 Print version information
 
-          --skip-sleep         skip evy sleep command ($EVY_SKIP_SLEEP)
-          --svg-out=FILE       output drawing to SVG file. Stdout: -.
-          --svg-style=STYLE    style of top-level SVG element.
+          --skip-sleep              Skip evy sleep command ($EVY_SKIP_SLEEP).
+          --svg-out=FILE            Output drawing to SVG file. Stdout: -.
+          --svg-style=STYLE         Style of top-level SVG element.
+      -s, --no-assertion-summary    Do not print assertion summary, only report
+                                    failed assertion(s).
+          --fail-fast               Stop execution on first failed assertion.
 
 <!-- genend -->
 
@@ -78,14 +81,14 @@ You can also get help for each subcommand by running it with the
     Format Evy files.
 
     Arguments:
-      [<files> ...]    Source files. Default stdin
+      [<files> ...]    Source files. Default: stdin.
 
     Flags:
       -h, --help       Show context-sensitive help.
       -V, --version    Print version information
 
-      -w, --write      update .evy file
-      -c, --check      check if already formatted
+      -w, --write      Update .evy file.
+      -c, --check      Check if already formatted.
 
 <!-- genend -->
 

--- a/examples/human-eval/000.evy
+++ b/examples/human-eval/000.evy
@@ -26,27 +26,4 @@ func test
     assert false (hasCloseElements [1.1 2.2 3.1 4.1 5.1] 0.5)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/001.evy
+++ b/examples/human-eval/001.evy
@@ -35,27 +35,4 @@ func test
     assert ["()" "(())" "(()())"] (separateParenGroups "( ) (( )) (( )( ))")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/002.evy
+++ b/examples/human-eval/002.evy
@@ -13,27 +13,4 @@ func test
     assert true (((abs (truncateNumber (123.456 - 0.456))) < 0.000001))
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/003.evy
+++ b/examples/human-eval/003.evy
@@ -23,27 +23,4 @@ func test
     assert true (belowZero [1 -2 2 -2 5 -5 4 -4])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/004.evy
+++ b/examples/human-eval/004.evy
@@ -26,27 +26,4 @@ func test
     assert true ((abs ((meanAbsoluteDeviation [1 2 3 4 5]) - 6 / 5)) < 0.000001)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/005.evy
+++ b/examples/human-eval/005.evy
@@ -19,27 +19,4 @@ func test
     assert [2 2 2 2 2] (intersperse [2 2 2] 2)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/006.evy
+++ b/examples/human-eval/006.evy
@@ -32,27 +32,4 @@ func test
     assert [4] (parseNestedParens "(()(())((())))")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/007.evy
+++ b/examples/human-eval/007.evy
@@ -27,27 +27,4 @@ func test
     assert ["grunt" "prune"] (filter ["grunt" "trumpet" "prune" "gruesome"] "run")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/008.evy
+++ b/examples/human-eval/008.evy
@@ -20,20 +20,4 @@ func test
     assert [10 10] (sumProduct [10])
 end
 
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if (sprintf "%v" want) != (sprintf "%v" got)
-        fails = fails + 1
-        printf "want != got:\n want: %v\n got:  %v\n" want got
-    end
-end
-
-func finished
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-finished

--- a/examples/human-eval/009.evy
+++ b/examples/human-eval/009.evy
@@ -23,27 +23,4 @@ func test
     assert [3 3 3 100 100] (rollingMax [3 2 3 100 3])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/010.evy
+++ b/examples/human-eval/010.evy
@@ -39,27 +39,4 @@ func test
     assert "jerryrrej" (makePalindrome "jerry")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/011.evy
+++ b/examples/human-eval/011.evy
@@ -19,27 +19,4 @@ func test
     assert "0101" (stringXor "0101" "0000")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/012.evy
+++ b/examples/human-eval/012.evy
@@ -28,27 +28,4 @@ func test
     assert "zzzz" (longest ["x" "yyy" "zzzz" "www" "kkkk" "abc"])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/013.evy
+++ b/examples/human-eval/013.evy
@@ -17,27 +17,4 @@ func test
     assert 12 (gcd 144 60)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/014.evy
+++ b/examples/human-eval/014.evy
@@ -16,27 +16,4 @@ func test
     assert ["W" "WW" "WWW"] (allPrefixes "WWW")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/015.evy
+++ b/examples/human-eval/015.evy
@@ -15,27 +15,4 @@ func test
     assert "0 1 2 3 4 5 6 7 8 9 10" (stringSequence 10)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/016.evy
+++ b/examples/human-eval/016.evy
@@ -18,27 +18,4 @@ func test
     assert 5 (countDistinctCharacters "Jerry jERRY JeRRRY")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/017.evy
+++ b/examples/human-eval/017.evy
@@ -34,28 +34,4 @@ func test
     assert [2 1 2 1 4 2 4 2] (parseMusic "o| .| o| .| o o| o o|")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/018.evy
+++ b/examples/human-eval/018.evy
@@ -21,28 +21,4 @@ func test
     assert 1 (findTimes "john doe" "john")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/019.evy
+++ b/examples/human-eval/019.evy
@@ -26,28 +26,4 @@ func test
     assert "zero one two three four five six" (sortNumbers "six five four three two one zero")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/020.evy
+++ b/examples/human-eval/020.evy
@@ -35,28 +35,4 @@ func test
     assert [2.2 3.1] (findClosest [1.1 2.2 3.1 4.1 5.1])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/021.evy
+++ b/examples/human-eval/021.evy
@@ -27,27 +27,4 @@ func test
     assert [0.25 0 1 0.5 0.75] (rescale_to_unit [12 11 15 13 14])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/022.evy
+++ b/examples/human-eval/022.evy
@@ -20,28 +20,4 @@ func test
     assert [3 3 3] (filterInts [3 "c" 3 3 "a" "b"])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/023.evy
+++ b/examples/human-eval/023.evy
@@ -11,28 +11,4 @@ func test
     assert 9 (strlen "asdasnakj")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/024.evy
+++ b/examples/human-eval/024.evy
@@ -17,28 +17,4 @@ func test
     assert 7 (largestDivisor 49)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/025.evy
+++ b/examples/human-eval/025.evy
@@ -33,28 +33,4 @@ func test
     assert [2 3 3] (factorize 3*2*3)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/026.evy
+++ b/examples/human-eval/026.evy
@@ -27,28 +27,4 @@ func test
     assert [1 4 5] (removeDuplicates [1 2 3 2 4 3 5])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/027.evy
+++ b/examples/human-eval/027.evy
@@ -20,28 +20,4 @@ func test
     assert "tHESE VIOLENT DELIGHTS HAVE VIOLENT ENDS" (flipCase "These violent delights have violent ends")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/028.evy
+++ b/examples/human-eval/028.evy
@@ -11,28 +11,4 @@ func test
     assert "xyzwk" (concatenate ["x" "y" "z" "w" "k"])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/029.evy
+++ b/examples/human-eval/029.evy
@@ -16,28 +16,4 @@ func test
     assert ["xxx" "xxxAAA" "xxx"] (filterByPrefix ["xxx" "asd" "xxy" "john doe" "xxxAAA" "xxx"] "xxx")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/030.evy
+++ b/examples/human-eval/030.evy
@@ -18,28 +18,4 @@ func test
     assert [] (getPositive [])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/031.evy
+++ b/examples/human-eval/031.evy
@@ -34,28 +34,4 @@ func test
     assert false (isPrime 13441*19)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/033.evy
+++ b/examples/human-eval/033.evy
@@ -45,28 +45,4 @@ func test
     assert [2 6 3 4 8 9 5 1] (sort_third [5 6 3 4 8 9 2 1])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/034.evy
+++ b/examples/human-eval/034.evy
@@ -35,28 +35,4 @@ func test
     assert [] (unique [])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/035.evy
+++ b/examples/human-eval/035.evy
@@ -16,28 +16,4 @@ func test
     assert 124 (max_element [5 3 -5 2 -3 3 9 0 124 1 -10])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/036.evy
+++ b/examples/human-eval/036.evy
@@ -30,28 +30,4 @@ func test
     assert 8026 (fizzBuzz 100000)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/037.evy
+++ b/examples/human-eval/037.evy
@@ -41,28 +41,4 @@ func test
     assert [-12 8 3 4 5 2 12 11 23 -10] (sortEven [5 8 -12 4 23 2 3 11 12 -10])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/038.evy
+++ b/examples/human-eval/038.evy
@@ -43,28 +43,4 @@ func test
     assert "abcd" (decode "bcad")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/039.evy
+++ b/examples/human-eval/039.evy
@@ -45,28 +45,4 @@ func test
     assert 433494437 (primeFib 10)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/examples/human-eval/040.evy
+++ b/examples/human-eval/040.evy
@@ -33,27 +33,4 @@ func test
 
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/041.evy
+++ b/examples/human-eval/041.evy
@@ -19,27 +19,4 @@ func test
     assert 100 (collisions 10)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/042.evy
+++ b/examples/human-eval/042.evy
@@ -15,27 +15,4 @@ func test
     assert [6 3 6 3 4 4 10 1 124] (inc [5 2 5 2 3 3 9 0 123])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/043.evy
+++ b/examples/human-eval/043.evy
@@ -30,27 +30,4 @@ func test
     assert false (sumZero [-3 9 -1 4 2 31])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/044.evy
+++ b/examples/human-eval/044.evy
@@ -28,27 +28,4 @@ func test
     end
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/045.evy
+++ b/examples/human-eval/045.evy
@@ -11,27 +11,4 @@ func test
     assert 40 (triangleArea 10 8)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/046.evy
+++ b/examples/human-eval/046.evy
@@ -23,27 +23,4 @@ func test
     assert 386 (fib4 12)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/047.evy
+++ b/examples/human-eval/047.evy
@@ -36,27 +36,4 @@ func test
     assert 7 (median [8 1 3 9 9 2 7])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/048.evy
+++ b/examples/human-eval/048.evy
@@ -23,27 +23,4 @@ func test
     assert false (isPalindrome "xywzx")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/049.evy
+++ b/examples/human-eval/049.evy
@@ -22,27 +22,4 @@ func test
     assert 3 (modpn 31 5)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/050.evy
+++ b/examples/human-eval/050.evy
@@ -30,27 +30,4 @@ func test
     assert abc (decode (encode abc))
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/051.evy
+++ b/examples/human-eval/051.evy
@@ -26,27 +26,4 @@ func test
     assert "ybcd" (removeVowels "ybcd")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/052.evy
+++ b/examples/human-eval/052.evy
@@ -19,27 +19,4 @@ func test
     assert false (below [1 8 4 10] 10)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/053.evy
+++ b/examples/human-eval/053.evy
@@ -13,27 +13,4 @@ func test
     assert 12 (add 7 5)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/054.evy
+++ b/examples/human-eval/054.evy
@@ -27,27 +27,4 @@ func test
     assert false (sameChars "aabb" "aaccc")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/055.evy
+++ b/examples/human-eval/055.evy
@@ -17,27 +17,4 @@ func test
     assert 144 (fib 12)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/056.evy
+++ b/examples/human-eval/056.evy
@@ -35,27 +35,4 @@ func test
     assert false (checkBrackets "<><><<><>><>>><>")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/057.evy
+++ b/examples/human-eval/057.evy
@@ -34,27 +34,4 @@ func test
     assert true (monotonic [9 9 9 9])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/058.evy
+++ b/examples/human-eval/058.evy
@@ -57,27 +57,4 @@ func test
     assert [] (common [4 3 2 8] [])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/059.evy
+++ b/examples/human-eval/059.evy
@@ -31,27 +31,4 @@ func test
     assert 29 (largestPrimeFactor 13195)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/060.evy
+++ b/examples/human-eval/060.evy
@@ -16,27 +16,4 @@ func test
     assert 5050 (sum 100)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/061.evy
+++ b/examples/human-eval/061.evy
@@ -34,27 +34,4 @@ func test
     assert false (checkBrackets "()()(()())()))()")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/062.evy
+++ b/examples/human-eval/062.evy
@@ -19,27 +19,4 @@ func test
     assert [] (derivative [1])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/063.evy
+++ b/examples/human-eval/063.evy
@@ -27,27 +27,4 @@ func test
     assert 927 (fib3 14)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/064.evy
+++ b/examples/human-eval/064.evy
@@ -31,27 +31,4 @@ func test
     assert 3 (vowelCount "ACEDY")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/065.evy
+++ b/examples/human-eval/065.evy
@@ -27,27 +27,4 @@ func test
     assert "11" (shift 11 101)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/066.evy
+++ b/examples/human-eval/066.evy
@@ -34,27 +34,4 @@ func test
     assert 327 (asciiSum "You arE Very Smart")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/067.evy
+++ b/examples/human-eval/067.evy
@@ -25,27 +25,4 @@ func test
     assert 19 (mangoCount "1 apples and 100 oranges" 120)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/068.evy
+++ b/examples/human-eval/068.evy
@@ -57,27 +57,4 @@ func test
     assert [] (pluck [7 9 7 1])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/069.evy
+++ b/examples/human-eval/069.evy
@@ -57,27 +57,4 @@ func test
     assert -1 (search [3 10 10 9 2])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/070.evy
+++ b/examples/human-eval/070.evy
@@ -46,27 +46,4 @@ func test
     assert [111111] (strangeSort [111111])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/071.evy
+++ b/examples/human-eval/071.evy
@@ -28,27 +28,4 @@ func test
     assert -1 (triangleArea 2 2 10)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/072.evy
+++ b/examples/human-eval/072.evy
@@ -44,27 +44,4 @@ func test
     assert true (willFly [5] 5)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/073.evy
+++ b/examples/human-eval/073.evy
@@ -29,27 +29,4 @@ func test
     assert 1 (changeSize [0 1])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/074.evy
+++ b/examples/human-eval/074.evy
@@ -31,27 +31,4 @@ func test
 
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/075.evy
+++ b/examples/human-eval/075.evy
@@ -53,27 +53,4 @@ func test
     assert true (prime3 11*13*7)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/076.evy
+++ b/examples/human-eval/076.evy
@@ -37,27 +37,4 @@ func test
     assert true (isPower 1 12)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/077.evy
+++ b/examples/human-eval/077.evy
@@ -28,27 +28,4 @@ func test
     assert false (iscube 1729)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/078.evy
+++ b/examples/human-eval/078.evy
@@ -38,27 +38,4 @@ func test
     assert 0 (hexprimes "")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/079.evy
+++ b/examples/human-eval/079.evy
@@ -33,27 +33,4 @@ func test
     assert "db1111db" (convert 15)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/080.evy
+++ b/examples/human-eval/080.evy
@@ -33,27 +33,4 @@ func test
     assert false (happy "iopaxioi")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/081.evy
+++ b/examples/human-eval/081.evy
@@ -67,27 +67,4 @@ func test
     assert ["E" "D-"] (grades [0 0.7])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/082.evy
+++ b/examples/human-eval/082.evy
@@ -37,27 +37,4 @@ func test
     assert false (primeLength "0")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/083.evy
+++ b/examples/human-eval/083.evy
@@ -15,27 +15,4 @@ func test
     assert 18000 (count1 5)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/084.evy
+++ b/examples/human-eval/084.evy
@@ -24,27 +24,4 @@ func test
     assert "10010" (solve 963)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/085.evy
+++ b/examples/human-eval/085.evy
@@ -17,27 +17,4 @@ func test
     assert 12 (add [4 4 6 8])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/086.evy
+++ b/examples/human-eval/086.evy
@@ -83,27 +83,4 @@ func test
     assert ".Hi My aemn is Meirst .Rboot How aer ?ouy" (antiShuffle "Hi. My name is Mister Robot. How are you?")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/087.evy
+++ b/examples/human-eval/087.evy
@@ -28,35 +28,12 @@ func coords:[]num m:[][]num n:num
 end
 
 func test
-    assert [[0 0] [1 4] [1 0] [2 5] [2 0]] (coords [[1 2 3 4 5 6] [1 2 3 4 1 6] [1 2 3 4 5 1]] 1)
-    assert [[0 1] [1 1] [2 1] [3 1] [4 1] [5 1]] (coords [[1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6]] 2)
-    assert [[0 0] [1 0] [2 1] [2 0] [3 2] [3 0] [4 3] [4 0] [5 4] [5 0] [6 5] [6 0]] (coords [[1 2 3 4 5 6] [1 2 3 4 5 6] [1 1 3 4 5 6] [1 2 1 4 5 6] [1 2 3 1 5 6] [1 2 3 4 1 6] [1 2 3 4 5 1]] 1)
+    assert [0 0 1 4 1 0 2 5 2 0] (coords [[1 2 3 4 5 6] [1 2 3 4 1 6] [1 2 3 4 5 1]] 1)
+    assert [0 1 1 1 2 1 3 1 4 1 5 1] (coords [[1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6] [1 2 3 4 5 6]] 2)
+    assert [0 0 1 0 2 1 2 0 3 2 3 0 4 3 4 0 5 4 5 0 6 5 6 0] (coords [[1 2 3 4 5 6] [1 2 3 4 5 6] [1 1 3 4 5 6] [1 2 1 4 5 6] [1 2 3 1 5 6] [1 2 3 4 1 6] [1 2 3 4 5 1]] 1)
     assert [] (coords [] 1)
     assert [] (coords [[1]] 2)
-    assert [[2 2]] (coords [[] [1] [1 2 3]] 3)
-end
-
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
+    assert [2 2] (coords [[] [1] [1 2 3]] 3)
 end
 
 test
-printResult

--- a/examples/human-eval/088.evy
+++ b/examples/human-eval/088.evy
@@ -41,27 +41,4 @@ func test
     assert [23 21 14 11] (sortArray [21 14 23 11])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/089.evy
+++ b/examples/human-eval/089.evy
@@ -29,27 +29,4 @@ func test
     assert "e" (encrypt "a")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/090.evy
+++ b/examples/human-eval/090.evy
@@ -42,27 +42,4 @@ func test
     assert -35 (nextSmallest [-35 34 12 -45])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/091.evy
+++ b/examples/human-eval/091.evy
@@ -39,27 +39,4 @@ func test
     assert 0 (boredoms "You and I are going for a walk")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/092.evy
+++ b/examples/human-eval/092.evy
@@ -26,27 +26,4 @@ func test
     assert true (sum 3 4 7)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/093.evy
+++ b/examples/human-eval/093.evy
@@ -30,27 +30,4 @@ func test
     assert "k dQnT kNqW wHcT Tq wRkTg" (encode "I DoNt KnOw WhAt tO WrItE")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/094.evy
+++ b/examples/human-eval/094.evy
@@ -46,27 +46,4 @@ func test
     assert 7 (largestPrimeSumOfDigits [0 8 1 2 1 7])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/095.evy
+++ b/examples/human-eval/095.evy
@@ -32,27 +32,4 @@ func test
     assert true (sameCaseKey {fruit:"Orange" taste:"Sweet"})
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/096.evy
+++ b/examples/human-eval/096.evy
@@ -42,27 +42,4 @@ func test
     assert [2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97] (primesTo 101)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/097.evy
+++ b/examples/human-eval/097.evy
@@ -25,27 +25,4 @@ func test
     assert 0 (multiply 0 0)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/098.evy
+++ b/examples/human-eval/098.evy
@@ -24,27 +24,4 @@ func test
     assert 2 (countUpper "EEEE")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" total-fails total
-end
-
 test
-printResult

--- a/examples/human-eval/099.evy
+++ b/examples/human-eval/099.evy
@@ -22,27 +22,4 @@ func test
     assert 0 (closest "0")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if wantType == "[]" or wantType == "{}" and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/100.evy
+++ b/examples/human-eval/100.evy
@@ -22,27 +22,4 @@ func test
     assert [8 10 12 14 16 18 20 22] (makePile 8)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/101.evy
+++ b/examples/human-eval/101.evy
@@ -23,27 +23,4 @@ func test
     assert ["ahmed" "gamal"] (words "ahmed     , gamal")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/102.evy
+++ b/examples/human-eval/102.evy
@@ -27,27 +27,4 @@ func test
     assert 546 (choose 546 546)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/103.evy
+++ b/examples/human-eval/103.evy
@@ -35,27 +35,4 @@ func test
     assert "0b101" (avg 5 5)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/104.evy
+++ b/examples/human-eval/104.evy
@@ -44,27 +44,4 @@ func test
     assert [31 135] (oddDigits [135 103 31])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/105.evy
+++ b/examples/human-eval/105.evy
@@ -54,27 +54,4 @@ func test
 
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/106.evy
+++ b/examples/human-eval/106.evy
@@ -28,27 +28,4 @@ func test
     assert [1 2 6] (f 3)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/107.evy
+++ b/examples/human-eval/107.evy
@@ -57,27 +57,4 @@ func test
     assert [0 1] (palindromeCount 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/108.evy
+++ b/examples/human-eval/108.evy
@@ -43,27 +43,4 @@ func test
     assert 1 (countNums [1])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/109.evy
+++ b/examples/human-eval/109.evy
@@ -45,27 +45,4 @@ func test
     assert false (sortedWithShift [2 1 3])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/110.evy
+++ b/examples/human-eval/110.evy
@@ -38,27 +38,4 @@ func test
     assert "YES" (solve [100 200] [200 200])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/111.evy
+++ b/examples/human-eval/111.evy
@@ -47,27 +47,4 @@ func test
     assert {a:1} (histogram "a")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/112.evy
+++ b/examples/human-eval/112.evy
@@ -37,27 +37,4 @@ func test
     assert ["" true] (delete "mamma" "mia")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/113.evy
+++ b/examples/human-eval/113.evy
@@ -41,27 +41,4 @@ func test
     ]
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/114.evy
+++ b/examples/human-eval/114.evy
@@ -37,27 +37,4 @@ func test
     assert -1 (minSum [1 -1])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/115.evy
+++ b/examples/human-eval/115.evy
@@ -49,27 +49,4 @@ func test
     assert 2 (lowerCount [[1 1 1 1] [1 1 1 1]] 9)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/116.evy
+++ b/examples/human-eval/116.evy
@@ -52,27 +52,4 @@ func test
     assert [2 4 8 16 32] (binSort [2 4 8 16 32])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/117.evy
+++ b/examples/human-eval/117.evy
@@ -38,27 +38,4 @@ func test
     assert ["b" "c" "d" "f"] (selectWords "a b c d e f" 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/118.evy
+++ b/examples/human-eval/118.evy
@@ -40,27 +40,4 @@ func test
     assert "o" (findVowel "Above")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/119.evy
+++ b/examples/human-eval/119.evy
@@ -48,27 +48,4 @@ func test
     assert "Yes" (matchParens [")" "("])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/120.evy
+++ b/examples/human-eval/120.evy
@@ -57,27 +57,4 @@ func test
     assert [] (maxArr [1 2 3 -23 243 -400 0] 0)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/121.evy
+++ b/examples/human-eval/121.evy
@@ -24,27 +24,4 @@ func test
     assert 3 (solve [3 13 2 9])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/122.evy
+++ b/examples/human-eval/122.evy
@@ -24,27 +24,4 @@ func test
     assert 1 (solve [1] 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/123.evy
+++ b/examples/human-eval/123.evy
@@ -55,27 +55,4 @@ func test
     assert [1] (oddCollatz 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/124.evy
+++ b/examples/human-eval/124.evy
@@ -55,27 +55,4 @@ func test
     assert false (validateDate "04-2003")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/125.evy
+++ b/examples/human-eval/125.evy
@@ -35,27 +35,4 @@ func test
     assert 0 (splitWords "")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/126.evy
+++ b/examples/human-eval/126.evy
@@ -65,27 +65,4 @@ func test
     assert true (isSorted [1 2 3 4])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/127.evy
+++ b/examples/human-eval/127.evy
@@ -46,27 +46,4 @@ func test
     assert "NO" (intersectPrime [-2 -2] [-3 -2])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/128.evy
+++ b/examples/human-eval/128.evy
@@ -42,27 +42,4 @@ func test
     assert 0 (signedAbsSum [-1 1 1 0])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/129.evy
+++ b/examples/human-eval/129.evy
@@ -70,27 +70,4 @@ func test
     assert [1 2 1 2 1 2 1 2 1 2] (minPath [[1 2] [3 4]] 10)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/130.evy
+++ b/examples/human-eval/130.evy
@@ -38,27 +38,4 @@ func test
     assert [1 3] (tri 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/131.evy
+++ b/examples/human-eval/131.evy
@@ -31,27 +31,4 @@ func test
     assert 0 (digitProd 2468)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/132.evy
+++ b/examples/human-eval/132.evy
@@ -46,27 +46,4 @@ func test
     assert false (isNested "]]]]]]]]")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/133.evy
+++ b/examples/human-eval/133.evy
@@ -31,27 +31,4 @@ func test
     assert 2 (squares [-1 1 0])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/134.evy
+++ b/examples/human-eval/134.evy
@@ -28,27 +28,4 @@ func test
     assert (checkLast "apple pi e ") false
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/135.evy
+++ b/examples/human-eval/135.evy
@@ -28,27 +28,4 @@ func test
     assert -1 (solve [])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/136.evy
+++ b/examples/human-eval/136.evy
@@ -23,42 +23,15 @@ end
 func test
     assert [false 1] (maxNegMinPos [2 4 1 3 5 7])
     assert [false 1] (maxNegMinPos [2 4 1 3 5 7 0])
-    assert (anyArr [-2 1]) (maxNegMinPos [1 3 2 4 5 6 -2])
-    assert (anyArr [-7 2]) (maxNegMinPos [4 5 3 6 2 7 -7])
-    assert (anyArr [-9 2]) (maxNegMinPos [7 3 8 4 9 2 5 -9])
-    assert (anyArr [false false]) (maxNegMinPos [])
-    assert (anyArr [false false]) (maxNegMinPos [0])
+    assert [-2 1] (maxNegMinPos [1 3 2 4 5 6 -2])
+    assert [-7 2] (maxNegMinPos [4 5 3 6 2 7 -7])
+    assert [-9 2] (maxNegMinPos [7 3 8 4 9 2 5 -9])
+    assert [false false] (maxNegMinPos [])
+    assert [false false] (maxNegMinPos [0])
     assert [-1 false] (maxNegMinPos [-1 -3 -5 -6])
     assert [-1 false] (maxNegMinPos [-1 -3 -5 -6 0])
-    assert (anyArr [-3 1]) (maxNegMinPos [-6 -4 -4 -3 1])
-    assert (anyArr [-3 1]) (maxNegMinPos [-6 -4 -4 -3 -100 1])
-end
-
-func anyArr:[]any a:[]any
-    return a
-end
-
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
+    assert [-3 1] (maxNegMinPos [-6 -4 -4 -3 1])
+    assert [-3 1] (maxNegMinPos [-6 -4 -4 -3 -100 1])
 end
 
 test
-printResult

--- a/examples/human-eval/137.evy
+++ b/examples/human-eval/137.evy
@@ -38,27 +38,4 @@ func test
     assert false (compare "1" 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/138.evy
+++ b/examples/human-eval/138.evy
@@ -18,27 +18,4 @@ func test
     assert true (isSum 16)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/139.evy
+++ b/examples/human-eval/139.evy
@@ -23,27 +23,4 @@ func test
     assert 1 (specialFact 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/140.evy
+++ b/examples/human-eval/140.evy
@@ -39,27 +39,4 @@ func test
     assert "-Exa_1_2_2_mple" (replaceSpaces "   Exa 1 2 2 mple")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/141.evy
+++ b/examples/human-eval/141.evy
@@ -61,27 +61,4 @@ func test
     assert "No" (checkFilename "s.")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/142.evy
+++ b/examples/human-eval/142.evy
@@ -36,27 +36,4 @@ func test
     assert -1448 (solve [-1 -3 17 -1 -15 13 -1 14 -14 -12 -5 14 -14 6 13 11 16 16 4 10])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/143.evy
+++ b/examples/human-eval/143.evy
@@ -45,27 +45,4 @@ func test
     assert "is" (primeWords "here is")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/144.evy
+++ b/examples/human-eval/144.evy
@@ -31,27 +31,4 @@ func test
     assert false (simplify "1/5" "1/5")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/145.evy
+++ b/examples/human-eval/145.evy
@@ -46,27 +46,4 @@ func test
     assert [-76 -21 0 4 23 6 6] (sort [0 6 6 -76 -21 23 4])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/146.evy
+++ b/examples/human-eval/146.evy
@@ -30,27 +30,4 @@ func test
     assert 0 (filter [])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/147.evy
+++ b/examples/human-eval/147.evy
@@ -33,27 +33,4 @@ func test
     assert 53361 (triples 100)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/148.evy
+++ b/examples/human-eval/148.evy
@@ -36,27 +36,4 @@ func test
     assert [] (between "Jupiter" "Makemake")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/149.evy
+++ b/examples/human-eval/149.evy
@@ -48,27 +48,4 @@ func test
     assert ["cc" "dd" "aaaa" "bbbb"] (sort ["aaaa" "bbbb" "dd" "cc"])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/150.evy
+++ b/examples/human-eval/150.evy
@@ -28,27 +28,4 @@ func test
     assert 2 (xIfPrime 2 2 0)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/151.evy
+++ b/examples/human-eval/151.evy
@@ -24,27 +24,4 @@ func test
     assert 34 (squareSum [0.2 3 5])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/152.evy
+++ b/examples/human-eval/152.evy
@@ -29,27 +29,4 @@ func test
     assert [2 0 0 1] (compare [1 2 3 5] [-1 2 3 4])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/153.evy
+++ b/examples/human-eval/153.evy
@@ -56,27 +56,4 @@ func test
     assert "Sp.671235" (strongest "Sp" ["671235" "Bb"])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/154.evy
+++ b/examples/human-eval/154.evy
@@ -26,27 +26,4 @@ func test
     assert true (contains "winemtt" "tinem")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/155.evy
+++ b/examples/human-eval/155.evy
@@ -34,27 +34,4 @@ func test
     assert [1 0] (count 0)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/156.evy
+++ b/examples/human-eval/156.evy
@@ -39,27 +39,4 @@ func test
     assert "m" (toRoman 1000)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/157.evy
+++ b/examples/human-eval/157.evy
@@ -26,27 +26,4 @@ func test
     assert false (rightAngle 2 2 10)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/158.evy
+++ b/examples/human-eval/158.evy
@@ -57,27 +57,4 @@ func test
     assert "play" (maxUniques ["play" "play" "play"])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/159.evy
+++ b/examples/human-eval/159.evy
@@ -30,27 +30,4 @@ func test
     assert [5 0] (eat 4 5 1)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/160.evy
+++ b/examples/human-eval/160.evy
@@ -66,27 +66,4 @@ func test
     assert 11 (solve ["+" "*" "+"] [1 2 3 4])
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/161.evy
+++ b/examples/human-eval/161.evy
@@ -41,27 +41,4 @@ func test
     assert "#CCC" (solve "#ccc")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/163.evy
+++ b/examples/human-eval/163.evy
@@ -21,27 +21,4 @@ func test
     assert [] (generate 17 89)
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/too-hard-for-now/162.evy
+++ b/examples/human-eval/too-hard-for-now/162.evy
@@ -15,27 +15,4 @@ func test
     assert "5f4dcc3b5aa765d61d8327deb882cf99" (toMD5 "password")
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult

--- a/examples/human-eval/too-hard-for-now/32.evy
+++ b/examples/human-eval/too-hard-for-now/32.evy
@@ -48,28 +48,4 @@ func test
     // end
 end
 
-// Test boilerplate
-fails := 0
-total := 0
-
-func assert want:any got:any
-    total = total + 1
-    if want == got
-        return
-    end
-    wantType := (typeof want)[:2]
-    gotType := (typeof got)[:2]
-    if (wantType == "[]" or wantType == "{}") and wantType == gotType and (len want) == 0 and (len got) == 0
-        return
-    end
-    fails = fails + 1
-    printf "want != got:\n want: %v\n got:  %v\n" want got
-end
-
-func printResult
-    printf "%2.f of %2.f tests passed\n" (total - fails) total
-end
-
 test
-printResult
-

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -203,6 +203,9 @@
                 <li>
                   <a href="builtins.html#panic"><code>panic</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#assert"><code>assert</code></a>
+                </li>
               </ul>
             </li>
             <li>
@@ -997,6 +1000,76 @@ end
         <p>
           The <code>panic</code> function takes a single argument, which is the error message that
           the program will print before it terminates with exit status 1.
+        </p>
+        <h3><a id="assert" href="#assert" class="anchor">#</a><code>assert</code></h3>
+        <p>
+          <code>assert</code> is used to check if a condition is true or two values –
+          <code>want</code> and <code>got</code> – are the same. If the condition is not true or the
+          two values are not the same, the program will print the failed assertion and terminate
+          with exit status 1.
+        </p>
+        <p>
+          <code>assert</code> optionally takes a message or a formatted message with arguments to
+          print along with the failed assertion as a third and following arguments:
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy-err">answer := 6 * 9
+assert 42 answer &quot;answer is 42 not %v&quot; answer
+</code></pre>
+        <p>Output</p>
+        <pre><code class="language-evy-output">❌ 1 failed assertion
+✔️ 0 passed assertions
+line 2 column 11: failed assertion: want != got: 42 != 54 (answer is 42 not 54)
+</code></pre>
+        <h4>Reference</h4>
+        <pre><code>assert cond:bool
+assert want:any got:any [msg:string [argsany...]]
+</code></pre>
+        <p>
+          The <code>assert</code> function takes either a single boolean argument
+          <code>cond</code> and ensures it is <code>true</code>, or two arguments
+          <code>want</code> and <code>got</code>, in that order, and ensures they are the same.
+        </p>
+        <p>
+          In the case of the single argument, the argument must be of type <code>bool</code>.
+          <code>assert</code> verifies that this argument has the value <code>true</code>. If
+          <code>cond</code> is false, <code>assert</code> terminates the program execution and
+          prints the failed assertion.
+        </p>
+        <p>
+          In the case of two arguments, <code>want</code> and <code>got</code>,
+          <code>assert</code> verifies the arguments are the same. If they are not the same
+          <code>assert</code> terminates the program execution and prints the failed assertion.
+        </p>
+        <p>
+          <strong>Sameness</strong> of <code>want</code> and <code>got</code> means either
+          <code>want == got</code> or <code>want</code> and <code>got</code> are composite values,
+          arrays or maps, containing the same values. <code>want</code> can be of a more
+          <em>specific</em> type than <code>got</code> as long as their values are the same. For
+          example, the following assertion holds true even though <code>want</code> is of type
+          <code>[][]num</code> and <code>got</code> is of type <code>[]any</code>.
+        </p>
+        <pre><code class="language-evy">got:[]any
+got = [[1] [2 3]]
+assert [[1] [2 3]] got
+</code></pre>
+        <p>
+          In the case of three arguments, the third argument is a message of type
+          <code>string</code> that is printed if the assertion fails.
+        </p>
+        <p>
+          In case of four or more arguments, the third argument is a <em>format string</em> with
+          <em>specifiers</em>. The remaining arguments are the arguments are used to replace these
+          specifiers, see <a href="#sprintf"><code>sprintf</code></a> for details on formatting.
+          This means the following two assertions are equivalent.
+        </p>
+        <pre><code class="language-evy">val := 2
+assert 1 val &quot;val is %v&quot; val
+assert 1 val (sprintf &quot;val is %v&quot; val)
+</code></pre>
+        <p>
+          Using <code>assert</code> with four or more arguments is a convenience compared to adding
+          an inline call to <code>sprintf</code>.
         </p>
         <h2><a id="conversion" href="#conversion" class="anchor">#</a>Conversion</h2>
         <h3><a id="str2num" href="#str2num" class="anchor">#</a><code>str2num</code></h3>

--- a/frontend/docs/index.html
+++ b/frontend/docs/index.html
@@ -203,6 +203,9 @@
                 <li>
                   <a href="builtins.html#panic"><code>panic</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#assert"><code>assert</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/docs/spec.html
+++ b/frontend/docs/spec.html
@@ -203,6 +203,9 @@
                 <li>
                   <a href="builtins.html#panic"><code>panic</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#assert"><code>assert</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/docs/syntax_by_example.html
+++ b/frontend/docs/syntax_by_example.html
@@ -203,6 +203,9 @@
                 <li>
                   <a href="builtins.html#panic"><code>panic</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#assert"><code>assert</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/docs/usage.html
+++ b/frontend/docs/usage.html
@@ -590,15 +590,18 @@ Run &quot;evy &lt;command&gt; --help&quot; for more information on a command.
 Run Evy program.
 
 Arguments:
-  [&lt;source&gt;]    Source file. Default stdin
+  [&lt;source&gt;]    Source file. Default: stdin.
 
 Flags:
-  -h, --help               Show context-sensitive help.
-  -V, --version            Print version information
+  -h, --help                    Show context-sensitive help.
+  -V, --version                 Print version information
 
-      --skip-sleep         skip evy sleep command ($EVY_SKIP_SLEEP)
-      --svg-out=FILE       output drawing to SVG file. Stdout: -.
-      --svg-style=STYLE    style of top-level SVG element.
+      --skip-sleep              Skip evy sleep command ($EVY_SKIP_SLEEP).
+      --svg-out=FILE            Output drawing to SVG file. Stdout: -.
+      --svg-style=STYLE         Style of top-level SVG element.
+  -s, --no-assertion-summary    Do not print assertion summary, only report
+                                failed assertion(s).
+      --fail-fast               Stop execution on first failed assertion.
 </code></pre>
         <!-- genend -->
         <h3><a id="evy-fmt-help" href="#evy-fmt-help" class="anchor">#</a>evy fmt --help</h3>
@@ -608,14 +611,14 @@ Flags:
 Format Evy files.
 
 Arguments:
-  [&lt;files&gt; ...]    Source files. Default stdin
+  [&lt;files&gt; ...]    Source files. Default: stdin.
 
 Flags:
   -h, --help       Show context-sensitive help.
   -V, --version    Print version information
 
-  -w, --write      update .evy file
-  -c, --check      check if already formatted
+  -w, --write      Update .evy file.
+  -c, --check      Check if already formatted.
 </code></pre>
         <!-- genend -->
         <h3>

--- a/frontend/docs/usage.html
+++ b/frontend/docs/usage.html
@@ -203,6 +203,9 @@
                 <li>
                   <a href="builtins.html#panic"><code>panic</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#assert"><code>assert</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/module/highlight.js
+++ b/frontend/module/highlight.js
@@ -17,6 +17,7 @@ function escapeHTML(unsafe) {
 
 const builtins = new Set([
   "abs",
+  "assert",
   "atan2",
   "ceil",
   "circle",

--- a/main.go
+++ b/main.go
@@ -98,16 +98,18 @@ func main() {
 }
 
 type runCmd struct {
-	Source    string `arg:"" help:"Source file. Default stdin" default:"-"`
-	SkipSleep bool   `help:"skip evy sleep command" env:"EVY_SKIP_SLEEP"`
-	SVGOut    string `help:"output drawing to SVG file. Stdout: -." placeholder:"FILE"`
-	SVGStyle  string `help:"style of top-level SVG element." placeholder:"STYLE"`
+	Source             string `arg:"" help:"Source file. Default: stdin." default:"-"`
+	SkipSleep          bool   `help:"Skip evy sleep command." env:"EVY_SKIP_SLEEP"`
+	SVGOut             string `help:"Output drawing to SVG file. Stdout: -." placeholder:"FILE"`
+	SVGStyle           string `help:"Style of top-level SVG element." placeholder:"STYLE"`
+	NoAssertionSummary bool   `short:"s" help:"Do not print assertion summary, only report failed assertion(s)."`
+	FailFast           bool   `help:"Stop execution on first failed assertion."`
 }
 
 type fmtCmd struct {
-	Write bool     `short:"w" help:"update .evy file" xor:"mode"`
-	Check bool     `short:"c" help:"check if already formatted" xor:"mode"`
-	Files []string `arg:"" optional:"" help:"Source files. Default stdin"`
+	Write bool     `short:"w" help:"Update .evy file." xor:"mode"`
+	Check bool     `short:"c" help:"Check if already formatted." xor:"mode"`
+	Files []string `arg:"" optional:"" help:"Source files. Default: stdin."`
 }
 
 type serveCmd struct {
@@ -128,11 +130,11 @@ type startCmd struct {
 }
 
 type tokenizeCmd struct {
-	Source string `arg:"" help:"Source file. Default stdin" default:"-"`
+	Source string `arg:"" help:"Source file. Default: stdin" default:"-"`
 }
 
 type parseCmd struct {
-	Source string `arg:"" help:"Source file. Default stdin" default:"-"`
+	Source string `arg:"" help:"Source file. Default: stdin" default:"-"`
 }
 
 // Run implements the `evy run` CLI command, called by the Kong API.
@@ -145,6 +147,8 @@ func (c *runCmd) Run() error {
 	rt := cli.NewRuntime(c.runtimeOptions()...)
 
 	eval := evaluator.NewEvaluator(rt)
+	eval.AssertInfo.NoAssertionSummary = c.NoAssertionSummary
+	eval.AssertInfo.FailFast = c.FailFast
 	evyErr := eval.Run(string(b))
 	if !errors.As(evyErr, &parser.Errors{}) {
 		// even if there was an evaluator error, we want to write as much of the SVG that was produced.

--- a/pkg/evaluator/assertinfo.go
+++ b/pkg/evaluator/assertinfo.go
@@ -1,0 +1,50 @@
+package evaluator
+
+import "strconv"
+
+// AssertInfo contains flags for test runs, e.g. FailFast and testResult
+// information, e.g. total count.
+type AssertInfo struct {
+	FailFast           bool
+	NoAssertionSummary bool
+
+	errors []error
+	total  int
+}
+
+// FailCount returns the number of failed assertions.
+func (a *AssertInfo) FailCount() int {
+	return len(a.errors)
+}
+
+// SuccessCount returns the number of successful assertions.
+func (a *AssertInfo) SuccessCount() int {
+	return a.total - len(a.errors)
+}
+
+// TotalCount returns the total number of assertions executed.
+func (a *AssertInfo) TotalCount() int {
+	return a.total
+}
+
+// Report prints a summary of the test results.
+func (a *AssertInfo) Report(printFn func(string)) {
+	if a.NoAssertionSummary || a.TotalCount() == 0 {
+		return
+	}
+	succs := a.SuccessCount()
+	fails := a.FailCount()
+	if fails > 0 {
+		printFn("❌ " + strconv.Itoa(fails) + " failed assertion" + suffix(fails) + "\n" +
+			"✔️ " + strconv.Itoa(succs) + " passed assertion" + suffix(succs) + "\n")
+	} else {
+		printFn("✅ " + strconv.Itoa(succs) + " passed assertion" + suffix(succs) + "\n")
+	}
+}
+
+func suffix(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}


### PR DESCRIPTION
Add variadic assert command such that all of the following are passing assertions

	assert true
	assert 1==1
	assert 1 1
	assert "abc" "abc" "comparing words"

Implement it as builtin in the evaluator package so that it can be used via an
`evy test` command in a follow up commit.

Add test reporting at the end of the program evaluation, if TestInfo.Reporting
isn't set to NoReporting and there are calls to assert.

Document it all.

Add examples/human-eval as initial conformance test suite to the Makefile
under make target `conform`.

Fixes: https://github.com/evylang/todo/issues/103
Related-PR: https://github.com/evylang/evy/pull/341

---

Can be tested in the playground :)