### PR TITLE
builtins: Change the hsl function to return a string

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -1560,15 +1560,15 @@ does not change. The initial color is `"black"`.
 
 ### `hsl`
 
-`hsl` changes the color of the pen, similar to [`color`](#color). However, the
-arguments to the `hsl` function are provided as numbers and therefore are
-more suited to mathematical manipulation, e.g. to find the complimentary
-color, create a trail in animations with the alpha value or create color
-gradients.
+`hsl` returns a string to be used with the [`color`](#color) and
+[`clear`](#clear) functions. The arguments to the `hsl` function are numbers
+and therefore are more suited to mathematical manipulation, e.g. to find the
+complimentary color, create a trail in animations with the alpha value or
+create color gradients.
 
-`hsl` uses the CSS (Cascading Style Sheets) [hsl function] to specify the
-color. In Evy the `hsl` function takes one to four arguments: `hue`,
-`saturation`, `lightness`, and `alpha`.
+`hsl` takes one to four arguments - `hue`, `saturation`, `lightness`, and
+`alpha` - and returns a [CSS (Cascading Style Sheets) hsl function] string
+specifying a color.
 
 The `hue` argument is required. It is a number from 0 to 360 that represents
 the color on the [color wheel]:
@@ -1589,14 +1589,14 @@ range between 0 and 100 percent if given:
 - `lightness` is measure for brightness with 100 meaning white and 0 meaning black (default: 50)
 - `alpha` is measure for opacity or transparency with 100 meaning fully opaque and 0 meaning fully transparent (default: 100)
 
-[hsl function]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
+[CSS (Cascading Style Sheets) hsl function]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
 [color wheel]: https://www.joshwcomeau.com/css/color-formats/#hsl-4
 
 #### Example
 
 ```evy
 for i := range 360
-    hsl i
+    color (hsl i)
     move i/3.6 0
     rect 1/3.6 100
 end
@@ -1608,13 +1608,16 @@ Output
 
 #### Reference
 
-    hsl hue:num [saturation:num [lightness:num [alpha:num]]]
+    hsl:string hue:num [saturation:num [lightness:num [alpha:num]]]
 
-The `hsl` function changes the color of the **stroke** and the **fill** to the
-given CSS hsl color. The `hue` value must be between 0 and 360. The
-`saturation`, `lightness` and `alpha` values must be between 0 and 100. See
-the Mozilla Developer documentation on the [CSS hsl function] for more
-details.
+`hsl` returns a string to be used with the [`color`](#color) and
+[`clear`](#clear) functions. `hsl` takes one to four `num` arguments - `hue`,
+`saturation`, `lightness`, and `alpha` - and returns `string` containing a
+[CSS hsl function] string.
+
+The `hue` value must be between 0 and 360. The `saturation`, `lightness` and
+`alpha` values must be between 0 and 100. See the Mozilla Developer
+documentation on the [CSS hsl function] for more details.
 
 [CSS hsl function]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
 

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -1842,19 +1842,20 @@ rect 20 20
         </p>
         <h3><a id="hsl" href="#hsl" class="anchor">#</a><code>hsl</code></h3>
         <p>
-          <code>hsl</code> changes the color of the pen, similar to
-          <a href="#color"><code>color</code></a
-          >. However, the arguments to the <code>hsl</code> function are provided as numbers and
-          therefore are more suited to mathematical manipulation, e.g. to find the complimentary
-          color, create a trail in animations with the alpha value or create color gradients.
+          <code>hsl</code> returns a string to be used with the
+          <a href="#color"><code>color</code></a> and
+          <a href="#clear"><code>clear</code></a> functions. The arguments to the
+          <code>hsl</code> function are numbers and therefore are more suited to mathematical
+          manipulation, e.g. to find the complimentary color, create a trail in animations with the
+          alpha value or create color gradients.
         </p>
         <p>
-          <code>hsl</code> uses the CSS (Cascading Style Sheets)
+          <code>hsl</code> takes one to four arguments - <code>hue</code>, <code>saturation</code>,
+          <code>lightness</code>, and <code>alpha</code> - and returns a
           <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl"
-            >hsl function</a
+            >CSS (Cascading Style Sheets) hsl function</a
           >
-          to specify the color. In Evy the <code>hsl</code> function takes one to four arguments:
-          <code>hue</code>, <code>saturation</code>, <code>lightness</code>, and <code>alpha</code>.
+          string specifying a color.
         </p>
         <p>
           The <code>hue</code> argument is required. It is a number from 0 to 360 that represents
@@ -1922,7 +1923,7 @@ rect 20 20
         </ul>
         <h4>Example</h4>
         <pre><code class="language-evy">for i := range 360
-    hsl i
+    color (hsl i)
     move i/3.6 0
     rect 1/3.6 100
 end
@@ -1934,14 +1935,24 @@ end
           src="img/gradient.png"
         />
         <h4>Reference</h4>
-        <pre><code>hsl hue:num [saturation:num [lightness:num [alpha:num]]]
+        <pre><code>hsl:string hue:num [saturation:num [lightness:num [alpha:num]]]
 </code></pre>
         <p>
-          The <code>hsl</code> function changes the color of the <strong>stroke</strong> and the
-          <strong>fill</strong> to the given CSS hsl color. The <code>hue</code> value must be
-          between 0 and 360. The <code>saturation</code>, <code>lightness</code> and
-          <code>alpha</code> values must be between 0 and 100. See the Mozilla Developer
-          documentation on the
+          <code>hsl</code> returns a string to be used with the
+          <a href="#color"><code>color</code></a> and
+          <a href="#clear"><code>clear</code></a> functions. <code>hsl</code> takes one to four
+          <code>num</code> arguments - <code>hue</code>, <code>saturation</code>,
+          <code>lightness</code>, and <code>alpha</code> - and returns
+          <code>string</code> containing a
+          <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl"
+            >CSS hsl function</a
+          >
+          string.
+        </p>
+        <p>
+          The <code>hue</code> value must be between 0 and 360. The <code>saturation</code>,
+          <code>lightness</code> and <code>alpha</code> values must be between 0 and 100. See the
+          Mozilla Developer documentation on the
           <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl"
             >CSS hsl function</a
           >

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -101,7 +101,7 @@ func newBuiltins(rt Runtime) builtins {
 		"width":  numBuiltin("width", rt.Width),
 		"color":  stringBuiltin("color", rt.Color),
 		"colour": stringBuiltin("colour", rt.Color),
-		"hsl":    {Func: hslFunc(rt.Color), Decl: hslDecl},
+		"hsl":    {Func: hslFunc(), Decl: hslDecl},
 
 		"clear": {Func: clearFunc(rt.Clear), Decl: clearDecl},
 		"grid":  {Func: gridFunc(rt.Gridn), Decl: emptyDecl("grid")},
@@ -546,10 +546,10 @@ func rand1Func(_ *scope, _ []value) (value, error) {
 var hslDecl = &parser.FuncDefStmt{
 	Name:          "hsl",
 	VariadicParam: &parser.Var{Name: "n", T: parser.NUM_TYPE},
-	ReturnType:    parser.NONE_TYPE,
+	ReturnType:    parser.STRING_TYPE,
 }
 
-func hslFunc(colorFn func(string)) builtinFunc {
+func hslFunc() builtinFunc {
 	return func(_ *scope, args []value) (value, error) {
 		if len(args) < 1 || len(args) > 4 {
 			return nil, fmt.Errorf(`%w: "hsl" takes 1 to 4 num arguments`, ErrBadArguments)
@@ -580,8 +580,7 @@ func hslFunc(colorFn func(string)) builtinFunc {
 			}
 		}
 		color := fmt.Sprintf("hsl(%vdeg %v%% %v%% / %v%%)", hue, saturation, lightness, alpha)
-		colorFn(color)
-		return &noneVal{}, nil
+		return &stringVal{V: color}, nil
 	}
 }
 


### PR DESCRIPTION
Change the `hsl` function to return a string so that it can be used with the
`color` or the `clear` function.

---
https://evy-lang-stage-play--356-kmaciv5o.web.app/#content=H4sIAAAAAAAAE0vLL1LIVLCyVShKzEtPVTA2M+BSUFBQSM7PyS9S0MgozlHI1ASL5OaXpSpk6hvrmSlAlBSlJpcoGIIFDA0MuFLzUrgAw9CzBU0AAAA=

