### PR TITLE
playsite: Add `editor=none` options to hash

### DIFF
--- a/frontend/play/css/index.css
+++ b/frontend/play/css/index.css
@@ -200,10 +200,16 @@ button.share > div {
   display: flex;
   overflow: clip;
   transition: translate 0.3s ease-in-out;
+  justify-content: center;
 }
 
-.main.view-output {
-  translate: -100vw;
+@media (max-width: 767px) {
+  .main.view-output {
+    translate: -100vw;
+  }
+  .main {
+    justify-content: left;
+  }
 }
 
 @media (prefers-reduced-motion) {

--- a/frontend/play/index.html
+++ b/frontend/play/index.html
@@ -242,6 +242,9 @@
         document.querySelector(".placeholder").innerText = sessionStorage.getItem("evy-editor")
         document.querySelector(".lines").innerText = ""
       }
+      if (window.location.hash.includes("editor=none")) {
+        document.querySelector(".editor-wrap").classList.add("hidden")
+      }
     </script>
   </body>
 </html>

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -17,6 +17,7 @@ let sampleData
 let actions = "fmt,ui,eval"
 let editor
 let errors = false
+let editorHidden = false
 
 // --- Initialize ------------------------------------------------------
 
@@ -234,6 +235,10 @@ async function handleRun() {
 // handleMobRun handles three states for mobile devices:
 // run -> stop -> code
 async function handleMobRun() {
+  if (editorHidden) {
+    handleRun()
+    return
+  }
   if (onCodeScreen()) {
     // we need to wait for the slide transition to finish otherwise
     // el.focus() in jsRead() messes up the layout
@@ -399,6 +404,9 @@ async function handleHashChange() {
   clearOutput()
   await format()
   editor.onUpdate(clearHash)
+  editorHidden = opts.editor === "none"
+  const classList = document.querySelector(".editor-wrap").classList
+  editorHidden ? classList.add("hidden") : classList.remove("hidden")
 }
 
 // parseHash parses URL fragment into object e.g.:


### PR DESCRIPTION
Add `editor=none` options to hash in preparation for classroom work: I'd like
to show students a program in execution without giving away how it's
programmed - find out what this thing does by just observing it.

This is a hack. Truth is the playground is ripe for a re-think and re-write,
ideally based around web-components. But that's a big job and this will do
for now. I hope.

---

Try with:
https://evy-lang-stage-play--369-a5xbmcq8.web.app/#sample=welcome&editor=none
https://evy-lang-stage-play--369-a5xbmcq8.web.app/#sample=splashtrig&editor=none