### PR TITLE
learn: Refactor question model and MD utilties

### DIFF
--- a/learn/pkg/learn/export_test.go
+++ b/learn/pkg/learn/export_test.go
@@ -65,7 +65,7 @@ func findFiles(root string) []string {
 	var files []string
 	rootFS := os.DirFS(root)
 	_ = fs.WalkDir(rootFS, ".", func(filename string, d fs.DirEntry, _ error) error {
-		if !d.IsDir() {
+		if !d.IsDir() && filepath.Ext(filename) != ".DS_Store" {
 			files = append(files, filename)
 		}
 		return nil

--- a/learn/pkg/learn/frontmatter.go
+++ b/learn/pkg/learn/frontmatter.go
@@ -3,80 +3,7 @@ package learn
 import (
 	"fmt"
 	"slices"
-
-	"gopkg.in/yaml.v3"
 )
-
-type frontmatter struct {
-	Type         frontmatterType `yaml:"type,omitempty"` // question
-	Difficulty   difficulty      `yaml:"difficulty,omitempty"`
-	AnswerType   answerType      `yaml:"answer-type,omitempty"` // single-choice, multiple-choice, free-text, multiple-free-texts, program
-	Answer       string          `yaml:"answer,omitempty"`
-	SealedAnswer string          `yaml:"sealed-answer,omitempty"`
-}
-
-func (f *frontmatter) validate() error {
-	if f.Type != "question" {
-		return fmt.Errorf("%w: want: %q, got: %q", ErrWrongFrontmatterType, "question", f.Type)
-	}
-	if f.Answer == "" && f.SealedAnswer == "" {
-		return fmt.Errorf("no answer found: %w", ErrNoFrontmatterAnswer)
-	}
-	if f.Answer != "" && f.SealedAnswer != "" {
-		return fmt.Errorf("%w: sealed and unsealed answer found, only one allowed", ErrInvalidFrontmatter)
-	}
-	return nil
-}
-
-func (f *frontmatter) getAnswer(privateKey string) (Answer, error) {
-	text := f.Answer
-	if f.SealedAnswer != "" && privateKey == "" {
-		return Answer{}, ErrSealedAnswerNoKey
-	}
-	if f.SealedAnswer != "" {
-		var err error
-		text, err = Decrypt(privateKey, f.SealedAnswer)
-		if err != nil {
-			return Answer{}, err
-		}
-	}
-	if text == "" {
-		return Answer{}, fmt.Errorf("cannot get answerkey: %w", ErrNoFrontmatterAnswer)
-	}
-	return NewAnswer(f.AnswerType, text)
-}
-
-func (f *frontmatter) Seal(publicKey string) error {
-	if f.Answer == "" && f.SealedAnswer != "" {
-		return nil // already sealed
-	}
-	if f.Answer == "" {
-		return fmt.Errorf("cannot seal empty answer: %w", ErrNoFrontmatterAnswer)
-	}
-	sealed, err := Encrypt(publicKey, f.Answer)
-	if err != nil {
-		return err
-	}
-	f.SealedAnswer = sealed
-	f.Answer = ""
-	return nil
-}
-
-func (f *frontmatter) Unseal(privateKey string) error {
-	if f.Answer != "" && f.SealedAnswer == "" {
-		return nil // already unsealed
-	}
-	if f.SealedAnswer == "" {
-		return fmt.Errorf("cannot unseal empty sealed-answer: %w", ErrNoFrontmatterAnswer)
-	}
-	unsealed, err := Decrypt(privateKey, f.SealedAnswer)
-	if err != nil {
-		return err
-	}
-	f.SealedAnswer = ""
-	f.Answer = unsealed
-	return nil
-}
 
 type (
 	frontmatterType string
@@ -85,7 +12,7 @@ type (
 )
 
 var (
-	validFrontmatterTypes = []string{"course", "unit", "exercise", "question"}
+	validFrontmatterTypes = []string{"course", "unit", "unittest", "quiz", "exercise", "question"}
 	validAnswerTypes      = []string{"single-choice", "multiple-choice", "free-text", "multiple-free-texts", "program"}
 	validDifficulties     = []string{"easy", "medium", "hard", "retriable"}
 )
@@ -128,15 +55,4 @@ func unmarshalText(fieldName string, validStrings []string, text []byte, s *stri
 	}
 	*s = str
 	return nil
-}
-
-func parseFrontmatter(str string) (*frontmatter, error) {
-	fm := &frontmatter{}
-	if err := yaml.Unmarshal([]byte(str), fm); err != nil {
-		return nil, fmt.Errorf("%w: cannot process Question Markdown frontmatter: %w", ErrInvalidFrontmatter, err)
-	}
-	if err := fm.validate(); err != nil {
-		return nil, err
-	}
-	return fm, nil
 }

--- a/learn/pkg/learn/markdown.go
+++ b/learn/pkg/learn/markdown.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode"
 
+	"evylang.dev/evy/pkg/md"
 	"gopkg.in/yaml.v3"
 	"rsc.io/markdown"
 )
@@ -54,10 +55,11 @@ func parseMD(rawMD string) *markdown.Document {
 
 func md2HTML(rawMD string) string {
 	doc := parseMD(rawMD)
+	md.Walk(doc, md.RewriteLink)
 	buf := &bytes.Buffer{}
-	buf.WriteString(questionPrefixHTML)
+	buf.WriteString(prefixHTML)
 	doc.PrintHTML(buf)
-	buf.WriteString(questionSuffixHTML)
+	buf.WriteString(suffixHTML)
 	return buf.String()
 }
 

--- a/learn/pkg/learn/option.go
+++ b/learn/pkg/learn/option.go
@@ -1,25 +1,47 @@
 package learn
 
 // Option is used on QuestionModel creation to set optional parameters.
-type Option func(configurableModel)
+type Option func(*configurableModel)
 
-type configurableModel interface {
-	setPrivateKey(string)
-	setIgnoreSealed()
-	setRawMD(rawFrontmatter string, rawMD string)
+type configurableModel struct {
+	privateKey     string
+	ignoreSealed   bool
+	rawFrontmatter string
+	rawMD          string
+}
+
+func (m *configurableModel) setPrivateKey(privateKey string) {
+	m.privateKey = privateKey
+}
+
+func (m *configurableModel) setIgnoreSealed() {
+	m.ignoreSealed = true
+}
+
+func (m *configurableModel) setRawMD(rawFrontmatter string, rawMD string) {
+	m.rawFrontmatter = rawFrontmatter
+	m.rawMD = rawMD
+}
+
+func newConfigurableModel(options []Option) *configurableModel {
+	m := &configurableModel{}
+	for _, opt := range options {
+		opt(m)
+	}
+	return m
 }
 
 // WithPrivateKey sets privateKey and all follow-up method invocations attempt
 // to unseal sealed answers.
 func WithPrivateKey(privateKey string) Option {
-	return func(m configurableModel) {
+	return func(m *configurableModel) {
 		m.setPrivateKey(privateKey)
 	}
 }
 
 // WithIgnoreSealed sets explicit flag to ignore all sealed question.
 func WithIgnoreSealed() Option {
-	return func(m configurableModel) {
+	return func(m *configurableModel) {
 		m.setIgnoreSealed()
 	}
 }
@@ -27,7 +49,7 @@ func WithIgnoreSealed() Option {
 // WithRawMD stores given frontmatter and markdown Contents, useful if
 // Markdown file has already been read.
 func WithRawMD(rawFrontmatter string, rawMD string) Option {
-	return func(m configurableModel) {
+	return func(m *configurableModel) {
 		m.setRawMD(rawFrontmatter, rawMD)
 	}
 }

--- a/learn/pkg/learn/questionfm.go
+++ b/learn/pkg/learn/questionfm.go
@@ -1,0 +1,74 @@
+package learn
+
+import "fmt"
+
+type questionFrontmatter struct {
+	Type         frontmatterType `yaml:"type,omitempty"` // question
+	Difficulty   difficulty      `yaml:"difficulty,omitempty"`
+	AnswerType   answerType      `yaml:"answer-type,omitempty"` // single-choice, multiple-choice, free-text, multiple-free-texts, program
+	Answer       string          `yaml:"answer,omitempty"`
+	SealedAnswer string          `yaml:"sealed-answer,omitempty"`
+}
+
+func (f *questionFrontmatter) validate() error {
+	if f.Type != "question" {
+		return fmt.Errorf("%w: want: %q, got: %q", ErrWrongFrontmatterType, "question", f.Type)
+	}
+	if f.Answer == "" && f.SealedAnswer == "" {
+		return fmt.Errorf("no answer found: %w", ErrNoFrontmatterAnswer)
+	}
+	if f.Answer != "" && f.SealedAnswer != "" {
+		return fmt.Errorf("%w: sealed and unsealed answer found, only one allowed", ErrInvalidFrontmatter)
+	}
+	return nil
+}
+
+func (f *questionFrontmatter) getAnswer(privateKey string) (Answer, error) {
+	text := f.Answer
+	if f.SealedAnswer != "" && privateKey == "" {
+		return Answer{}, ErrSealedAnswerNoKey
+	}
+	if f.SealedAnswer != "" {
+		var err error
+		text, err = Decrypt(privateKey, f.SealedAnswer)
+		if err != nil {
+			return Answer{}, err
+		}
+	}
+	if text == "" {
+		return Answer{}, fmt.Errorf("cannot get answerkey: %w", ErrNoFrontmatterAnswer)
+	}
+	return NewAnswer(f.AnswerType, text)
+}
+
+func (f *questionFrontmatter) Seal(publicKey string) error {
+	if f.Answer == "" && f.SealedAnswer != "" {
+		return nil // already sealed
+	}
+	if f.Answer == "" {
+		return fmt.Errorf("cannot seal empty answer: %w", ErrNoFrontmatterAnswer)
+	}
+	sealed, err := Encrypt(publicKey, f.Answer)
+	if err != nil {
+		return err
+	}
+	f.SealedAnswer = sealed
+	f.Answer = ""
+	return nil
+}
+
+func (f *questionFrontmatter) Unseal(privateKey string) error {
+	if f.Answer != "" && f.SealedAnswer == "" {
+		return nil // already unsealed
+	}
+	if f.SealedAnswer == "" {
+		return fmt.Errorf("cannot unseal empty sealed-answer: %w", ErrNoFrontmatterAnswer)
+	}
+	unsealed, err := Decrypt(privateKey, f.SealedAnswer)
+	if err != nil {
+		return err
+	}
+	f.SealedAnswer = ""
+	f.Answer = unsealed
+	return nil
+}

--- a/learn/pkg/learn/renderer.go
+++ b/learn/pkg/learn/renderer.go
@@ -264,6 +264,7 @@ func runEvy(source string, t ResultType) string {
 	opts := []cli.Option{
 		cli.WithSkipSleep(true),
 		cli.WithOutputWriter(textWriter),
+		cli.WithCls(textWriter.Reset),
 		cli.WithSVG("" /* root style */),
 	}
 	rt := cli.NewRuntime(opts...)

--- a/learn/pkg/learn/testdata/course1/README.md
+++ b/learn/pkg/learn/testdata/course1/README.md
@@ -1,0 +1,9 @@
+---
+type: course
+---
+
+# Course 1
+
+Only one unit ready at the moment, sorry:
+
+- [Unit 1: Demo Unit](unit1/README.md)

--- a/learn/pkg/learn/testdata/course1/unit1/README.md
+++ b/learn/pkg/learn/testdata/course1/unit1/README.md
@@ -1,0 +1,37 @@
+---
+type: unit
+---
+
+# Unit 1: Demo Unit
+
+```
+Legend:
+✳️ Exercise mastered: Proficient skill correct on the unit test (🟩 ☝️).
+🟩 Exercise proficient: 100% correct or familiar skill correct during a quiz or unit test (🟨 ☝️).
+🟨 Exercise familiar: >=70 % correct.
+🟪 Exercise attempted: < 70 % correct or wrong during quiz or unit test.
+🔲 Exercise not started
+✨ Quiz
+⭐️ Unit test
+```
+
+Unit introduction goes here. 1-2 sentences, maybe a paragraph.
+
+## Getting Started
+
+- [`print` command](intro.md)
+- [Exercise: `print` 👈](exercise1/README.md)
+- [Drawing canvas](shape/intro.md)
+- [Draw shapes](shape/commands.md)
+- [Exercise: Shape commands 👈](shape/README.md)
+- [Quiz: drawing and print ✨](quiz1.md)
+
+## Draw with Style
+
+- [Draw text](text/intro.md)
+- [Exercise: text and shapes 👈](text/README.md)
+- [Clear output](cls/cls.md)
+- [Clear drawing](cls/clear.md)
+- [Exercise: styled shapes 👈](cls/README.md)
+- [Quiz: Text and style ✨](quiz2.md)
+- [Unit test: drawing and print ⭐️](unittest.md)

--- a/learn/pkg/learn/testdata/course1/unit1/cls/README.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/README.md
@@ -1,0 +1,10 @@
+---
+type: exercise
+composition:
+  - easy: 2
+  - medium: 2
+---
+
+# Clear exercise
+
+Clear printed text and drawings.

--- a/learn/pkg/learn/testdata/course1/unit1/cls/clear.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/clear.md
@@ -1,0 +1,4 @@
+# `clear` command
+
+The `clear` command is used to clear the output of the canvas. It is useful
+when you want to start a new drawing or remove the current one.

--- a/learn/pkg/learn/testdata/course1/unit1/cls/cls.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/cls.md
@@ -1,0 +1,3 @@
+# `cls` command
+
+The `cls` command is used to clear the text output of the console.

--- a/learn/pkg/learn/testdata/course1/unit1/cls/draw/a.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/draw/a.evy
@@ -1,0 +1,5 @@
+move 50 50
+circle 20
+clear
+circle 10
+

--- a/learn/pkg/learn/testdata/course1/unit1/cls/draw/b.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/draw/b.evy
@@ -1,0 +1,4 @@
+move 50 50
+circle 10
+clear
+circle 20

--- a/learn/pkg/learn/testdata/course1/unit1/cls/draw/c.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/draw/c.evy
@@ -1,0 +1,5 @@
+move 20 20
+circle 10
+clear
+move 60 60
+circle 20

--- a/learn/pkg/learn/testdata/course1/unit1/cls/draw/d.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/draw/d.evy
@@ -1,0 +1,5 @@
+move 40 40
+circle 10
+clear
+move 80 80
+circle 20

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-cls1.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-cls1.md
@@ -1,0 +1,26 @@
+---
+type: question
+difficulty: medium
+answer-type: single-choice
+answer: c
+---
+
+## The `print` command
+
+What does this program output?
+
+```evy
+print "hey"
+cls
+print "ho"
+print "hi"
+cls
+print "hi"
+```
+
+Choose one correct answer:
+
+- `"hey"`
+- `ho`
+- `hi`
+- `"hi"`

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-cls2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-cls2.md
@@ -1,0 +1,27 @@
+---
+type: question
+difficulty: medium
+answer-type: single-choice
+answer: a
+---
+
+## The `print` command
+
+What does this program output?
+
+```evy
+print "hey"
+print "ho"
+cls
+print "hi"
+print "ha"
+cls
+print "hey"
+```
+
+Choose one correct answer:
+
+- `hey`
+- `ho`
+- `hi`
+- `ha`

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-cls3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-cls3.md
@@ -1,0 +1,43 @@
+---
+type: question
+difficulty: medium
+answer-type: multiple-choice
+answer: a,b
+---
+
+## The `print` command
+
+Which two program generates the following output?
+
+```
+hi
+ho
+```
+
+Choose one correct answer:
+
+- ```evy
+  print "ho"
+  cls
+  print "hi"
+  print "ho"
+  ```
+- ```evy
+  print "hi"
+  cls
+  print "hi"
+  print "ho"
+  ```
+- ```evy
+  print "hi"
+  cls
+  print "hi"
+  cls
+  print "ho"
+  print "hi"
+  ```
+- ```evy
+  print "hi"
+  cls
+  print "ho"
+  ```

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-cls4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-cls4.md
@@ -1,0 +1,43 @@
+---
+type: question
+difficulty: medium
+answer-type: multiple-choice
+answer: a,d
+---
+
+## The `print` command
+
+Which two program generates the following output?
+
+```
+ho
+```
+
+Choose one correct answer:
+
+- ```evy
+  print "ho"
+  cls
+  print "hi"
+  cls
+  print "ho"
+  ```
+- ```evy
+  print "hi"
+  cls
+  print "hi"
+  print "ho"
+  ```
+- ```evy
+  print "hi"
+  cls
+  print "hi"
+  cls
+  print "ho"
+  print "hi"
+  ```
+- ```evy
+  print "hi"
+  cls
+  print "ho"
+  ```

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-draw1.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-draw1.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: c
+---
+
+## Clear drawings
+
+Which program generates the following output?
+
+[question](draw/c.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](draw/a.evy "evy:source")
+- [answer](draw/b.evy "evy:source")
+- [answer](draw/c.evy "evy:source")
+- [answer](draw/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-draw2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-draw2.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: b
+---
+
+## Clear drawings
+
+Which program generates the following output?
+
+[question](draw/b.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](draw/a.evy "evy:source")
+- [answer](draw/b.evy "evy:source")
+- [answer](draw/c.evy "evy:source")
+- [answer](draw/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-draw3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-draw3.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: a
+---
+
+## Clear drawings
+
+Which program generates the following output?
+
+[question](draw/a.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](draw/a.evy "evy:svg")
+- [answer](draw/b.evy "evy:svg")
+- [answer](draw/c.evy "evy:svg")
+- [answer](draw/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-draw4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-draw4.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: d
+---
+
+## Clear drawings
+
+Which program generates the following output?
+
+[question](draw/d.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](draw/a.evy "evy:svg")
+- [answer](draw/b.evy "evy:svg")
+- [answer](draw/c.evy "evy:svg")
+- [answer](draw/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/intro.md
+++ b/learn/pkg/learn/testdata/course1/unit1/intro.md
@@ -1,0 +1,9 @@
+# You first Unit 🌱
+
+Let's start by understanding the `print` command.
+It outputs the given text to the screen.
+
+```
+print 1 2 3
+print "abc"
+```

--- a/learn/pkg/learn/testdata/course1/unit1/quiz1.md
+++ b/learn/pkg/learn/testdata/course1/unit1/quiz1.md
@@ -1,0 +1,12 @@
+---
+type: quiz
+exercises:
+  - exercise1
+  - shape
+composition:
+  - easy: 1
+  - medium: 2
+  - hard: 2
+---
+
+# Quiz 1: print and shapes

--- a/learn/pkg/learn/testdata/course1/unit1/quiz2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/quiz2.md
@@ -1,0 +1,12 @@
+---
+type: quiz
+exercises:
+  - text
+  - cls
+composition:
+  - easy: 2
+  - medium: 2
+  - hard: 2
+---
+
+# Quiz 2: Drawing style and clear

--- a/learn/pkg/learn/testdata/course1/unit1/shape/2circles/a.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/2circles/a.evy
@@ -1,0 +1,5 @@
+move 80 20
+circle 5
+
+move 60 60
+circle 10

--- a/learn/pkg/learn/testdata/course1/unit1/shape/2circles/b.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/2circles/b.evy
@@ -1,0 +1,5 @@
+move 20 20
+circle 10
+
+move 40 60
+circle 5

--- a/learn/pkg/learn/testdata/course1/unit1/shape/2circles/c.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/2circles/c.evy
@@ -1,0 +1,5 @@
+move 80 80
+circle 5
+
+move 60 40
+circle 10

--- a/learn/pkg/learn/testdata/course1/unit1/shape/2circles/d.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/2circles/d.evy
@@ -1,0 +1,5 @@
+move 80 80
+circle 10
+
+move 40 40
+circle 5

--- a/learn/pkg/learn/testdata/course1/unit1/shape/README.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/README.md
@@ -1,0 +1,10 @@
+---
+type: exercise
+composition:
+  - easy: 2
+  - medium: 2
+---
+
+# Shape Exercise
+
+Intro to drawing shapes

--- a/learn/pkg/learn/testdata/course1/unit1/shape/circle/a.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/circle/a.evy
@@ -1,0 +1,2 @@
+move 20 20
+circle 10

--- a/learn/pkg/learn/testdata/course1/unit1/shape/circle/b.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/circle/b.evy
@@ -1,0 +1,2 @@
+move 20 80
+circle 10

--- a/learn/pkg/learn/testdata/course1/unit1/shape/circle/c.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/circle/c.evy
@@ -1,0 +1,2 @@
+move 80 20
+circle 10

--- a/learn/pkg/learn/testdata/course1/unit1/shape/circle/d.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/circle/d.evy
@@ -1,0 +1,2 @@
+move 80 80
+circle 10

--- a/learn/pkg/learn/testdata/course1/unit1/shape/commands.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/commands.md
@@ -1,0 +1,5 @@
+# Drawing commands
+
+- `move x y`: move drawing pen to coordinates `x` `y`
+- `circle r`: draw a circle at current position with radius `r`
+- `rect w h`: draw a rectangle at current position with given width `w` and height `h`

--- a/learn/pkg/learn/testdata/course1/unit1/shape/intro.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/intro.md
@@ -1,0 +1,8 @@
+# Drawing commands
+
+Use drawing command to draw shapes on the canvas, ex:
+
+```evy
+move 50 50
+circle 20
+```

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles1.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles1.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: hard
+answer-type: single-choice
+answer: c
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](2circles/c.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](2circles/a.evy "evy:source")
+- [answer](2circles/b.evy "evy:source")
+- [answer](2circles/c.evy "evy:source")
+- [answer](2circles/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles2.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: hard
+answer-type: single-choice
+answer: b
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](2circles/b.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](2circles/a.evy "evy:source")
+- [answer](2circles/b.evy "evy:source")
+- [answer](2circles/c.evy "evy:source")
+- [answer](2circles/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles3.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: medium
+answer-type: single-choice
+answer: a
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](2circles/a.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](2circles/a.evy "evy:svg")
+- [answer](2circles/b.evy "evy:svg")
+- [answer](2circles/c.evy "evy:svg")
+- [answer](2circles/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles4.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: medium
+answer-type: single-choice
+answer: d
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](2circles/d.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](2circles/a.evy "evy:svg")
+- [answer](2circles/b.evy "evy:svg")
+- [answer](2circles/c.evy "evy:svg")
+- [answer](2circles/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-circle1.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-circle1.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy # "easy", "medium", "hard", "retriable"
+answer-type: single-choice # single-choice, multiple-choice, free-text, multiple-free-texts, program
+answer: c
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](circle/c.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](circle/a.evy "evy:source")
+- [answer](circle/b.evy "evy:source")
+- [answer](circle/c.evy "evy:source")
+- [answer](circle/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-circle2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-circle2.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy # "easy", "medium", "hard", "retriable"
+answer-type: single-choice # single-choice, multiple-choice, free-text, multiple-free-texts, program
+answer: b
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](circle/b.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](circle/a.evy "evy:svg")
+- [answer](circle/b.evy "evy:svg")
+- [answer](circle/c.evy "evy:svg")
+- [answer](circle/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-circle3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-circle3.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy # "easy", "medium", "hard", "retriable"
+answer-type: single-choice # single-choice, multiple-choice, free-text, multiple-free-texts, program
+answer: d
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](circle/d.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](circle/a.evy "evy:svg")
+- [answer](circle/b.evy "evy:svg")
+- [answer](circle/c.evy "evy:svg")
+- [answer](circle/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-circle4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-circle4.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy # "easy", "medium", "hard", "retriable"
+answer-type: single-choice # single-choice, multiple-choice, free-text, multiple-free-texts, program
+answer: d
+---
+
+## Understanding sequence: `move`,`circle` commands
+
+Which program generates the following output?
+
+[question](circle/d.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](circle/a.evy "evy:source")
+- [answer](circle/b.evy "evy:source")
+- [answer](circle/c.evy "evy:source")
+- [answer](circle/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/text/README.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/README.md
@@ -1,0 +1,10 @@
+---
+type: exercise
+composition:
+  - easy: 2
+  - medium: 2
+---
+
+# Text exercise
+
+Draw text on the canvas, not the console. This text can be styled.

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/a.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/a.evy
@@ -1,0 +1,5 @@
+move 20 20
+color "red"
+text "Hello"
+color "blue"
+text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/b.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/b.evy
@@ -1,0 +1,5 @@
+move 20 20
+color "red"
+text "World"
+color "blue"
+text "Hello"

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/c.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/c.evy
@@ -1,0 +1,5 @@
+move 20 20
+color "blue"
+text "Hello"
+color "re"
+text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/d.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/d.evy
@@ -1,0 +1,5 @@
+move 20 20
+color "blue"
+text "World"
+color "red"
+text "Hello"

--- a/learn/pkg/learn/testdata/course1/unit1/text/plain/a.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/plain/a.evy
@@ -1,0 +1,4 @@
+move 20 20
+text "Hello"
+move 20 60
+text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/plain/b.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/plain/b.evy
@@ -1,0 +1,4 @@
+move 20 60
+text "Hello"
+move 20 20
+text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/plain/c.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/plain/c.evy
@@ -1,0 +1,4 @@
+move 20 20
+text "Hello"
+move 60 20
+text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/plain/d.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/plain/d.evy
@@ -1,0 +1,4 @@
+move 60 20
+text "Hello"
+move 20 20
+text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-colored1.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-colored1.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: hard
+answer-type: single-choice
+answer: c
+---
+
+## Draw colored text on canvas
+
+Which program generates the following output?
+
+[question](colored/c.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](colored/a.evy "evy:source")
+- [answer](colored/b.evy "evy:source")
+- [answer](colored/c.evy "evy:source")
+- [answer](colored/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-colored2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-colored2.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: hard
+answer-type: single-choice
+answer: d
+---
+
+## Draw colored text on canvas
+
+Which program generates the following output?
+
+[question](colored/d.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](colored/a.evy "evy:source")
+- [answer](colored/b.evy "evy:source")
+- [answer](colored/c.evy "evy:source")
+- [answer](colored/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-colored3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-colored3.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: medium
+answer-type: single-choice
+answer: a
+---
+
+## Draw colored text on canvas
+
+Which program generates the following output?
+
+[question](colored/a.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](colored/a.evy "evy:svg")
+- [answer](colored/b.evy "evy:svg")
+- [answer](colored/c.evy "evy:svg")
+- [answer](colored/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-colored4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-colored4.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: medium
+answer-type: single-choice
+answer: b
+---
+
+## Draw colored text on canvas
+
+Which program generates the following output?
+
+[question](colored/b.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](colored/a.evy "evy:svg")
+- [answer](colored/b.evy "evy:svg")
+- [answer](colored/c.evy "evy:svg")
+- [answer](colored/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-plain1.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-plain1.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: c
+---
+
+## Draw text on canvas
+
+Which program generates the following output?
+
+[question](plain/c.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](plain/a.evy "evy:source")
+- [answer](plain/b.evy "evy:source")
+- [answer](plain/c.evy "evy:source")
+- [answer](plain/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-plain2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-plain2.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: a
+---
+
+## Draw text on canvas
+
+Which program generates the following output?
+
+[question](plain/a.evy "evy:svg")
+
+Choose one correct answer:
+
+- [answer](plain/a.evy "evy:source")
+- [answer](plain/b.evy "evy:source")
+- [answer](plain/c.evy "evy:source")
+- [answer](plain/d.evy "evy:source")

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-plain3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-plain3.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: b
+---
+
+## Draw text on canvas
+
+Which program generates the following output?
+
+[question](plain/b.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](plain/a.evy "evy:svg")
+- [answer](plain/b.evy "evy:svg")
+- [answer](plain/c.evy "evy:svg")
+- [answer](plain/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-plain4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-plain4.md
@@ -1,0 +1,19 @@
+---
+type: question
+difficulty: easy
+answer-type: single-choice
+answer: d
+---
+
+## Draw text on canvas
+
+Which program generates the following output?
+
+[question](plain/d.evy "evy:source")
+
+Choose one correct answer:
+
+- [answer](plain/a.evy "evy:svg")
+- [answer](plain/b.evy "evy:svg")
+- [answer](plain/c.evy "evy:svg")
+- [answer](plain/d.evy "evy:svg")

--- a/learn/pkg/learn/testdata/course1/unit1/unittest.md
+++ b/learn/pkg/learn/testdata/course1/unit1/unittest.md
@@ -1,0 +1,14 @@
+---
+type: unittest
+composition:
+  - easy: 3
+  - hard: 1
+  - medium: 2
+  - hard: 1
+  - easy: 4
+  - medium: 2
+ignore-exercises:
+  - exercise1
+---
+
+# Unit test: Understanding sequence

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -21,6 +21,7 @@ type Runtime struct {
 	evaluator.GraphicsRuntime
 	reader    *bufio.Reader
 	writer    io.Writer
+	clsFn     func()
 	SkipSleep bool
 }
 
@@ -52,6 +53,13 @@ func WithOutputWriter(w io.Writer) Option {
 	}
 }
 
+// WithCls sets the action to be done for `cls` command.
+func WithCls(clsFn func()) Option {
+	return func(rt *Runtime) {
+		rt.clsFn = clsFn
+	}
+}
+
 // NewRuntime returns an initialized cli runtime.
 func NewRuntime(options ...Option) *Runtime {
 	rt := &Runtime{
@@ -71,7 +79,11 @@ func (rt *Runtime) Print(s string) {
 }
 
 // Cls clears the screen.
-func (*Runtime) Cls() {
+func (rt *Runtime) Cls() {
+	if rt.clsFn != nil {
+		rt.clsFn()
+		return
+	}
 	cmd := exec.Command("clear")
 	if runtime.GOOS == "windows" {
 		cmd = exec.Command("cmd", "/c", "cls")

--- a/pkg/md/link.go
+++ b/pkg/md/link.go
@@ -1,0 +1,23 @@
+package md
+
+import (
+	"net/url"
+
+	"rsc.io/markdown"
+)
+
+// RewriteLink replace a relative link to a .md file the HTML filename
+// equivalent, see [HTMLFilename].
+func RewriteLink(n Node) {
+	mdl, ok := n.(*markdown.Link)
+	if !ok {
+		return
+	}
+	u, err := url.Parse(mdl.URL)
+	if err != nil || u.IsAbs() {
+		return
+	}
+	// relative path, fix *.md filenames
+	u.Path = HTMLFilename(u.Path)
+	mdl.URL = u.String()
+}

--- a/pkg/md/link_test.go
+++ b/pkg/md/link_test.go
@@ -1,0 +1,43 @@
+package md
+
+import (
+	"testing"
+
+	"evylang.dev/evy/pkg/assert"
+	"rsc.io/markdown"
+)
+
+func TestUpdateRelLink(t *testing.T) {
+	tests := []struct {
+		name string
+		mdl  *markdown.Link
+		want string
+	}{
+		{
+			name: "empty",
+			mdl:  &markdown.Link{},
+			want: "",
+		},
+		{
+			name: "relative",
+			mdl:  &markdown.Link{URL: "banana.md"},
+			want: "banana.html",
+		},
+		{
+			name: "relative-README.md",
+			mdl:  &markdown.Link{URL: "banana/README.md"},
+			want: "banana/index.html",
+		},
+		{
+			name: "absolute",
+			mdl:  &markdown.Link{URL: "http://example.com/banana.md"},
+			want: "http://example.com/banana.md",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RewriteLink(tt.mdl)
+			assert.Equal(t, tt.want, tt.mdl.URL)
+		})
+	}
+}


### PR DESCRIPTION
Refactor question model and various utilities in preparation
for exercise, unit, unittest, quiz and course models, see
#377 .
Add a pluggable `cls` function so that we can use `bytes.Buffer`
to capture output.
Add testdata for follow-up commits with more comprehensive course
markdown.

---

Rendered new testdata:
https://learn.evytest.dev/all/