### PR TITLE
evaluator: Fix assignment of composites with copied references

### DIFF
--- a/examples/human-eval/160.evy
+++ b/examples/human-eval/160.evy
@@ -18,7 +18,8 @@
 //     Operand is a list of of non-negative integers.
 //     Operator list has at least one operator, and operand list has at least two operands.
 func solve:num ops:[]string nums:[]num
-    return solveExp ops nums 0
+    arr := solveExp ops nums 0 0
+    return arr[0]
 end
 
 precedence:{}num
@@ -28,16 +29,15 @@ precedence["*"] = 2
 precedence["//"] = 2
 precedence["**"] = 3
 
-func solveExp:num ops:[]string nums:[]num prec:num
-    left := nums[0]
-    while (len ops) != 0 and prec < precedence[ops[0]]
-        op := ops[0]
-        ops = ops[1:]
-        nums = nums[1:]
-        right := solveExp ops nums precedence[op]
-        left = solveOp left op right
+func solveExp:[]num ops:[]string nums:[]num idx:num prec:num
+    left := nums[idx]
+    while idx < (len ops) and prec < precedence[ops[idx]]
+        op := ops[idx]
+        result := solveExp ops nums idx+1 precedence[op] // recurse into right sub-tree
+        left = solveOp left op result[0]
+        idx = result[1]
     end
-    return left
+    return [left idx]
 end
 
 func solveOp:num a:num op:string b:num
@@ -57,7 +57,7 @@ func solveOp:num a:num op:string b:num
 end
 
 func test
-    assert 37 (solve ["**" "*" "+"] [2 3 4 5])
+    assert 14 (solve ["+" "*"] [2 3 4])
     assert 9 (solve ["+" "*" "-"] [2 3 4 5])
     assert 8 (solve ["//" "*"] [7 3 4])
     assert 7 (solve ["+" "*"] [1 2 3])

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1320,6 +1320,92 @@ print a b
 }
 
 func TestCompositeAssignment(t *testing.T) {
+	tests := map[string]string{
+		`
+n := 1
+a := [n n]
+m := {n: n}
+n = 2
+print n a m
+`: `
+2 [1 1] {n:1}
+`[1:],
+		`
+a := {a: 1}
+b := a
+b = {b: 2}
+print "a" a
+print "b" b
+`: `
+a {a:1}
+b {b:2}
+`[1:],
+		`
+a := [1]
+b := a
+b = [2]
+print "a" a
+print "b" b
+`: `
+a [1]
+b [2]
+`[1:],
+		`
+a := {a:1}
+b := {aa:a}
+c := {aa:a}
+c.aa = {c:2}
+print "a" a
+print "b" b
+print "c" c
+`: `
+a {a:1}
+b {aa:{a:1}}
+c {aa:{c:2}}
+`[1:],
+		`
+a := [1 2]
+b := [a]
+c := [a]
+c[0] = [3 4]
+print "a" a
+print "b" b
+print "c" c
+`: `
+a [1 2]
+b [[1 2]]
+c [[3 4]]
+`[1:],
+		`
+arr := [1 2 3]
+
+func fn a:[]num
+    a[0] = 100
+    a = [6 7 8]
+end
+
+fn arr
+print "arr" arr // [100 2 3]
+`: `
+arr [100 2 3]
+`[1:],
+		`
+a:any
+arr := [1 2 3]
+a = arr
+arr[2] = 222
+arr = [5 6 7]
+print "a" a
+print "arr" arr
+`: `
+a [1 2 222]
+arr [5 6 7]
+`[1:],
+	}
+	for input, want := range tests {
+		got := run(input)
+		assert.Equal(t, want, got, input)
+	}
 	prog := `
 n := 1
 a := [n n]

--- a/pkg/evaluator/scope.go
+++ b/pkg/evaluator/scope.go
@@ -1,5 +1,7 @@
 package evaluator
 
+import "fmt"
+
 type scope struct {
 	values map[string]value
 	outer  *scope
@@ -28,4 +30,18 @@ func (s *scope) set(name string, val value) {
 		return
 	}
 	s.values[name] = val
+}
+
+func (s *scope) update(name string, val value) {
+	if name == "_" {
+		return
+	}
+	if _, ok := s.values[name]; ok {
+		s.values[name] = val
+		return
+	}
+	if s.outer == nil {
+		panic(fmt.Errorf("%w: update of unknown variable %q", ErrAssignmentTarget, name))
+	}
+	s.outer.update(name, val)
 }

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -205,6 +205,16 @@ func (a *arrayVal) Index(idx value) (value, error) {
 	return elements[i], nil
 }
 
+func (a *arrayVal) SetIndex(idx, val value) error {
+	i, err := normalizeIndex(idx, len(*a.Elements), indexExpression)
+	if err != nil {
+		return err
+	}
+	elements := *a.Elements
+	elements[i] = val
+	return nil
+}
+
 func (a *arrayVal) Copy() *arrayVal {
 	elements := make([]value, len(*a.Elements))
 	for i, v := range *a.Elements {
@@ -251,7 +261,7 @@ func copyOrRef(val value) value {
 // deepCopy copies the given value, copying the elements of arrays
 // and maps recursively so as to not reference arrays or maps. It is
 // used by the array repetition operator which is the only place in
-// evy that arrays and map references are "derefenced".
+// evy that arrays and map references are "dereferenced".
 func deepCopy(val value) value {
 	switch v := val.(type) {
 	case *numVal:
@@ -324,12 +334,11 @@ func (m *mapVal) Get(key string) (value, error) {
 	return val, nil
 }
 
-func (m *mapVal) InsertKey(key string, t *parser.Type) {
-	if _, ok := m.Pairs[key]; ok {
-		return
+func (m *mapVal) SetKey(key string, val value) {
+	if _, ok := m.Pairs[key]; !ok {
+		*m.Order = append(*m.Order, key)
 	}
-	*m.Order = append(*m.Order, key)
-	m.Pairs[key] = zero(t)
+	m.Pairs[key] = val
 }
 
 func (m *mapVal) Delete(key string) {


### PR DESCRIPTION
Fix assignment of composites with copied references, so that that

	a := [1]
	b := a
	b = [2]
	print a b // [a] [b]

now does NOT update the a variable anymore. The assignment now always creates
a new value, rather than updating the existing one.

Fixes: https://github.com/evylang/evy/issues/362