### PR TITLE
playsite: Fix synthetic leave move event

### DIFF
--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -797,7 +797,7 @@ function registerEventHandler(ptr, len) {
     c.onpointerup = (e) => exp.onUp(logicalX(e), logicalY(e))
   } else if (s === "move") {
     c.onpointermove = (e) => exp.onMove(logicalX(e), logicalY(e))
-    c.onpointerleave = (e) => exp.onMove(...leaveXY(e))
+    c.onmouseleave = (e) => exp.onMove(...leaveXY(e)) // pointer can leave in middle of canvas
   } else if (s === "key") {
     unfocusRunBotton()
     document.addEventListener("keydown", keydownListener)


### PR DESCRIPTION
Previously, we've added a special "last" move event for canvas' the
`pointerleave` event. This was in response  to watching my daughter play with
the watermelon sample 🍉 and being confused with what it did when leaving the
mouse left the canvas (https://play.evy.dev/#ellipse - I've noticed kids are
often not that dexterous yet with mice as they use a lot more iPads etc).
Unfortunately, there was no way of capturing in Evy code the condition "mouse
has left canvas" so we added this last synthetic Evy "move" event to be fired
right at the closest edge at 0 y, 100 y, x 0 or x 100 - this allows to test
for leave in the move handler with:

	x == 0 or x == 100 or y == 0 or y == 100

Additionally it can be used to draw lines right to the edge.

This seemed like a great compromise, until I recently realized the
`pointerleave` event _also_ gets fired when we lift the pointer (finger) in
the middle of the canvas on a touch device, which causes weird random last
move events being fired on the often "far away", nearest edge and long lines
drawn out from the middle of the canvas for see the interactive drawing
example on a phone or tablet (https://play.evy.dev/#draw).

This fix here only adds the synthetic edge events for mouse events not touch
events. This is probably not perfect either and has further edge cases, but
short of introducing an Evy leave event handler (which I don't want to do,
because the global namespace is already pretty busy), this seems to fix all
known issues around the leave event.