### PR TITLE
learn: Add course catalog exporting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - cyclop
     - depguard
     - dupword
+    - dupl
     - execinquery
     - exhaustive
     - exhaustruct

--- a/learn/README.md
+++ b/learn/README.md
@@ -41,16 +41,16 @@ It currently supports the following sub-commands:
 Try it with
 
     make install
-    levy export all --unselaed-only pkg/question/testdata/course1/unit1/exercise1 out
-    levy seal pkg/question/testdata/course1/unit1/exercise1/question1.md
+    levy export all --ignore-sealed pkg/learn/testdata/course1 out
+    levy seal pkg/learn/testdata/course1/unit1/exercise1/question1.md
 
 For sample error messages in case of failed verification, try
 
-    levy verify pkg/question/testdata/course1/unit1/err-exercise1/err-false-negative.md
+    levy verify pkg/learn/testdata/course1/unit1/err-exercise1/err-false-negative.md
 
 To unseal sealed questions you need the secret private key. Here is a sample
 usage with a private-key that is a test key. Do not use this key in
 production!
 
     export EVY_LEARN_PRIVATE_KEY="MIIEpQIBAAKCAQEAuNEufiuryg/OZPKVUbaIRam1UNqju5binwrRzsOGWkM6DYKqxW2tA+O7dhg9do/Jm0lr+rkVqf8CR/HejD08n9OTsHe0NeblLwZncQX1J3ayyGsu+xAFxQ0hvFfG+Vy8KXJAgug6CCsaiVgBwOWPdfEOqEDv5S5XlnwQh9dxWB8m/1CTDmqSdIhYnzQQp13ZyumCRgrIHKSYPR3KCZD8KLRvkoIrF0DU18f6ASO7wjv7FBhgQ2ZAR/Yud/h6ceQKvAW0W3MmPiJblZhbrsPQGi7eZZo4K8aAvuzQmcYq17/E/e6MnOweoyik4lIAG0uGa7FiY5f9NVuir7JPA2lCLwIDAQABAoIBAQCJHEcNu4BbC5bnNUCpum0moVyue0X1KV8+9lvotQ27cRxkYYgnp9IvjIfKePlAODQtTC8bdqwnzdP3Y+zixZtwRxrOVEARrRZh6LJdGzpg6KKCJWJZR+2/3pokjEpFPRMq/GP3uikzXib1taC3ZpcjvI5PLL3MnLDGJ4xr+t1Pral8BXSILhUSQzgMFAB8+5V+zWnUPuPzCeym3VeYpZSdbSsR+CZnxy4vbB4cSj97M1MgBTOPocduE5cRrE8mumAk93dzBmKH+/potjLOMhCiJJFVtPO9GXLLduLAH9qKwSk2vJytIX8KwYFTCve2EKhMB9ydBhk09zVoELUle0mhAoGBAOc9agk5CahkNOVO1E3Cw1zK+Da+2LXYk2HhjTpOTkr2lKji8v1eSDkk5R72ZfPrI5s8sBrkW0OqPJVXDnmho78quWHTwxvJrnrIcuZLa1Kn4H+cHN81J9jGcim7kLPTZUcnU0RMR7Xn3lT61H5lB3LSFplRq52tqS5AaxaksS0tAoGBAMybQjceAVTihCHKFkaFV8Ys2dm5p5ejCzYklY+jA0UdTmHT6kmr13KIA6k61+s8kyZDaGutZ6lRyHuCfotL6j6jr8rsn/EbDikZ4/XhhO9+B+xJMXolKLFA+/pBPxNs7KLSjZ3mH7N0qzxbQzyVWF4BhSxTxIjWEGAtc1ZUJN5LAoGBAMYPFzRhE0GU2q2RkEwuRnDDNEiHvEw8/Td4HiPTkEGq4/ens2KKj6fKTyju+LIsM6oyF9BgyT6yoAN1tmM9rGf/qxr8av/xBa4K5EcWUA1S1vnV9/DCsad9iajvC2jK5tND/pDgGQfYWtlEoh7EX9Xb1hlqF2kNpnuEF3UkiNDdAoGBAJzuMFlKAEd0/VdVQsSQHYR4fhbKmMprWXwLj1L9+tIV6jqKaVZcIQFNZVF1OorIiSx94ydDdxCdE6H3sstwTJgCwCBqYTpyP+gyXXAHqwhtp/IJKZO/0HgzmZCWXqStlMpFqC0FhicEQxol/WoIOiDQFa6sCT/Sv/iko6QBIc4FAoGAMSC5SUsgUiHo6gvp2put1ySmJIVj3roqI6mAndi2hLVMalF1Q5F4X4HVHWqOj7QA7zpf3ATotCI4AbmfOwpFCZ4rEP0QsbV2uZ/3NhxwAE1MWrv+ht2ONe74sOYg7Z+XAjD7TW7We3KTewerVnC/VotKZ+3Eq2FgelSYDvlNmoQ="
-    levy unseal pkg/question/testdata/course1/unit1/exercise1/question1-sealed.md
+    levy unseal pkg/learn/testdata/course1/unit1/exercise1/question1-sealed.md

--- a/learn/cmd/levy/main.go
+++ b/learn/cmd/levy/main.go
@@ -63,7 +63,7 @@ func main() {
 }
 
 type exportCmd struct {
-	ExportType        string `arg:"" enum:"html,answerkey,all" help:"Export target: one of html, answerkey, all."`
+	ExportType        string `arg:"" enum:"html,answerkey,catalog,all" help:"Export target: one of html, answerkey, catalog, all."`
 	Srcdir            string `arg:"" help:"Source directory containing markdown files." placeholder:"SRCDIR"`
 	Destdir           string `arg:"" default:"." help:"Output directory (default: .)" placeholder:"DESTDIR"`
 	IgnoreSealed      bool   `short:"i" help:"Only export answerkey and add solution to unsealed answers. Suitable if private key not available."`
@@ -91,12 +91,13 @@ type unsealCmd struct {
 }
 
 func (c *exportCmd) Run() error {
-	if c.ExportType == "answerkey" && c.WithAnswersMarked {
+	if c.WithAnswersMarked && c.ExportType != "all" && c.ExportType != "html" {
 		return errors.New(`--with-marked can only be used with all "all" and "html" export targets`) //nolint:err113 // dynamic errors in main are fine.
 	}
 	exportOptions := learn.ExportOptions{
 		WriteHTML:         c.ExportType == "html" || c.ExportType == "all",
 		WriteAnswerKey:    c.ExportType == "answerkey" || c.ExportType == "all",
+		WriteCatalog:      c.ExportType == "catalog" || c.ExportType == "all",
 		WithAnswersMarked: c.WithAnswersMarked,
 	}
 	modelOptions := getOptions(c.IgnoreSealed, c.PrivateKey)

--- a/learn/go.mod
+++ b/learn/go.mod
@@ -3,18 +3,12 @@ module evylang.dev/evy/learn
 go 1.22
 
 require (
-	evylang.dev/evy v0.1.123
+	evylang.dev/evy v0.1.130
 	github.com/alecthomas/kong v0.9.0
 	gopkg.in/yaml.v3 v3.0.1
-	rsc.io/markdown v0.0.0-20240306144322-0bf8f97ee8ef
+	rsc.io/markdown v0.0.0-20240603215554-74725d8a840a
 )
 
-require (
-	golang.org/x/text v0.15.0 // indirect
-	golang.org/x/tools v0.20.0 // indirect
-)
+require golang.org/x/text v0.16.0 // indirect
 
 replace evylang.dev/evy => ..
-
-// Remove when https://github.com/rsc/markdown/pull/18 is merged.
-replace rsc.io/markdown => evylang.dev/markdown v0.0.0-20240503034508-36e9fda2871b

--- a/learn/go.sum
+++ b/learn/go.sum
@@ -1,5 +1,3 @@
-evylang.dev/markdown v0.0.0-20240503034508-36e9fda2871b h1:V3xYhVgk3HorpKjaNVtjNRqShyvr5rpYHUMlkNZ/QjU=
-evylang.dev/markdown v0.0.0-20240503034508-36e9fda2871b/go.mod h1:8xcPgWmwlZONN1D9bjxtHEjrUtSEa3fakVF8iaewYKQ=
 github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
 github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v0.9.0 h1:G5diXxc85KvoV2f0ZRVuMsi45IrBgx9zDNGNj165aPA=
@@ -10,11 +8,13 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
 github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
-golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
-golang.org/x/tools v0.20.0 h1:hz/CVckiOxybQvFw6h7b/q80NTr9IUQb4s1IIzW7KNY=
-golang.org/x/tools v0.20.0/go.mod h1:WvitBU7JJf6A4jOdg4S1tviW9bhUxkgeCui/0JHctQg=
+golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
+golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+rsc.io/markdown v0.0.0-20240603215554-74725d8a840a h1:0ylZ/EkURbWbHm3vaTZpwqSj6L2jQJHdgg6wQy27a1I=
+rsc.io/markdown v0.0.0-20240603215554-74725d8a840a/go.mod h1:8xcPgWmwlZONN1D9bjxtHEjrUtSEa3fakVF8iaewYKQ=

--- a/learn/pkg/learn/catalog.go
+++ b/learn/pkg/learn/catalog.go
@@ -1,0 +1,84 @@
+package learn
+
+import (
+	"path/filepath"
+)
+
+// Course represents the bare bones structure of a course as needed on the
+// learn landing page and against progress tracking.
+type Course struct {
+	Name string `firestore:"name,omitempty" json:"name,omitempty"`
+	// PartialID  is the last path segment of the directory in which course
+	// Markdown file is located, as used in answerkey and AnswerPath.
+	// It is used in the same way for Unit and Exercise.
+	PartialID string          `firestore:"partialID,omitempty" json:"partialID,omitempty"`
+	MaxScore  int             `firestore:"maxScore,omitempty" json:"maxScore,omitempty"`
+	Units     map[string]Unit `firestore:"units,omitempty" json:"units,omitempty"`
+	UnitOrder []string        `firestore:"unitOrder,omitempty" json:"unitOrder,omitempty"`
+}
+
+// Unit represents the a unit within a course catalog.
+type Unit struct {
+	Name          string              `firestore:"name,omitempty" json:"name,omitempty"`
+	PartialID     string              `firestore:"partialID,omitempty" json:"partialID,omitempty"` // see Catalog.PartialID
+	MaxScore      int                 `firestore:"maxScore,omitempty" json:"maxScore,omitempty"`
+	Exercises     map[string]Exercise `firestore:"exercises,omitempty" json:"exercises,omitempty"`
+	ExerciseOrder []string            `firestore:"exerciseOrder,omitempty" json:"exerciseOrder,omitempty"`
+}
+
+// Exercise represents an exercise, a quiz or a unittest within a course
+// catalog.
+type Exercise struct {
+	PartialID   string            `firestore:"partialID,omitempty" json:"partialID,omitempty"` // see Catalog.PartialID
+	Type        string            `firestore:"type,omitempty" json:"type,omitempty"`           // "exercise", "quiz" or "unittest"
+	MaxScore    int               `firestore:"maxScore,omitempty" json:"maxScore,omitempty"`
+	Composition []DifficultyCount `firestore:"composition,omitempty" json:"composition,omitempty"`
+}
+
+const exerciseScore = 10
+
+// NewCourseCatalog creates a course catalog from a course model.
+func NewCourseCatalog(courseModel *CourseModel) Course {
+	course := Course{
+		Name:      courseModel.Name,
+		PartialID: filepath.Base(filepath.Dir(courseModel.Filename)),
+		Units:     map[string]Unit{},
+	}
+	for _, unitModel := range courseModel.Units {
+		unit := Unit{
+			Name:      unitModel.Name,
+			PartialID: filepath.Base(filepath.Dir(unitModel.Filename)),
+			Exercises: map[string]Exercise{},
+		}
+		for _, model := range unitModel.OrderedModels {
+			exercise := newExerciseCatalogEntry(model)
+			unit.Exercises[exercise.PartialID] = exercise
+			unit.ExerciseOrder = append(unit.ExerciseOrder, exercise.PartialID)
+			unit.MaxScore += exercise.MaxScore
+		}
+		course.Units[unit.PartialID] = unit
+		course.UnitOrder = append(course.UnitOrder, unit.PartialID)
+		course.MaxScore += unit.MaxScore
+	}
+	return course
+}
+
+func newExerciseCatalogEntry(model model) Exercise {
+	exercise := Exercise{}
+	switch m := model.(type) {
+	case *ExerciseModel:
+		exercise.PartialID = filepath.Base(filepath.Dir(m.Filename))
+		exercise.Composition = m.Frontmatter.Composition
+		exercise.MaxScore = exerciseScore
+		exercise.Type = "exercise"
+	case *QuizModel:
+		exercise.PartialID = baseNoExt(m.Filename)
+		exercise.Composition = m.Frontmatter.Composition
+		exercise.Type = "quiz"
+	case *UnittestModel:
+		exercise.PartialID = baseNoExt(m.Filename)
+		exercise.Composition = m.Frontmatter.Composition
+		exercise.Type = "unittest"
+	}
+	return exercise
+}

--- a/learn/pkg/learn/composition.go
+++ b/learn/pkg/learn/composition.go
@@ -21,8 +21,8 @@ import (
 //	  - hard: 3
 //	  - easy: 1
 type DifficultyCount struct {
-	Difficulty string
-	Count      int
+	Difficulty string `firestore:"difficulty,omitempty" json:"difficulty,omitempty"`
+	Count      int    `firestore:"count,omitempty" json:"count,omitempty"`
 }
 
 // UnmarshalYAML unmarshals a DifficultyCount from a YAML node. In the source

--- a/learn/pkg/learn/course.go
+++ b/learn/pkg/learn/course.go
@@ -16,6 +16,7 @@ type CourseModel struct {
 	Filename           string
 	Doc                *markdown.Document
 	Frontmatter        *courseFrontmatter
+	Name               string // flat markdown heading
 	Units              []*UnitModel
 }
 
@@ -106,5 +107,8 @@ func (m *CourseModel) parseFrontmatterMD() error {
 	}
 
 	m.Doc = parseMD(m.rawMD)
+	if m.Name, err = extractName(m.Doc); err != nil {
+		return fmt.Errorf("%w (%s)", err, m.Filename)
+	}
 	return nil
 }

--- a/learn/pkg/learn/exercise.go
+++ b/learn/pkg/learn/exercise.go
@@ -20,6 +20,7 @@ type ExerciseModel struct {
 	Filename              string
 	Doc                   *markdown.Document
 	Frontmatter           *exerciseFrontmatter
+	Name                  string
 	Questions             []*QuestionModel
 	QuestionsByDifficulty questionsByDifficulty
 }
@@ -106,5 +107,8 @@ func (m *ExerciseModel) parseFrontmatterMD() error {
 	}
 
 	m.Doc = parseMD(m.rawMD)
+	if m.Name, err = extractName(m.Doc); err != nil {
+		return fmt.Errorf("%w (%s)", err, m.Filename)
+	}
 	return nil
 }

--- a/learn/pkg/learn/export_test.go
+++ b/learn/pkg/learn/export_test.go
@@ -20,6 +20,7 @@ func TestExportAll(t *testing.T) {
 		WriteHTML:         true,
 		WriteAnswerKey:    true,
 		WithAnswersMarked: true,
+		WriteCatalog:      true,
 	}
 	err := Export(srcdir, destdir, opts, WithPrivateKey(testKeyPrivate))
 	assert.NoError(t, err)

--- a/learn/pkg/learn/markdown.go
+++ b/learn/pkg/learn/markdown.go
@@ -86,3 +86,18 @@ func collectMDLinks(doc *markdown.Document) []string {
 	})
 	return mdLinks
 }
+
+func extractName(doc *markdown.Document) (string, error) {
+	for _, b := range doc.Blocks {
+		h, ok := b.(*markdown.Heading)
+		if !ok {
+			continue
+		}
+		buf := &bytes.Buffer{}
+		for _, inline := range h.Text.Inline {
+			inline.PrintText(buf)
+		}
+		return buf.String(), nil
+	}
+	return "", fmt.Errorf("%w: no heading found", ErrBadMarkdownStructure)
+}

--- a/learn/pkg/learn/testdata/golden/export/all/catalog.json
+++ b/learn/pkg/learn/testdata/golden/export/all/catalog.json
@@ -1,0 +1,154 @@
+{
+  "course1": {
+    "name": "Course 1",
+    "partialID": "course1",
+    "maxScore": 40,
+    "units": {
+      "unit1": {
+        "name": "Unit 1: Demo Unit",
+        "partialID": "unit1",
+        "maxScore": 40,
+        "exercises": {
+          "cls": {
+            "partialID": "cls",
+            "type": "exercise",
+            "maxScore": 10,
+            "composition": [
+              {
+                "difficulty": "easy",
+                "count": 2
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              }
+            ]
+          },
+          "exercise1": {
+            "partialID": "exercise1",
+            "type": "exercise",
+            "maxScore": 10,
+            "composition": [
+              {
+                "difficulty": "easy",
+                "count": 2
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              }
+            ]
+          },
+          "quiz1": {
+            "partialID": "quiz1",
+            "type": "quiz",
+            "composition": [
+              {
+                "difficulty": "easy",
+                "count": 1
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              },
+              {
+                "difficulty": "hard",
+                "count": 2
+              }
+            ]
+          },
+          "quiz2": {
+            "partialID": "quiz2",
+            "type": "quiz",
+            "composition": [
+              {
+                "difficulty": "easy",
+                "count": 2
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              },
+              {
+                "difficulty": "hard",
+                "count": 2
+              }
+            ]
+          },
+          "shape": {
+            "partialID": "shape",
+            "type": "exercise",
+            "maxScore": 10,
+            "composition": [
+              {
+                "difficulty": "easy",
+                "count": 2
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              }
+            ]
+          },
+          "text": {
+            "partialID": "text",
+            "type": "exercise",
+            "maxScore": 10,
+            "composition": [
+              {
+                "difficulty": "easy",
+                "count": 2
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              }
+            ]
+          },
+          "unittest": {
+            "partialID": "unittest",
+            "type": "unittest",
+            "composition": [
+              {
+                "difficulty": "easy",
+                "count": 3
+              },
+              {
+                "difficulty": "hard",
+                "count": 1
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              },
+              {
+                "difficulty": "hard",
+                "count": 1
+              },
+              {
+                "difficulty": "easy",
+                "count": 4
+              },
+              {
+                "difficulty": "medium",
+                "count": 2
+              }
+            ]
+          }
+        },
+        "exerciseOrder": [
+          "exercise1",
+          "shape",
+          "quiz1",
+          "text",
+          "cls",
+          "quiz2",
+          "unittest"
+        ]
+      }
+    },
+    "unitOrder": [
+      "unit1"
+    ]
+  }
+}

--- a/learn/pkg/learn/unit.go
+++ b/learn/pkg/learn/unit.go
@@ -24,6 +24,7 @@ type UnitModel struct {
 	Filename           string
 	Doc                *markdown.Document
 	Frontmatter        *unitFrontmatter
+	Name               string
 	OrderedModels      []model // exercises, quizzes, unittests
 }
 
@@ -141,6 +142,9 @@ func (m *UnitModel) parseFrontmatterMD() error {
 	}
 	if _, ok := m.Doc.Blocks[0].(*markdown.Heading); !ok {
 		return fmt.Errorf("%w: first markdown element in unit Markdown file must be heading", ErrBadMarkdownStructure)
+	}
+	if m.Name, err = extractName(m.Doc); err != nil {
+		return fmt.Errorf("%w (%s)", err, m.Filename)
 	}
 	return nil
 }


### PR DESCRIPTION
Add course catalog exporting as single JSON file. Catalog contains all
information to generate a question set for an exercise, quiz or unittest
identified by composite IDs. It also holds the maximumScore achievable for
each course and unit. An exercise has a predefined score of 10. This will
allow for progress tracking as percentage.

Sneak in a couple of preparatory and clean-up commits: fix learn/README.md
update go dependencies and add Name field to some markdown model types.