### PR TITLE
builtins: Add `repr` function

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -30,7 +30,7 @@ see [syntax by example](syntax_by_example.md).
 6. [**Errors**](#errors)  
    [Panic](#panic-1), [Recoverable Errors](#recoverable-errors)
 7. [**String**](#string)  
-   [sprint](#sprint), [sprintf](#sprintf), [join](#join), [split](#split), [upper](#upper), [lower](#lower), [index](#index), [startswith](#startswith), [endswith](#endswith), [trim](#trim), [replace](#replace)
+   [sprint](#sprint), [sprintf](#sprintf), [join](#join), [split](#split), [upper](#upper), [lower](#lower), [index](#index), [startswith](#startswith), [endswith](#endswith), [trim](#trim), [replace](#replace), [repr](#repr)
 8. [**Random**](#random)  
    [rand](#rand), [rand1](#rand1)
 9. [**Math**](#math)  
@@ -1093,6 +1093,48 @@ ABC123xyzABC ABC
 
 The `replace` function replaces all occurrences of the substring `old`
 in the string `s` with the substring `new`.
+
+### `repr`
+
+`repr` returns a string representation of its arguments, typically as valid,
+formatted Evy code. The notable exception are maps with keys that could not be
+used in a map literal.
+
+#### Example
+
+```evy
+s := repr 1 "abc"
+print s
+```
+
+Output
+
+```evy:output
+1 "abc"
+```
+
+#### Reference
+
+    repr:string a:any...
+
+The `repr` function returns a string representation of its arguments,
+typically as valid, formatted Evy code. The notable exception are maps with
+keys that could not be used in a map literal.
+
+| Type     | Representation                             |
+| -------- | ------------------------------------------ |
+| `num`    | as is                                      |
+| `bool`   | as is                                      |
+| `string` | double-quoted with internal quotes escaped |
+| `[]`...  | enclosed in square brackets, details below |
+| `{}`...  | enclosed in curly braces, details below    |
+
+The elements of an array are printed according to `repr` and space-separated.
+
+The key-value pairs of a map are space-separated, with keys separated from
+values by `:`. Keys are printed without quotes if they are valid identifiers
+or Evy keywords, and surrounded by quotes with escaped internal quotes if
+not. Values are printed according to `repr`.
 
 ## Random
 

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -265,6 +265,9 @@
                 <li>
                   <a href="builtins.html#replace"><code>replace</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#repr"><code>repr</code></a>
+                </li>
               </ul>
             </li>
             <li>
@@ -1503,6 +1506,66 @@ print s
         <p>
           The <code>replace</code> function replaces all occurrences of the substring
           <code>old</code> in the string <code>s</code> with the substring <code>new</code>.
+        </p>
+        <h3><a id="repr" href="#repr" class="anchor">#</a><code>repr</code></h3>
+        <p>
+          <code>repr</code> returns a string representation of its arguments, typically as valid,
+          formatted Evy code. The notable exception are maps with keys that could not be used in a
+          map literal.
+        </p>
+        <h4>Example</h4>
+        <pre><code class="language-evy">s := repr 1 &quot;abc&quot;
+print s
+</code></pre>
+        <p>Output</p>
+        <pre><code class="language-evy-output">1 &quot;abc&quot;
+</code></pre>
+        <h4>Reference</h4>
+        <pre><code>repr:string a:any...
+</code></pre>
+        <p>
+          The <code>repr</code> function returns a string representation of its arguments, typically
+          as valid, formatted Evy code. The notable exception are maps with keys that could not be
+          used in a map literal.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Representation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>num</code></td>
+              <td>as is</td>
+            </tr>
+            <tr>
+              <td><code>bool</code></td>
+              <td>as is</td>
+            </tr>
+            <tr>
+              <td><code>string</code></td>
+              <td>double-quoted with internal quotes escaped</td>
+            </tr>
+            <tr>
+              <td><code>[]</code>...</td>
+              <td>enclosed in square brackets, details below</td>
+            </tr>
+            <tr>
+              <td><code>{}</code>...</td>
+              <td>enclosed in curly braces, details below</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          The elements of an array are printed according to <code>repr</code> and space-separated.
+        </p>
+        <p>
+          The key-value pairs of a map are space-separated, with keys separated from values by
+          <code>:</code>. Keys are printed without quotes if they are valid identifiers or Evy
+          keywords, and surrounded by quotes with escaped internal quotes if not. Values are printed
+          according to <code>repr</code>.
         </p>
         <h2><a id="random" href="#random" class="anchor">#</a>Random</h2>
         <h3><a id="rand" href="#rand" class="anchor">#</a><code>rand</code></h3>

--- a/frontend/docs/index.html
+++ b/frontend/docs/index.html
@@ -265,6 +265,9 @@
                 <li>
                   <a href="builtins.html#replace"><code>replace</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#repr"><code>repr</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/docs/spec.html
+++ b/frontend/docs/spec.html
@@ -265,6 +265,9 @@
                 <li>
                   <a href="builtins.html#replace"><code>replace</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#repr"><code>repr</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/docs/syntax_by_example.html
+++ b/frontend/docs/syntax_by_example.html
@@ -265,6 +265,9 @@
                 <li>
                   <a href="builtins.html#replace"><code>replace</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#repr"><code>repr</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/docs/usage.html
+++ b/frontend/docs/usage.html
@@ -265,6 +265,9 @@
                 <li>
                   <a href="builtins.html#replace"><code>replace</code></a>
                 </li>
+                <li>
+                  <a href="builtins.html#repr"><code>repr</code></a>
+                </li>
               </ul>
             </li>
             <li>

--- a/frontend/module/highlight.js
+++ b/frontend/module/highlight.js
@@ -57,6 +57,7 @@ const builtins = new Set([
   "read",
   "rect",
   "replace",
+  "repr",
   "round",
   "sin",
   "sleep",

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -63,6 +63,7 @@ func newBuiltins(rt Runtime) builtins {
 		"endswith":   {Func: endswithFunc, Decl: endswithDecl},
 		"trim":       {Func: trimFunc, Decl: trimDecl},
 		"replace":    {Func: replaceFunc, Decl: replaceDecl},
+		"repr":       {Func: reprFunc, Decl: reprDecl},
 
 		"str2num":  {Func: builtinFunc(str2numFunc), Decl: str2numDecl},
 		"str2bool": {Func: builtinFunc(str2boolFunc), Decl: str2boolDecl},
@@ -377,6 +378,20 @@ func replaceFunc(_ *scope, args []value) (value, error) {
 	return &stringVal{V: strings.ReplaceAll(s, oldStr, newStr)}, nil
 }
 
+var reprDecl = &parser.FuncDefStmt{
+	Name:          "repr",
+	VariadicParam: &parser.Var{Name: "a", T: parser.ANY_TYPE},
+	ReturnType:    parser.STRING_TYPE,
+}
+
+func reprFunc(_ *scope, args []value) (value, error) {
+	str := make([]string, len(args))
+	for i, arg := range args {
+		str[i] = arg.Repr()
+	}
+	return &stringVal{V: strings.Join(str, " ")}, nil
+}
+
 var str2numDecl = &parser.FuncDefStmt{
 	Name:       "str2num",
 	Params:     []*parser.Var{{Name: "s", T: parser.STRING_TYPE}},
@@ -535,7 +550,7 @@ func assertFunc(_ *scope, args []value) (value, error) {
 		want := args[0]
 		got := args[1]
 		if !same(want, got) {
-			return nil, fmt.Errorf("%w: want != got: %v != %v%s", ErrAssert, want, got, assertMessage(args))
+			return nil, fmt.Errorf("%w: want != got: %v != %v%s", ErrAssert, want.Repr(), got.Repr(), assertMessage(args))
 		}
 	}
 	return nil, nil

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -561,7 +561,7 @@ func TestFailedAssertion(t *testing.T) {
 		"assert false": "line 1 column 8: failed assertion: not true",
 		"assert 1 2":   "line 1 column 10: failed assertion: want != got: 1 != 2",
 		`assert "abc" "123" "string comparison"
-		`: "line 1 column 14: failed assertion: want != got: abc != 123 (string comparison)",
+		`: `line 1 column 14: failed assertion: want != got: "abc" != "123" (string comparison)`,
 		`answer := 6*9
 		assert 42 answer "the answer is 42, not %v" answer
 		`: `line 2 column 13: failed assertion: want != got: 42 != 54 (the answer is 42, not 54)`,
@@ -605,7 +605,7 @@ assert "abc" "123" "custom message"
 	want := `
 line 3 column 8: failed assertion: not true
 line 4 column 10: failed assertion: want != got: 1 != 2
-line 6 column 14: failed assertion: want != got: abc != 123 (custom message)`[1:]
+line 6 column 14: failed assertion: want != got: "abc" != "123" (custom message)`[1:]
 	assert.Equal(t, want, assertionErrors.Error())
 
 	eval = NewEvaluator(rt)

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -219,6 +219,19 @@ func (l *Lexer) readString() (string, error) {
 	return r, nil
 }
 
+// IsIdent returns true if the given string is a valid identifier.
+func IsIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if !isLetter(r) && (i > 0 && !isDigit(r)) {
+			return false
+		}
+	}
+	return true
+}
+
 func isLetter(r rune) bool {
 	return unicode.IsLetter(r) || r == '_'
 }


### PR DESCRIPTION
Add `repr` function to the evaluator. The function returns a space-separate
string representation of its values that can be copied back in as valid Evy
code for most parts, similar to Python's `repr` function.

Use it in `assert` function so that `assert "2" 2` prints a less confusing
error message.