### PR TITLE
learn: Prepare for txtar support by levy

### DIFF
--- a/learn/pkg/learn/catalog.go
+++ b/learn/pkg/learn/catalog.go
@@ -41,13 +41,13 @@ const exerciseScore = 10
 func NewCourseCatalog(courseModel *CourseModel) Course {
 	course := Course{
 		Name:      courseModel.Name(),
-		PartialID: filepath.Base(filepath.Dir(courseModel.Filename)),
+		PartialID: filepath.Base(filepath.Dir(courseModel.Filename())),
 		Units:     map[string]Unit{},
 	}
 	for _, unitModel := range courseModel.Units {
 		unit := Unit{
 			Name:      unitModel.Name(),
-			PartialID: filepath.Base(filepath.Dir(unitModel.Filename)),
+			PartialID: filepath.Base(filepath.Dir(unitModel.Filename())),
 			Exercises: map[string]Exercise{},
 		}
 		for _, model := range unitModel.OrderedModels {
@@ -67,16 +67,16 @@ func newExerciseCatalogEntry(model model) Exercise {
 	exercise := Exercise{}
 	switch m := model.(type) {
 	case *ExerciseModel:
-		exercise.PartialID = filepath.Base(filepath.Dir(m.Filename))
+		exercise.PartialID = filepath.Base(filepath.Dir(m.Filename()))
 		exercise.Composition = m.Frontmatter.Composition
 		exercise.MaxScore = exerciseScore
 		exercise.Type = "exercise"
 	case *QuizModel:
-		exercise.PartialID = baseNoExt(m.Filename)
+		exercise.PartialID = baseNoExt(m.Filename())
 		exercise.Composition = m.Frontmatter.Composition
 		exercise.Type = "quiz"
 	case *UnittestModel:
-		exercise.PartialID = baseNoExt(m.Filename)
+		exercise.PartialID = baseNoExt(m.Filename())
 		exercise.Composition = m.Frontmatter.Composition
 		exercise.Type = "unittest"
 	}

--- a/learn/pkg/learn/composition.go
+++ b/learn/pkg/learn/composition.go
@@ -109,6 +109,8 @@ func (q questionsByDifficulty) PrintHTML(buf *bytes.Buffer) {
 // The generated question set will eventually be tracked and persisted for returning
 // students on the internet. This means we need to generate the question set before
 // we start the exercise.
+//
+// TODO: Use exercise round robin strategy for question selection for quiz and unittest.
 func GenerateQuestionSet(questionsByDifficulty questionsByDifficulty, composition []DifficultyCount) []*QuestionModel {
 	permByDifficulty := map[string][]int{}
 	for difficulty, quesitons := range questionsByDifficulty {

--- a/learn/pkg/learn/composition.go
+++ b/learn/pkg/learn/composition.go
@@ -53,12 +53,12 @@ func (q questionsByDifficulty) merge(other questionsByDifficulty) {
 	filenames := map[string]bool{}
 	for _, questions := range q {
 		for _, question := range questions {
-			filenames[question.Filename] = true
+			filenames[question.Filename()] = true
 		}
 	}
 	for difficulty, questions := range other {
 		for _, question := range questions {
-			if !filenames[question.Filename] {
+			if !filenames[question.Filename()] {
 				q[difficulty] = append(q[difficulty], question)
 			}
 		}
@@ -86,7 +86,7 @@ func (q questionsByDifficulty) PrintHTML(buf *bytes.Buffer) {
 		questions := q[difficulty]
 		filenames := make([]string, len(questions))
 		for i, question := range questions {
-			filenames[i] = question.Filename
+			filenames[i] = question.Filename()
 		}
 		slices.Sort(filenames)
 		for _, filename := range filenames {

--- a/learn/pkg/learn/composition_test.go
+++ b/learn/pkg/learn/composition_test.go
@@ -9,16 +9,16 @@ import (
 func TestGenerateQuestionSet(t *testing.T) {
 	questions := questionsByDifficulty{
 		"easy": []*QuestionModel{
-			{Filename: "easy1.md"},
-			{Filename: "easy2.md"},
-			{Filename: "easy3.md"},
-			{Filename: "easy4.md"},
+			{configurableModel: &configurableModel{filename: "easy1.md"}},
+			{configurableModel: &configurableModel{filename: "easy2.md"}},
+			{configurableModel: &configurableModel{filename: "easy3.md"}},
+			{configurableModel: &configurableModel{filename: "easy4.md"}},
 		},
 		"medium": []*QuestionModel{
-			{Filename: "medium1.md"},
-			{Filename: "medium2.md"},
-			{Filename: "medium3.md"},
-			{Filename: "medium4.md"},
+			{configurableModel: &configurableModel{filename: "medium1.md"}},
+			{configurableModel: &configurableModel{filename: "medium2.md"}},
+			{configurableModel: &configurableModel{filename: "medium3.md"}},
+			{configurableModel: &configurableModel{filename: "medium4.md"}},
 		},
 	}
 	composition := []DifficultyCount{
@@ -34,7 +34,7 @@ func TestGenerateQuestionSet(t *testing.T) {
 	for range repeats {
 		questionSet := GenerateQuestionSet(questions, composition)
 		for _, question := range questionSet {
-			repeatsByFilename[question.Filename]++
+			repeatsByFilename[question.Filename()]++
 		}
 	}
 	assert.Equal(t, 8, len(repeatsByFilename), "%#v", repeatsByFilename)

--- a/learn/pkg/learn/course.go
+++ b/learn/pkg/learn/course.go
@@ -50,7 +50,7 @@ func (m *CourseModel) buildUnits() error {
 		fname := filepath.Join(dir, relPath)
 		model, err := newModel(fname, opts, m.cache)
 		if err != nil {
-			return fmt.Errorf("%w: %s", err, fname)
+			return err
 		}
 		if unit, ok := model.(*UnitModel); ok {
 			m.Units = append(m.Units, unit)

--- a/learn/pkg/learn/export_test.go
+++ b/learn/pkg/learn/export_test.go
@@ -45,7 +45,9 @@ func assertSameContents(t *testing.T, wantDir, gotDir string) {
 	wantFiles := findFiles(wantDir)
 	gotFiles := findFiles(gotDir)
 	if slices.Compare(wantFiles, gotFiles) != 0 {
-		t.Errorf("want and got directories do not have the same files.\n want: %v\ngot: %v\n", wantFiles, gotFiles)
+		missingWantFiles := diff(wantFiles, gotFiles)
+		additionalGotFiles := diff(gotFiles, wantFiles)
+		t.Errorf("want and got directories do not have the same files.\nmissing files: %v\nextra files:  %v\n", missingWantFiles, additionalGotFiles)
 	}
 
 	for _, filename := range wantFiles {
@@ -59,6 +61,20 @@ func assertSameContents(t *testing.T, wantDir, gotDir string) {
 			t.Errorf("files %s and %s are not equal", wantFile, gotFile)
 		}
 	}
+}
+
+func diff(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
 }
 
 // findFiles finds all files in directory recursively.

--- a/learn/pkg/learn/learn.go
+++ b/learn/pkg/learn/learn.go
@@ -46,11 +46,13 @@ var (
 type model interface {
 	ToHTML(withAnswersMarked bool) (string, error)
 	Name() string
+	Filename() string
 }
 
 type plainMD struct {
-	doc  *markdown.Document
-	name string
+	filename string
+	doc      *markdown.Document
+	name     string
 }
 
 func (p *plainMD) ToHTML(_ bool) (string, error) {
@@ -62,13 +64,17 @@ func (p *plainMD) Name() string {
 	return p.name
 }
 
-func newPlainMD(mdString string) (*plainMD, error) {
+func (p *plainMD) Filename() string {
+	return p.filename
+}
+
+func newPlainMD(mdString, filename string) (*plainMD, error) {
 	doc := parseMD(mdString)
 	name, err := extractName(doc)
 	if err != nil {
 		return nil, err
 	}
-	return &plainMD{doc: doc, name: name}, nil
+	return &plainMD{doc: doc, name: name, filename: filename}, nil
 }
 
 func newModel(mdFile string, opts []Option, modelCache map[string]model) (model, error) {
@@ -82,7 +88,7 @@ func newModel(mdFile string, opts []Option, modelCache map[string]model) (model,
 	}
 	var model model
 	if frontmatterString == "" {
-		model, err = newPlainMD(mdString)
+		model, err = newPlainMD(mdString, mdFile)
 	} else {
 		model, err = newModelWithFrontmatter(mdFile, frontmatterString, mdString, opts)
 	}

--- a/learn/pkg/learn/option.go
+++ b/learn/pkg/learn/option.go
@@ -4,11 +4,16 @@ package learn
 type Option func(*configurableModel)
 
 type configurableModel struct {
+	filename       string
 	privateKey     string
 	ignoreSealed   bool
 	rawFrontmatter string
 	rawMD          string
 	cache          map[string]model
+}
+
+func (m *configurableModel) Filename() string {
+	return m.filename
 }
 
 func (m *configurableModel) setPrivateKey(privateKey string) {
@@ -28,8 +33,11 @@ func (m *configurableModel) setCache(cache map[string]model) {
 	m.cache = cache
 }
 
-func newConfigurableModel(options []Option) *configurableModel {
-	m := &configurableModel{cache: map[string]model{}}
+func newConfigurableModel(filename string, options []Option) *configurableModel {
+	m := &configurableModel{
+		filename: filename,
+		cache:    map[string]model{},
+	}
 	for _, opt := range options {
 		opt(m)
 	}

--- a/learn/pkg/learn/question.go
+++ b/learn/pkg/learn/question.go
@@ -66,7 +66,7 @@ func NewQuestionModel(filename string, options ...Option) (*QuestionModel, error
 		return nil, err
 	}
 	if err := question.buildQuestionModelForChoice(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w (%s)", err, question.Filename)
 	}
 	return question, nil
 }

--- a/learn/pkg/learn/question.go
+++ b/learn/pkg/learn/question.go
@@ -158,13 +158,9 @@ func (m *QuestionModel) printAnswerChoicesHTML(list *markdown.List, buf *bytes.B
 	if m.Frontmatter.AnswerType == "multiple-choice" {
 		inputType = "checkbox"
 	}
-	var correctAnswers map[int]bool
-	if withAnswersMarked && !(m.IsSealed() && m.ignoreSealed) {
-		answer, err := m.Frontmatter.getAnswer(m.privateKey)
-		if err != nil {
-			return err
-		}
-		correctAnswers = answer.correctAnswerIndices()
+	correctAnswers, err := m.correctAnswerIndices(withAnswersMarked)
+	if err != nil {
+		return err
 	}
 	for i, item := range list.Items {
 		checked := ""
@@ -186,6 +182,20 @@ func (m *QuestionModel) printAnswerChoicesHTML(list *markdown.List, buf *bytes.B
 	}
 	buf.WriteString("</fieldset>\n")
 	return nil
+}
+
+func (m *QuestionModel) correctAnswerIndices(withAnswersMarked bool) (map[int]bool, error) {
+	if !withAnswersMarked {
+		return nil, nil
+	}
+	if m.IsSealed() && m.ignoreSealed {
+		return nil, nil
+	}
+	answer, err := m.Frontmatter.getAnswer(m.privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: (%s)", err, m.Filename())
+	}
+	return answer.correctAnswerIndices(), nil
 }
 
 func (m *QuestionModel) getVerifiedAnswer() (Answer, error) {

--- a/learn/pkg/learn/question_test.go
+++ b/learn/pkg/learn/question_test.go
@@ -226,15 +226,15 @@ func TestErrInconsistency(t *testing.T) {
 }
 
 func TestRendererTracking(t *testing.T) {
-	embeds := map[string][]string{
-		"question1":      nil,
-		"question2":      nil,
-		"question-img1":  {"dot-dot-a-evy-svg", "dot-dot-b-evy-svg", "dot-dot-c-evy-svg", "dot-dot-d-evy-svg"},
-		"question-img2":  {"dot-dot-a-evy-svg"},
-		"question-link1": {"dot-dot-c-evy", "dot-dot-a-evy", "dot-dot-b-evy", "dot-dot-c-evy", "dot-dot-d-evy"},
-		"question-link2": {"dot-dot-c-evy", "dot-dot-a-evy", "dot-dot-b-evy", "dot-dot-c-evy", "dot-dot-d-evy"},
-		"question-link3": {"print-print-b-evy", "print-print-a-evy", "print-print-b-evy", "print-print-c-evy", "print-print-d-evy"},
-		"question-link4": {"print-print-d-evy", "print-print-a-evy", "print-print-b-evy", "print-print-c-evy", "print-print-d-evy"},
+	embeds := map[string]int{
+		"question1":      0,
+		"question2":      0,
+		"question-img1":  4, // "dot-dot-a-evy-svg", "dot-dot-b-evy-svg", "dot-dot-c-evy-svg", "dot-dot-d-evy-svg"
+		"question-img2":  1, // "dot-dot-a-evy-svg"
+		"question-link1": 5, // "dot-dot-c-evy", "dot-dot-a-evy", "dot-dot-b-evy", "dot-dot-c-evy", "dot-dot-d-evy"
+		"question-link2": 5, // "dot-dot-c-evy", "dot-dot-a-evy", "dot-dot-b-evy", "dot-dot-c-evy", "dot-dot-d-evy"
+		"question-link3": 5, // "print-print-b-evy", "print-print-a-evy", "print-print-b-evy", "print-print-c-evy", "print-print-d-evy"
+		"question-link4": 5, // "print-print-d-evy", "print-print-a-evy", "print-print-b-evy", "print-print-c-evy", "print-print-d-evy"
 	}
 	for name, want := range embeds {
 		t.Run(name, func(t *testing.T) {
@@ -242,14 +242,7 @@ func TestRendererTracking(t *testing.T) {
 			model, err := NewQuestionModel(fname)
 			assert.NoError(t, err)
 			got := model.embeds
-			assert.Equal(t, len(want), len(got))
-			m := map[string]bool{}
-			for _, w := range want {
-				m[w] = true
-			}
-			for _, g := range got {
-				assert.Equal(t, true, m[g.id], "cannot find "+g.id)
-			}
+			assert.Equal(t, want, len(got))
 		})
 	}
 }

--- a/learn/pkg/learn/question_test.go
+++ b/learn/pkg/learn/question_test.go
@@ -39,7 +39,7 @@ func TestNewQuestionModel(t *testing.T) {
 			got, err := NewQuestionModel(fname)
 			assert.NoError(t, err)
 
-			assert.Equal(t, fname, got.Filename)
+			assert.Equal(t, fname, got.Filename())
 			want := frontmatterType("question")
 			assert.Equal(t, want, got.Frontmatter.Type)
 		})

--- a/learn/pkg/learn/quiz.go
+++ b/learn/pkg/learn/quiz.go
@@ -17,7 +17,6 @@ import (
 // individual exercises.
 type QuizModel struct {
 	*configurableModel    // used by functional options
-	Filename              string
 	Doc                   *markdown.Document
 	Frontmatter           *quizFrontmatter
 	name                  string
@@ -27,10 +26,9 @@ type QuizModel struct {
 // NewQuizModel returns a new quiz model from a quiz Markdown file.
 func NewQuizModel(filename string, options ...Option) (*QuizModel, error) {
 	quiz := &QuizModel{
-		Filename:              filename,
 		name:                  "Quiz",
 		QuestionsByDifficulty: questionsByDifficulty{},
-		configurableModel:     newConfigurableModel(options),
+		configurableModel:     newConfigurableModel(filename, options),
 	}
 	quiz.cache[filename] = quiz
 	if err := quiz.parseFrontmatterMD(); err != nil {
@@ -49,7 +47,7 @@ type quizFrontmatter struct {
 }
 
 func (m *QuizModel) buildExercises() error {
-	dir := filepath.Dir(m.Filename)
+	dir := filepath.Dir(m.Filename())
 	var mdFiles []string
 	for _, path := range m.Frontmatter.Exercises {
 		files, err := filepath.Glob(filepath.Join(dir, path) + "/*.md")
@@ -93,9 +91,9 @@ func (m *QuizModel) Name() string {
 func (m *QuizModel) parseFrontmatterMD() error {
 	var err error
 	if m.rawFrontmatter == "" && m.rawMD == "" {
-		m.rawFrontmatter, m.rawMD, err = readSplitMDFile(m.Filename)
+		m.rawFrontmatter, m.rawMD, err = readSplitMDFile(m.Filename())
 		if err != nil {
-			return fmt.Errorf("%w (%s)", err, m.Filename)
+			return fmt.Errorf("%w (%s)", err, m.Filename())
 		}
 	}
 	m.Frontmatter = &quizFrontmatter{}

--- a/learn/pkg/learn/quiz_test.go
+++ b/learn/pkg/learn/quiz_test.go
@@ -14,8 +14,8 @@ func TestQuiz1(t *testing.T) {
 	assert.Equal(t, 5, len(questions))
 	questionSet := map[string]bool{}
 	for _, q := range questions {
-		questionSet[q.Filename] = true
-		got := strings.Contains(q.Filename, "exercise1") || strings.Contains(q.Filename, "shape")
+		questionSet[q.Filename()] = true
+		got := strings.Contains(q.Filename(), "exercise1") || strings.Contains(q.Filename(), "shape")
 		assert.Equal(t, true, got, "quiz1 should only contain exercise1 or shape questions", q.Filename)
 	}
 	assert.Equal(t, 5, len(questionSet))
@@ -28,8 +28,8 @@ func TestQuiz2(t *testing.T) {
 	assert.Equal(t, 6, len(questions))
 	questionSet := map[string]bool{}
 	for _, q := range questions {
-		questionSet[q.Filename] = true
-		got := strings.Contains(q.Filename, "text") || strings.Contains(q.Filename, "cls")
+		questionSet[q.Filename()] = true
+		got := strings.Contains(q.Filename(), "text") || strings.Contains(q.Filename(), "cls")
 		assert.Equal(t, true, got, "quiz2 should only contain text or cls questions", q.Filename)
 	}
 	assert.Equal(t, 6, len(questionSet))

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-draw3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-draw3.md
@@ -7,7 +7,7 @@ answer: a
 
 ## Clear drawings
 
-Which program generates the following output?
+What does this program output?
 
 [question](draw/a.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/cls/q-draw4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/cls/q-draw4.md
@@ -7,7 +7,7 @@ answer: d
 
 ## Clear drawings
 
-Which program generates the following output?
+What does this program output?
 
 [question](draw/d.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles3.md
@@ -7,7 +7,7 @@ answer: a
 
 ## Understanding sequence: `move`,`circle` commands
 
-Which program generates the following output?
+What does this program output?
 
 [question](2circles/a.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-2circles4.md
@@ -7,7 +7,7 @@ answer: d
 
 ## Understanding sequence: `move`,`circle` commands
 
-Which program generates the following output?
+What does this program output?
 
 [question](2circles/d.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-circle2.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-circle2.md
@@ -7,7 +7,7 @@ answer: b
 
 ## Understanding sequence: `move`,`circle` commands
 
-Which program generates the following output?
+What does this program output?
 
 [question](circle/b.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/shape/q-circle3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/shape/q-circle3.md
@@ -7,7 +7,7 @@ answer: d
 
 ## Understanding sequence: `move`,`circle` commands
 
-Which program generates the following output?
+What does this program output?
 
 [question](circle/d.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/a.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/a.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
 text "Hello"

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/b.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/b.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
 text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/c.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/c.evy
@@ -1,5 +1,6 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/colored/d.evy
+++ b/learn/pkg/learn/testdata/course1/unit1/text/colored/d.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
 text "World"

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-colored3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-colored3.md
@@ -7,7 +7,7 @@ answer: a
 
 ## Draw colored text on canvas
 
-Which program generates the following output?
+What does this program output?
 
 [question](colored/a.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-colored4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-colored4.md
@@ -7,7 +7,7 @@ answer: b
 
 ## Draw colored text on canvas
 
-Which program generates the following output?
+What does this program output?
 
 [question](colored/b.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-plain3.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-plain3.md
@@ -7,7 +7,7 @@ answer: b
 
 ## Draw text on canvas
 
-Which program generates the following output?
+What does this program output?
 
 [question](plain/b.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/course1/unit1/text/q-plain4.md
+++ b/learn/pkg/learn/testdata/course1/unit1/text/q-plain4.md
@@ -7,7 +7,7 @@ answer: d
 
 ## Draw text on canvas
 
-Which program generates the following output?
+What does this program output?
 
 [question](plain/d.evy "evy:source")
 

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/index.html
@@ -189,7 +189,7 @@ circle 20
 </form>
 <form id=q-draw3 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -250,7 +250,7 @@ circle 10
 </form>
 <form id=q-draw4 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-draw3 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw4.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-draw4 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/index.html
@@ -122,7 +122,7 @@ circle 10
 </form>
 <form id=q-circle2 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
@@ -172,7 +172,7 @@ circle 10
 </form>
 <form id=q-circle3 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>
@@ -263,7 +263,7 @@ circle 10
 </form>
 <form id=q-2circles3 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -320,7 +320,7 @@ circle 10
 </form>
 <form id=q-2circles4 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-2circles3 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 20
 circle 5
 

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles4.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-2circles4 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle2.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-circle2 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-circle3 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/a.evy
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/a.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
 text "Hello"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/b.evy
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/b.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
 text "World"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/c.evy
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/c.evy
@@ -1,5 +1,6 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/d.evy
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/colored/d.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
 text "World"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/index.html
@@ -181,7 +181,7 @@ text "World"
 </form>
 <form id=q-plain3 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -237,7 +237,7 @@ text "World"
 </form>
 <form id=q-plain4 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20
@@ -293,8 +293,9 @@ text "World"
 </form>
 <form id=q-colored3 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -307,8 +308,8 @@ text "World"
 <input type="radio" value="a" name="answer" checked />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -316,8 +317,8 @@ text "World"
 <input type="radio" value="b" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -325,8 +326,8 @@ text "World"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -334,16 +335,17 @@ text "World"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>
 </form>
 <form id=q-colored4 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -356,8 +358,8 @@ text "Hello"
 <input type="radio" value="a" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -365,8 +367,8 @@ text "Hello"
 <input type="radio" value="b" name="answer" checked />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -374,8 +376,8 @@ text "Hello"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -383,8 +385,8 @@ text "Hello"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>
@@ -394,15 +396,16 @@ text "Hello"
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -412,7 +415,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -422,17 +426,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" checked />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"
@@ -446,15 +452,16 @@ text "Hello"
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -464,7 +471,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -474,17 +482,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" checked />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored1.html
@@ -77,15 +77,16 @@
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -95,7 +96,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -105,17 +107,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" checked />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored2.html
@@ -77,15 +77,16 @@
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -95,7 +96,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -105,17 +107,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" checked />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored3.html
@@ -74,8 +74,9 @@
   <body>
     <form id=q-colored3 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -88,8 +89,8 @@ text "World"
 <input type="radio" value="a" name="answer" checked />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -97,8 +98,8 @@ text "World"
 <input type="radio" value="b" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -106,8 +107,8 @@ text "World"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -115,8 +116,8 @@ text "World"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored4.html
@@ -74,8 +74,9 @@
   <body>
     <form id=q-colored4 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -88,8 +89,8 @@ text "Hello"
 <input type="radio" value="a" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -97,8 +98,8 @@ text "Hello"
 <input type="radio" value="b" name="answer" checked />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -106,8 +107,8 @@ text "Hello"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -115,8 +116,8 @@ text "Hello"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-plain3 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain4.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-plain4 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/index.html
@@ -189,7 +189,7 @@ circle 20
 </form>
 <form id=q-draw3 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -250,7 +250,7 @@ circle 10
 </form>
 <form id=q-draw4 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-draw3 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw4.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-draw4 class="difficulty-easy">
 <h2>Clear drawings</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/index.html
@@ -122,7 +122,7 @@ circle 10
 </form>
 <form id=q-circle2 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
@@ -172,7 +172,7 @@ circle 10
 </form>
 <form id=q-circle3 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>
@@ -263,7 +263,7 @@ circle 10
 </form>
 <form id=q-2circles3 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -320,7 +320,7 @@ circle 10
 </form>
 <form id=q-2circles4 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-2circles3 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 20
 circle 5
 

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles4.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-2circles4 class="difficulty-medium">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle2.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-circle2 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-circle3 class="difficulty-easy">
 <h2>Understanding sequence: <code>move</code>,<code>circle</code> commands</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/a.evy
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/a.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
 text "Hello"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/b.evy
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/b.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
 text "World"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/c.evy
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/c.evy
@@ -1,5 +1,6 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/d.evy
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/colored/d.evy
@@ -1,3 +1,4 @@
+font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
 text "World"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/index.html
@@ -181,7 +181,7 @@ text "World"
 </form>
 <form id=q-plain3 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -237,7 +237,7 @@ text "World"
 </form>
 <form id=q-plain4 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20
@@ -293,8 +293,9 @@ text "World"
 </form>
 <form id=q-colored3 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -307,8 +308,8 @@ text "World"
 <input type="radio" value="a" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -316,8 +317,8 @@ text "World"
 <input type="radio" value="b" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -325,8 +326,8 @@ text "World"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -334,16 +335,17 @@ text "World"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>
 </form>
 <form id=q-colored4 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -356,8 +358,8 @@ text "Hello"
 <input type="radio" value="a" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -365,8 +367,8 @@ text "Hello"
 <input type="radio" value="b" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -374,8 +376,8 @@ text "Hello"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -383,8 +385,8 @@ text "Hello"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>
@@ -394,15 +396,16 @@ text "Hello"
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -412,7 +415,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -422,17 +426,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"
@@ -446,15 +452,16 @@ text "Hello"
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -464,7 +471,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -474,17 +482,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored1.html
@@ -77,15 +77,16 @@
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -95,7 +96,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -105,17 +107,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored2.html
@@ -77,15 +77,16 @@
 <p>Which program generates the following output?</p>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
 <label for="a">a</label>
 <input type="radio" value="a" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -95,7 +96,8 @@ text "World"
 <div>
 <label for="b">b</label>
 <input type="radio" value="b" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -105,17 +107,19 @@ text "Hello"
 <div>
 <label for="c">c</label>
 <input type="radio" value="c" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "Hello"
-color "re"
+color "red"
 text "World"
 </code></pre>
 </div>
 <div>
 <label for="d">d</label>
 <input type="radio" value="d" name="answer" />
-<pre><code class="language-evy">move 20 20
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "blue"
 text "World"
 color "red"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored3.html
@@ -74,8 +74,9 @@
   <body>
     <form id=q-colored3 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "Hello"
 color "blue"
@@ -88,8 +89,8 @@ text "World"
 <input type="radio" value="a" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -97,8 +98,8 @@ text "World"
 <input type="radio" value="b" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -106,8 +107,8 @@ text "World"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -115,8 +116,8 @@ text "World"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored4.html
@@ -74,8 +74,9 @@
   <body>
     <form id=q-colored4 class="difficulty-medium">
 <h2>Draw colored text on canvas</h2>
-<p>Which program generates the following output?</p>
-<pre><code class="language-evy">move 20 20
+<p>What does this program output?</p>
+<pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
+move 20 20
 color "red"
 text "World"
 color "blue"
@@ -88,8 +89,8 @@ text "Hello"
 <input type="radio" value="a" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -97,8 +98,8 @@ text "Hello"
 <input type="radio" value="b" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="red" stroke="red" x="200" y="800">World</text>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 <div>
@@ -106,8 +107,8 @@ text "Hello"
 <input type="radio" value="c" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">Hello</text>
-  <text fill="re" stroke="re" x="200" y="800">World</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
 </svg>
 </div>
 <div>
@@ -115,8 +116,8 @@ text "Hello"
 <input type="radio" value="d" name="answer" />
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
-  <text fill="blue" stroke="blue" x="200" y="800">World</text>
-  <text fill="red" stroke="red" x="200" y="800">Hello</text>
+  <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
+  <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
 </svg>
 </div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain3.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-plain3 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain4.html
@@ -74,7 +74,7 @@
   <body>
     <form id=q-plain4 class="difficulty-easy">
 <h2>Draw text on canvas</h2>
-<p>Which program generates the following output?</p>
+<p>What does this program output?</p>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/unit.go
+++ b/learn/pkg/learn/unit.go
@@ -113,7 +113,7 @@ func (m *UnitModel) buildModels() error {
 		fname := filepath.Join(dir, relPath)
 		model, err := newModel(fname, opts, m.cache)
 		if err != nil {
-			return fmt.Errorf("%w: %s", err, fname)
+			return err
 		}
 		switch model := model.(type) {
 		case *ExerciseModel:

--- a/learn/pkg/learn/unit.go
+++ b/learn/pkg/learn/unit.go
@@ -21,7 +21,6 @@ import (
 // summary. The order is captured in the OrderedModels slice.
 type UnitModel struct {
 	*configurableModel // used by functional options
-	Filename           string
 	Doc                *markdown.Document
 	Frontmatter        *unitFrontmatter
 	name               string // exercises, quizzes, unittests
@@ -32,8 +31,7 @@ type UnitModel struct {
 // contents.
 func NewUnitModel(filename string, options ...Option) (*UnitModel, error) {
 	unit := &UnitModel{
-		Filename:          filename,
-		configurableModel: newConfigurableModel(options),
+		configurableModel: newConfigurableModel(filename, options),
 	}
 	unit.cache[filename] = unit
 	if err := unit.parseFrontmatterMD(); err != nil {
@@ -59,7 +57,7 @@ func (m *UnitModel) ToHTML(_ bool) (string, error) {
 	md.Walk(m.Doc, md.RewriteLink)
 	buf := &bytes.Buffer{}
 	m.Doc.Blocks[0].PrintHTML(buf)
-	unitDir := filepath.Dir(m.Filename)
+	unitDir := filepath.Dir(m.Filename())
 	if err := m.printBadgesHTML(buf, unitDir); err != nil {
 		return "", err
 	}
@@ -82,21 +80,18 @@ func (m *UnitModel) printBadgesHTML(buf *bytes.Buffer, baseDir string) error {
 }
 
 func badgeURL(m model, baseDir string) (string, string, error) {
-	var badge, fname string
+	var badge string
 	switch m := m.(type) {
 	case *ExerciseModel:
 		badge = "🔲"
-		fname = m.Filename
 	case *QuizModel:
 		badge = "✨"
-		fname = m.Filename
 	case *UnittestModel:
 		badge = "⭐️"
-		fname = m.Filename
 	default:
 		return "", "", fmt.Errorf("%w: unit link: unknown model type %T", ErrInconsistentMdoel, m)
 	}
-	relPath, err := filepath.Rel(baseDir, fname)
+	relPath, err := filepath.Rel(baseDir, m.Filename())
 	if err != nil {
 		return "", "", fmt.Errorf("%w: cannot create relative path to exercise, quiz or unittest", err)
 	}
@@ -106,7 +101,7 @@ func badgeURL(m model, baseDir string) (string, string, error) {
 
 func (m *UnitModel) buildModels() error {
 	relPaths := collectMDLinks(m.Doc)
-	dir := filepath.Dir(m.Filename)
+	dir := filepath.Dir(m.Filename())
 	opts := newOptions(m.ignoreSealed, m.privateKey, m.cache)
 	quizCount := 1
 	for _, relPath := range relPaths {
@@ -133,9 +128,9 @@ func (m *UnitModel) buildModels() error {
 func (m *UnitModel) parseFrontmatterMD() error {
 	var err error
 	if m.rawFrontmatter == "" && m.rawMD == "" {
-		m.rawFrontmatter, m.rawMD, err = readSplitMDFile(m.Filename)
+		m.rawFrontmatter, m.rawMD, err = readSplitMDFile(m.Filename())
 		if err != nil {
-			return fmt.Errorf("%w (%s)", err, m.Filename)
+			return fmt.Errorf("%w (%s)", err, m.Filename())
 		}
 	}
 	m.Frontmatter = &unitFrontmatter{}
@@ -154,7 +149,7 @@ func (m *UnitModel) parseFrontmatterMD() error {
 		return fmt.Errorf("%w: first markdown element in unit Markdown file must be heading", ErrBadMarkdownStructure)
 	}
 	if m.name, err = extractName(m.Doc); err != nil {
-		return fmt.Errorf("%w (%s)", err, m.Filename)
+		return fmt.Errorf("%w (%s)", err, m.Filename())
 	}
 	return nil
 }

--- a/learn/pkg/learn/unittest_test.go
+++ b/learn/pkg/learn/unittest_test.go
@@ -14,8 +14,8 @@ func TestNewUnittestModel(t *testing.T) {
 	assert.Equal(t, 13, len(questions))
 	questionSet := map[string]bool{}
 	for _, q := range questions {
-		questionSet[q.Filename] = true
-		assert.Equal(t, false, strings.Contains(q.Filename, "exercise1"), "unittest should ignore exercise1")
+		questionSet[q.Filename()] = true
+		assert.Equal(t, false, strings.Contains(q.Filename(), "exercise1"), "unittest should ignore exercise1")
 	}
 	assert.Equal(t, 13, len(questionSet))
 }


### PR DESCRIPTION
- Factor out `QuestionModel.correctAnswerIndices` method for later reuse by
  txtar.
- Remove embedMD type in QuestionModel as it is not used other than in tests.
- Add Filename() method to model interface, which is necessary in
  QuestionModel based on txtar sub-questions that don't have an underlying
  filename.
- Ensure testdata descriptions match the question and answer.

And further testdata and error message improvements.