### PR TITLE
parser: Fix confusing error message

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -440,9 +440,10 @@ func (p *parser) parseFuncDefSignature() *FuncDefStmt {
 	p.advance() // advance past function name IDENT
 	if p.cur.TokenType() == lexer.COLON {
 		p.advance() // advance past `:` of return type declaration, e.g. in `func rand:num`
+		tok := p.cur
 		fd.ReturnType = p.parseType()
 		if fd.ReturnType == nil {
-			p.appendErrorForToken("invalid return type: "+p.cur.Format(), fd.token)
+			p.appendErrorForToken("invalid return type", tok)
 		}
 	}
 	for !p.isAtEOL() && p.cur.TokenType() != lexer.DOT3 {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -152,6 +152,42 @@ func TestFunccallError(t *testing.T) {
 	}
 }
 
+func TestFuncDefError(t *testing.T) {
+	tests := map[string]string{
+		`
+func f:[]int
+  return 0
+end`: `line 2 column 8: invalid return type`,
+		`
+func f:int s:string
+  print s
+  return 0
+end`: `line 2 column 8: invalid return type`,
+		`
+func f:[]int s:string
+  print s
+  return 0
+end`: `line 2 column 8: invalid return type`,
+		`
+func f:[string s:string
+  print s
+  return 0
+end`: `line 2 column 8: invalid return type`,
+		`
+func f:[]string s:chars
+  print s
+  return 0
+end`: `line 2 column 17: invalid type declaration for "s"`,
+	}
+	for input, err1 := range tests {
+		parser := newParser(input, testBuiltins())
+		_ = parser.parse()
+		assertParseError(t, parser, input)
+		got := parser.errors.Truncate(1)
+		assert.Equal(t, err1, got.Error())
+	}
+}
+
 func TestBlock(t *testing.T) {
 	tests := map[string]string{
 		`


### PR DESCRIPTION
Fix confusing error message for "invalid return type: end of line" that
printed and associated the wrong tokens. We have now simplified the message
to `invalid return type` and associate it with the first token of the return
type declaration.