### PR TITLE
playsite: Allow sharing code with parse errors

### DIFF
--- a/frontend/play/css/index.css
+++ b/frontend/play/css/index.css
@@ -635,13 +635,16 @@ dialog .copy input {
   min-width: 10em;
 }
 
-#dialog-error .err {
+dialog .err {
   font-family: var(--font-family-code);
   color: var(--color);
   margin-left: 8px;
   margin-right: 8px;
 }
 
+dialog .note {
+  margin-bottom: 16px;
+}
 /* --- Utilities ----------------------------------------------------- */
 .hidden {
   display: none;

--- a/frontend/play/index.html
+++ b/frontend/play/index.html
@@ -184,25 +184,12 @@
           <button class="icon-close"></button>
         </header>
         <main>
+          <p class="note hidden">⚠️ Code has <span class="err">errors</span>!</p>
           <div class="copy">
             <input type="text" value="/play#gzipped+and+base64+encoded+evy+code+content" />
             <button type="button" class="icon-copy"></button>
           </div>
           <button class="primary">Done</button>
-        </main>
-      </form>
-    </dialog>
-
-    <!-- Evy sharing error dialog -->
-    <dialog id="dialog-error">
-      <form method="dialog">
-        <header>
-          <h1>Error</h1>
-          <button class="icon-close"></button>
-        </header>
-        <main>
-          <p>Fix <span class="err">parse error</span> first, please!</p>
-          <button class="primary">Ok</button>
         </main>
       </form>
     </dialog>

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -963,12 +963,9 @@ function showAbout() {
 
 async function share() {
   hideSidebar()
+  const note = document.querySelector("#dialog-share .note")
   await format()
-
-  if (errors) {
-    document.querySelector("#dialog-error").showModal()
-    return
-  }
+  errors ? note.classList.remove("hidden") : note.classList.add("hidden")
   const baseurl = window.location.origin + window.location.pathname
   const encoded = await encode(editor.value)
   const input = document.querySelector("#dialog-share .copy input")


### PR DESCRIPTION
Allow sharing Evy code via playground URLs even if the code cannot be
formatted. This should help with help, e.g. why does this code not work
`<link>`?

It'd be neat to also add sharing to the CLI, e.g. `evy share file.evy`
generating URL or `evy run --url`. We might leave this for later.