### PR TITLE
evaluator: Deep copy array repetitions

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -822,7 +822,7 @@ together. For example, `"fire"` + `"engine"` combines into the string
 
 The **repetition operator** `*`, repeats an array a number of times. The number
 must be a non-negative integer value. An array repeated zero times is an empty
-array.
+array. A deep copy is performed on the array elements before each repetition.
 
 [modulo operator]: https://en.wikipedia.org/wiki/Modulo_operation
 

--- a/frontend/docs/spec.html
+++ b/frontend/docs/spec.html
@@ -1372,7 +1372,7 @@ print 5 s[:-1]
         <p>
           The <strong>repetition operator</strong> <code>*</code>, repeats an array a number of
           times. The number must be a non-negative integer value. An array repeated zero times is an
-          empty array.
+          empty array. A deep copy is performed on the array elements before each repetition.
         </p>
         <h3>
           <a id="logical-operators" href="#logical-operators" class="anchor">#</a>Logical Operators

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -732,7 +732,7 @@ func evalBinaryArrayExpr(op parser.Operator, left *arrayVal, right value) (value
 		}
 		newElements := make([]value, 0, len(*left.Elements)*repetitions)
 		for range repetitions {
-			newElements = append(newElements, *(left.Copy().Elements)...)
+			newElements = append(newElements, *(deepCopy(left).(*arrayVal).Elements)...)
 		}
 		result := &arrayVal{Elements: &newElements}
 		return result, nil

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -645,6 +645,42 @@ print "arr5" arr5
 	}
 }
 
+func TestArrayRepetitionDeepCopy(t *testing.T) {
+	prog := `
+arr1:= [[0]*2] * 2
+arr1[0][1] = 1
+print "arr1" arr1 // [[0 1] [0 0]]
+
+a := [1] * 2
+arr2:= [a] * 2
+arr2[1][1] = 2
+print "arr2" arr2 // [[1 1] [1 2]]
+
+m := {a:[1]}
+arr3 := [m] * 2
+arr3[0].a[0] = 2
+print "arr3" arr3 // [{a:[2]} {a:[1]}]
+
+a2 := [m] * 2
+arr4:= [a2] * 2
+arr4[1][1].a[0] = 3
+print "arr4" arr4 // [[{a:[1]} {a:[1]}] [{a:[1]} {a:[3]}]]
+`
+	out := run(prog)
+	want := []string{
+		"arr1 [[0 1] [0 0]]",
+		"arr2 [[1 1] [1 2]]",
+		"arr3 [{a:[2]} {a:[1]}]",
+		"arr4 [[{a:[1]} {a:[1]}] [{a:[1]} {a:[3]}]]",
+		"",
+	}
+	got := strings.Split(out, "\n")
+	assert.Equal(t, len(want), len(got), out)
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
 func TestArrayRepetitionErr(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Deep copy array repetitions so that the repetition operator can be used to
initialize 2 or larger dimensional arrays. Previously a reference to inner
arrays was copied which did not allow for array elements to be updated
independently.

Co-authored-by: Cam Hutchison <camh@xdna.net>