### PR TITLE
playsite: Revisit the splash of trig example

### DIFF
--- a/frontend/play/samples/animate/splashtrig.evy
+++ b/frontend/play/samples/animate/splashtrig.evy
@@ -1,76 +1,43 @@
-sa := -0.007
-sb := -0.006
-sc := -0.005
-sd := -0.004
-se := -0.003
-radius := 5
+colors := ["red" "orange" "gold" "forestgreen" "blue" "indigo" "purple" "deeppink"]
+speed := [0.007 0.006 0.005 0.004 0.003]
+// 2% opacity leaves trails on movement, try hsl 0 0 0 2 for black
+background := hsl 0 0 100 2
+
+orbits := len speed // number of moving rings
+dots := len colors // number of dots per ring
+radius := 100 / (orbits * 4 + 2)
 
 pi := 3.141593
 tau := 2 * pi
 
-colors := [
-    "red" "orange" "gold" "forestgreen" "blue" "indigo" "purple" "deeppink"
-]
-dots := [
-    {phase:(0 / 8) orbit:10 s:sa}
-    {phase:(1 / 8) orbit:10 s:sa}
-    {phase:(2 / 8) orbit:10 s:sa}
-    {phase:(3 / 8) orbit:10 s:sa}
-    {phase:(4 / 8) orbit:10 s:sa}
-    {phase:(5 / 8) orbit:10 s:sa}
-    {phase:(6 / 8) orbit:10 s:sa}
-    {phase:(7 / 8) orbit:10 s:sa}
-    {phase:(0 / 8) orbit:20 s:sb}
-    {phase:(1 / 8) orbit:20 s:sb}
-    {phase:(2 / 8) orbit:20 s:sb}
-    {phase:(3 / 8) orbit:20 s:sb}
-    {phase:(4 / 8) orbit:20 s:sb}
-    {phase:(5 / 8) orbit:20 s:sb}
-    {phase:(6 / 8) orbit:20 s:sb}
-    {phase:(7 / 8) orbit:20 s:sb}
-    {phase:(0 / 8) orbit:30 s:sc}
-    {phase:(1 / 8) orbit:30 s:sc}
-    {phase:(2 / 8) orbit:30 s:sc}
-    {phase:(3 / 8) orbit:30 s:sc}
-    {phase:(4 / 8) orbit:30 s:sc}
-    {phase:(5 / 8) orbit:30 s:sc}
-    {phase:(6 / 8) orbit:30 s:sc}
-    {phase:(7 / 8) orbit:30 s:sc}
-    {phase:(0 / 8) orbit:40 s:sd}
-    {phase:(1 / 8) orbit:40 s:sd}
-    {phase:(2 / 8) orbit:40 s:sd}
-    {phase:(3 / 8) orbit:40 s:sd}
-    {phase:(4 / 8) orbit:40 s:sd}
-    {phase:(5 / 8) orbit:40 s:sd}
-    {phase:(6 / 8) orbit:40 s:sd}
-    {phase:(7 / 8) orbit:40 s:sd}
-    {phase:(0 / 8) orbit:50 s:se}
-    {phase:(1 / 8) orbit:50 s:se}
-    {phase:(2 / 8) orbit:50 s:se}
-    {phase:(3 / 8) orbit:50 s:se}
-    {phase:(4 / 8) orbit:50 s:se}
-    {phase:(5 / 8) orbit:50 s:se}
-    {phase:(6 / 8) orbit:50 s:se}
-    {phase:(7 / 8) orbit:50 s:se}
-]
+dot:{}num
+ring := [dot] * dots
+rings := [ring] * orbits
 
-for i := range (len dots)
-    dots[i].radius = radius
-    dots[i].color = i
+// initialize dots
+for i := range orbits
+    for j := range dots
+        dot := rings[i][j]
+        dot.speed = speed[i]
+        dot.orbit = (i + 1) * radius * 2
+        dot.phase = j / dots
+        dot.radius = radius
+        dot.color = j
+    end
 end
 
 on animate
-    // 2% opacity leaves trails on movement
-    clear (hsl 0 0 100 2)
-
-    for dot := range dots
-        update dot
-        draw dot colors[dot.color % (len colors)]
+    clear background
+    for ring := range rings
+        for dot := range ring
+            update dot
+            draw dot colors[dot.color]
+        end
     end
 end
 
 func update dot:{}num
-    dot.phase = dot.phase + dot.s
+    dot.phase = dot.phase - dot.speed
 end
 
 func draw dot:{}num col:string


### PR DESCRIPTION
Revisit the splash of trig example using the new `hsl` builtin and repetition
operator to initialize array. We've reworked the example so that the dots are
now stored in a two dimensional array: an array of rings, where each ring
array holds the dot within the ring. Arguably this is a little easier to
reason about. Additionally, we calculate by default the radius from the orbit
count, and the orbit value. We've also made the animation fully fit within
the canvas.

This changes should make it easier for people playing with it to:

- Add extra dots by adding an extra color
- Add extra orbits by adding an extra speed

I'm not 100% convinced that his is really making things easier to play with
though.

@fcostin - if you have time to look at this, please let me know if this is
still close enough to the original spirit in which you wrote this cool
animation.