### PR TITLE
cli: Support txtar format as input

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,6 +69,8 @@ You can also get help for each subcommand by running it with the
       -s, --no-assertion-summary    Do not print assertion summary, only report
                                     failed assertion(s).
           --fail-fast               Stop execution on first failed assertion.
+      -t, --txtar=MEMBER            Read source from txtar file and select select
+                                    given filename
 
 <!-- genend -->
 

--- a/frontend/docs/usage.html
+++ b/frontend/docs/usage.html
@@ -605,6 +605,8 @@ Flags:
   -s, --no-assertion-summary    Do not print assertion summary, only report
                                 failed assertion(s).
       --fail-fast               Stop execution on first failed assertion.
+  -t, --txtar=MEMBER            Read source from txtar file and select select
+                                given filename
 </code></pre>
         <!-- genend -->
         <h3><a id="evy-fmt-help" href="#evy-fmt-help" class="anchor">#</a>evy fmt --help</h3>

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/alecthomas/kong v0.9.0
+	golang.org/x/tools v0.6.0
 	rsc.io/markdown v0.0.0-20240306144322-0bf8f97ee8ef
 )
 

--- a/learn/pkg/learn/testdata/course1/unit1/exercise-txtar/q-print.txtar
+++ b/learn/pkg/learn/testdata/course1/unit1/exercise-txtar/q-print.txtar
@@ -1,0 +1,8 @@
+-- a.evy --
+print "hi"
+-- b.evy --
+print "hey"
+-- c.evy --
+print "print hey"
+-- d.evy --
+print "print hi"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print.txtar
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print.txtar
@@ -1,0 +1,8 @@
+-- a.evy --
+print "hi"
+-- b.evy --
+print "hey"
+-- c.evy --
+print "print hey"
+-- d.evy --
+print "print hi"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print.txtar
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print.txtar
@@ -1,0 +1,8 @@
+-- a.evy --
+print "hi"
+-- b.evy --
+print "hey"
+-- c.evy --
+print "print hey"
+-- d.evy --
+print "print hi"


### PR DESCRIPTION
Add support for the txtar file format as Evy source input. This will come in
handy for creating course work with multiple choice answers where we need
many small source files.