### PR TITLE
playsite: Fix hsl usage in events sample

### DIFF
--- a/frontend/play/samples/animate/bounce.evy
+++ b/frontend/play/samples/animate/bounce.evy
@@ -1,4 +1,4 @@
-background := "hsl(0deg 0% 0% / 10%)"
+background := hsl 0 0 0 10
 x := 10
 y := 50
 s := 1

--- a/frontend/play/samples/animate/splashtrig.evy
+++ b/frontend/play/samples/animate/splashtrig.evy
@@ -61,7 +61,7 @@ end
 
 on animate
     // 2% opacity leaves trails on movement
-    clear "hsl(0deg 100% 100% / 2%)"
+    clear (hsl 0 0 100 2)
 
     for dot := range dots
         update dot

--- a/frontend/play/samples/games/tictactoe.evy
+++ b/frontend/play/samples/games/tictactoe.evy
@@ -99,7 +99,7 @@ func drawWinningLine
         return
     end
     l := winningLine w
-    color "hsl(330deg 100% 50% / 80%)"
+    color (hsl 330 100 50 80)
     width 3
     move (getX l.i1) (getY l.i1)
     line (getX l.i2) (getY l.i2)

--- a/frontend/play/samples/interact/ellipse.evy
+++ b/frontend/play/samples/interact/ellipse.evy
@@ -12,7 +12,7 @@ print "for your perfect piece."
 draw
 
 func draw
-    clear "hsl(210deg 5% 15%)" // near black
+    clear (hsl 210 5 15) // near black
     drawEllipse
     drawText
     drawHighlight cur
@@ -28,7 +28,7 @@ end
 func drawText
     font {size:2.7 style:"italic" family:"Fira Code, monospace"}
     width 0.2
-    fill "hsl(210deg 13% 72%)" // light grey
+    fill (hsl 210 13 72) // light grey
     move 2 15
     text "// "
     for i := range (len labels)
@@ -36,10 +36,10 @@ func drawText
         text (sprintf "%5s" labels[i])
     end
     font {size:2.7 style:"normal"}
-    fill "hsl(27deg 100% 74%)" // orange
+    fill (hsl 27 100 74) // orange
     move 2 10
     text "ellipse"
-    fill "hsl(204deg 100% 75%)" // ligth  blue
+    fill (hsl 204 100 75) // light blue
     for i := range (len labels)
         move i*w+20 10
         text (sprintf "%5.0f" vals[i])

--- a/frontend/play/samples/tour/events.evy
+++ b/frontend/play/samples/tour/events.evy
@@ -45,7 +45,7 @@ on input id:string val:string
 end
 
 func dot x:num y:num radius:num hue:num
-    hsl hue 100 50
+    color (hsl hue)
     move x y
     circle radius
 end


### PR DESCRIPTION
Fix hsl usage in events sample to be composed with the color function.
We have updated hsl to return a string in commit 9b2c83c0 but forgot
to update the example. Let's do it!

While at it, remove all hsl strings in other samples.

---

Compare: https://play.evy.dev/#events
To: https://evy-lang-stage-play--359-whn7zd5c.web.app/#events

use arrow keys to change the color of the dot.