### PR TITLE
learn-site: Prepare for initial learn-site generation

### DIFF
--- a/learn/README.md
+++ b/learn/README.md
@@ -41,7 +41,7 @@ It currently supports the following sub-commands:
 Try it with
 
     make install
-    levy export all --ignore-sealed pkg/learn/testdata/course1 out
+    levy export all --ignore-sealed --self-contained pkg/learn/testdata/course1 out
     levy seal pkg/learn/testdata/course1/unit1/exercise1/question1.md
 
 For sample error messages in case of failed verification, try

--- a/learn/cmd/levy/main.go
+++ b/learn/cmd/levy/main.go
@@ -69,7 +69,7 @@ type exportCmd struct {
 	IgnoreSealed      bool   `short:"i" help:"Only export answerkey and add solution to unsealed answers. Suitable if private key not available."`
 	PrivateKey        string `short:"k" help:"Secret private key to decrypt sealed answers." env:"EVY_LEARN_PRIVATE_KEY"`
 	WithAnswersMarked bool   `short:"m" help:"Include marked answers in HTML output. Cannot be used with export target answerkey."`
-	WithHeadLinks     bool   `short:"l" help:"Use .css files rather than embedded CSS for standalone HTML. Same with scripts and favicon."`
+	SelfContained     bool   `short:"c" help:"Ensure .html files are self-contained (embed CSS, JS, Favicon)." negatable:""`
 }
 
 type verifyCmd struct {
@@ -100,7 +100,7 @@ func (c *exportCmd) Run() error {
 		WriteAnswerKey:    c.ExportType == "answerkey" || c.ExportType == "all",
 		WriteCatalog:      c.ExportType == "catalog" || c.ExportType == "all",
 		WithAnswersMarked: c.WithAnswersMarked,
-		WithHeadLinks:     c.WithHeadLinks,
+		SelfContained:     c.SelfContained,
 	}
 	modelOptions := getOptions(c.IgnoreSealed, c.PrivateKey)
 	return learn.Export(c.Srcdir, c.Destdir, exportOptions, modelOptions...)

--- a/learn/pkg/learn/composition.go
+++ b/learn/pkg/learn/composition.go
@@ -111,6 +111,7 @@ func (q questionsByDifficulty) PrintHTML(buf *bytes.Buffer) {
 // we start the exercise.
 //
 // TODO: Use exercise round robin strategy for question selection for quiz and unittest.
+// TODO: Add `group` field to frontmatter. Only one question per groups can be picked per exercise/quiz.
 func GenerateQuestionSet(questionsByDifficulty questionsByDifficulty, composition []DifficultyCount) []*QuestionModel {
 	permByDifficulty := map[string][]int{}
 	for difficulty, quesitons := range questionsByDifficulty {

--- a/learn/pkg/learn/course.go
+++ b/learn/pkg/learn/course.go
@@ -59,7 +59,7 @@ func (m *CourseModel) buildUnits() error {
 func (m *CourseModel) ToHTML(_ bool) (string, error) {
 	md.Walk(m.Doc, md.RewriteLink)
 	buf := &bytes.Buffer{}
-	m.Doc.PrintHTML(buf)
+	printHTML(m.Doc, buf)
 	if err := m.printUnitBadgesHTML(buf); err != nil {
 		return "", err
 	}

--- a/learn/pkg/learn/exercise.go
+++ b/learn/pkg/learn/exercise.go
@@ -52,7 +52,7 @@ type exerciseFrontmatter struct {
 func (m *ExerciseModel) ToHTML(withMarked bool) (string, error) {
 	buf := &bytes.Buffer{}
 	md.Walk(m.Doc, md.RewriteLink)
-	m.Doc.PrintHTML(buf)
+	printHTML(m.Doc, buf)
 	printComposition(buf, m.Frontmatter.Composition)
 	for _, d := range validDifficulties {
 		for _, question := range m.QuestionsByDifficulty[d] {

--- a/learn/pkg/learn/export.go
+++ b/learn/pkg/learn/export.go
@@ -17,7 +17,7 @@ type ExportOptions struct {
 	WriteAnswerKey    bool
 	WriteHTML         bool
 	WithAnswersMarked bool
-	WithHeadLinks     bool /* CSS, JS, Favicon links vs standalone embeds*/
+	SelfContained     bool /* CSS, JS, Favicon links vs standalone embeds*/
 	WriteCatalog      bool
 }
 
@@ -27,6 +27,9 @@ func (opts ExportOptions) validate() error {
 	}
 	if !opts.WriteHTML && opts.WithAnswersMarked {
 		return fmt.Errorf("%w: WithAnswersMarked requires WriteHTML", ErrInvalidExportOptions)
+	}
+	if !opts.WriteHTML && opts.SelfContained {
+		return fmt.Errorf("%w: SelfContained requires WriteHTML", ErrInvalidExportOptions)
 	}
 	return nil
 }
@@ -166,7 +169,7 @@ func writeHTMLFiles(models []model, srcDir, destDir string, opts ExportOptions) 
 		if err != nil {
 			return err
 		}
-		tmplData := newTmplData(mdFile, model.Name(), content, opts.WithHeadLinks)
+		tmplData := newTmplData(mdFile, model.Name(), content, !opts.SelfContained)
 		if err := writeHTMLFile(htmlFile, tmplData); err != nil {
 			return err
 		}

--- a/learn/pkg/learn/export_test.go
+++ b/learn/pkg/learn/export_test.go
@@ -21,6 +21,7 @@ func TestExportAll(t *testing.T) {
 		WriteAnswerKey:    true,
 		WithAnswersMarked: true,
 		WriteCatalog:      true,
+		SelfContained:     true,
 	}
 	err := Export(srcdir, destdir, opts, WithPrivateKey(testKeyPrivate))
 	assert.NoError(t, err)
@@ -33,7 +34,8 @@ func TestExportHTMLNoPrivateKey(t *testing.T) {
 	goldendir := "testdata/golden/export/html-no-private-key"
 
 	opts := ExportOptions{
-		WriteHTML: true,
+		WriteHTML:     true,
+		SelfContained: true,
 	}
 	err := Export(srcdir, destdir, opts, WithIgnoreSealed())
 	assert.NoError(t, err)

--- a/learn/pkg/learn/learn.go
+++ b/learn/pkg/learn/learn.go
@@ -58,7 +58,7 @@ type plainMD struct {
 
 func (p *plainMD) ToHTML(_ bool) (string, error) {
 	md.Walk(p.doc, md.RewriteLink)
-	return markdown.ToHTML(p.doc), nil
+	return toHTML(p.doc), nil
 }
 
 func (p *plainMD) Name() string {

--- a/learn/pkg/learn/markdown.go
+++ b/learn/pkg/learn/markdown.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -90,4 +91,73 @@ func extractName(doc *markdown.Document) (string, error) {
 		return buf.String(), nil
 	}
 	return "", fmt.Errorf("%w: no heading found", ErrBadMarkdownStructure)
+}
+
+func toHTML(doc *markdown.Document) string {
+	buf := &bytes.Buffer{}
+	for _, block := range doc.Blocks {
+		printHTML(block, buf)
+	}
+	return buf.String()
+}
+
+func printHTML(block markdown.Block, buf *bytes.Buffer) {
+	if alertType, ok := alertBlock(block); ok {
+		printAlert(block.(*markdown.Quote), buf, alertType)
+	} else {
+		block.PrintHTML(buf)
+	}
+}
+
+func alertBlock(block markdown.Block) (string, bool) {
+	quote, ok := block.(*markdown.Quote)
+	if !ok || len(quote.Blocks) == 0 {
+		return "", false
+	}
+	paragraph, ok := quote.Blocks[0].(*markdown.Paragraph)
+	if !ok || len(paragraph.Text.Inline) == 0 {
+		return "", false
+	}
+	plain, ok := paragraph.Text.Inline[0].(*markdown.Plain)
+	if !ok {
+		return "", false
+	}
+	text := strings.TrimSpace(plain.Text)
+	if !strings.HasPrefix(text, "[!") {
+		return "", false
+	}
+	idx := strings.Index(text, "]")
+	if idx == -1 {
+		return "", false
+	}
+	alertType := text[2:idx]
+	types := []string{"NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"}
+	// skip first inline in
+	if !slices.Contains(types, alertType) {
+		return "", false
+	}
+	paragraph.Text.Inline = paragraph.Text.Inline[1:]
+	return strings.ToLower(alertType), true
+}
+
+func printAlert(quote *markdown.Quote, buf *bytes.Buffer, alertType string) {
+	buf.WriteString(`<div class="alert alert-` + alertType + `">`)
+	buf.WriteString(`<p class="alert-title">`)
+	buf.WriteString(`<svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="`)
+	buf.WriteString(alertIconPath[alertType])
+	buf.WriteString(`"></path></svg>`)
+	buf.WriteString(strings.Title(alertType)) //nolint: staticcheck // we can savely use it here as we know all strings we want to use and have no punctuation.
+	buf.WriteString(`</p>`)
+	for _, block := range quote.Blocks {
+		block.PrintHTML(buf)
+	}
+	buf.WriteString(`</div>`)
+}
+
+var alertIconPath = map[string]string{
+	"note":      "M 0 8 a 8 8 0 1 1 16 0 A 8 8 0 0 1 0 8 Z m 8 -6.5 a 6.5 6.5 0 1 0 0 13 a 6.5 6.5 0 0 0 0 -13 Z M 6.5 7.75 A 0.75 0.75 0 0 1 7.25 7 h 1 a 0.75 0.75 0 0 1 0.75 0.75 v 2.75 h 0.25 a 0.75 0.75 0 0 1 0 1.5 h -2 a 0.75 0.75 0 0 1 0 -1.5 h 0.25 v -2 h -0.25 a 0.75 0.75 0 0 1 -0.75 -0.75 Z M 8 6 a 1 1 0 1 1 0 -2 a 1 1 0 0 1 0 2 Z",
+	"tip":       "M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z",
+	"important": "M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z",
+	"warning":   "M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z",
+	"caution":   "M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z",
 }

--- a/learn/pkg/learn/question.go
+++ b/learn/pkg/learn/question.go
@@ -159,7 +159,7 @@ func (m *QuestionModel) PrintHTML(buf *bytes.Buffer, withAnswersMarked bool) err
 		case ok: // question block (answers are covered in the cases above)
 			embed.RenderHTML(buf)
 		default:
-			block.PrintHTML(buf)
+			printHTML(block, buf)
 		}
 		if err != nil {
 			return err
@@ -206,7 +206,7 @@ func (m *QuestionModel) printAnswerChoicesHTML(list *markdown.List, buf *bytes.B
 			if embed, ok := m.embeds[block]; ok {
 				embed.RenderHTML(buf)
 			} else {
-				block.PrintHTML(buf)
+				printHTML(block, buf)
 			}
 		}
 		buf.WriteString("</div>\n")

--- a/learn/pkg/learn/quiz.go
+++ b/learn/pkg/learn/quiz.go
@@ -75,7 +75,7 @@ func (m *QuizModel) buildExercises() error {
 func (m *QuizModel) ToHTML(withAnswersMarked bool) (string, error) {
 	md.Walk(m.Doc, md.RewriteLink)
 	buf := &bytes.Buffer{}
-	m.Doc.PrintHTML(buf)
+	printHTML(m.Doc, buf)
 	if withAnswersMarked {
 		printComposition(buf, m.Frontmatter.Composition)
 		m.QuestionsByDifficulty.PrintHTML(buf)

--- a/learn/pkg/learn/subquestion.go
+++ b/learn/pkg/learn/subquestion.go
@@ -78,7 +78,7 @@ func newSubQuestion(m *QuestionModel, question, filename string, txtarEvyFile []
 		if txtarContent, ok := m.AnswerText.(*txtarContent); ok {
 			for _, file := range txtarContent.archive.Files {
 				if question == baseNoExt(file.Name) {
-					model.AnswerText = newRendererFromEvyBytes(file.Data, txtarContent.ResultType)
+					model.AnswerText = newRendererFromEvyBytesWithBlanked(file.Data, txtarContent.ResultType)
 				}
 			}
 		}

--- a/learn/pkg/learn/tmpl/learn.html.tmpl
+++ b/learn/pkg/learn/tmpl/learn.html.tmpl
@@ -4,19 +4,75 @@
     <meta charset="utf-8" />
     <title>{{.Title}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-{{- if .WithHeadLinks}}
     <link rel="icon" href="{{.Root}}/img/favicon.png" />
-  {{- range .CSSFiles}}
-    <link rel="stylesheet" href="{{$.Root}}/css/{{.}}" type="text/css" />
-  {{- end}}
-{{- else}}
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡️</text></svg>" />
-    <style>
-      {{.DefaultCSS | indent 3}}
-    </style>
-{{- end}}
+    <link rel="stylesheet" href="{{.Root}}/css/resets.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/root.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/elements.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/icons.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/header.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/dialog.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/primary.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/syntax.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/index.css" type="text/css" />
+    <link rel="stylesheet" href="{{.Root}}/css/fonts.css" type="text/css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "./module/highlight.js": "./module/highlight.js"
+        }
+      }
+    </script>
+    <script src="{{.Root}}/index.js" type="module"></script>
   </head>
   <body>
+    <header class="topnav docs">
+      <div class="left">
+        <button class="icon-hamburger" id="hamburger"></button>
+        <a href="/" class="desktop">
+          <img alt="Evy logo" class="logo" />
+        </a>
+      </div>
+      <div class="mobile center">
+        <span class="mobile">{{.Title}}</span>
+      </div>
+      <div class="right">
+        <nav class="docs-nav">
+          <button id="show-dialog-about">About</button>
+        </nav>
+        <a href="/" class="mobile logo-small"></a>
+      </div>
+    </header>
+
     {{.Content}}
+
+    <dialog id="dialog-about" class="large">
+      <form method="dialog">
+        <header>
+          <h1>About</h1>
+          <button class="icon-close"></button>
+        </header>
+        <main>
+          <object type="image/svg+xml" data="{{.Root}}/img/evy-e.v1.svg" class="evy-e dark-theme-only">
+            <img src="{{.Root}}/img/evy-e.v1.svg" alt="large, interactive letter 'e' as evy logo" />
+          </object>
+          <object type="image/svg+xml" data="{{.Root}}/img/evy-e-light-theme.v1.svg" class="evy-e light-theme-only">
+            <img src="{{.Root}}/img/evy-e.v1.svg" alt="large, interactive letter 'e' as evy logo" />
+          </object>
+          <h2>Evy is a simple programming language, made to learn coding.</h2>
+          <p>
+            Evy is a modern, beginner-friendly programming language that bridges the gap between
+            block-based coding and conventional programming languages. Its simple syntax and small
+            set of built-in functions make it easy to learn and use, but it still is powerful enough
+            for user interaction, games, and animations.
+          </p>
+          <p>
+            Created by a software engineer and parent who struggled to teach their kids programming
+            with conventional languages, Evy is designed to make real programming as fun and easy as
+            possible.
+          </p>
+          <button class="primary">Done</button>
+        </main>
+      </form>
+    </dialog>
   </body>
 </html>

--- a/learn/pkg/learn/tmpl/self-contained.html.tmpl
+++ b/learn/pkg/learn/tmpl/self-contained.html.tmpl
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{.Title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡️</text></svg>" />
+    <style>
+      {{.DefaultCSS | indent 3}}
+    </style>
+  </head>
+  <body>
+    {{.Content}}
+  </body>
+</html>

--- a/learn/pkg/learn/unit.go
+++ b/learn/pkg/learn/unit.go
@@ -62,7 +62,7 @@ func (m *UnitModel) ToHTML(_ bool) (string, error) {
 		return "", err
 	}
 	for _, block := range m.Doc.Blocks[1:] {
-		block.PrintHTML(buf)
+		printHTML(block, buf)
 	}
 	return buf.String(), nil
 }

--- a/learn/pkg/learn/unittest.go
+++ b/learn/pkg/learn/unittest.go
@@ -76,7 +76,7 @@ func (m *UnittestModel) buildExercises() error {
 func (m *UnittestModel) ToHTML(withAnswersMarked bool) (string, error) {
 	md.Walk(m.Doc, md.RewriteLink)
 	buf := &bytes.Buffer{}
-	m.Doc.PrintHTML(buf)
+	printHTML(m.Doc, buf)
 	if withAnswersMarked {
 		printComposition(buf, m.Frontmatter.Composition)
 		m.QuestionsByDifficulty.PrintHTML(buf)


### PR DESCRIPTION
- Generate text output from `//levy:blank` tagged txtar contents
- Render `> [!NOTE]` as a note block
- Split HTML templates into self-contained and learn
- Rename `--with-head-links` flag to `--self-contained`