### PR TITLE
deploy: Use special root path re-write for learn subdomain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # --- Global -------------------------------------------------------------------
 O = out
-COVERAGE = 70
+COVERAGE = 69
 VERSION ?= $(shell git describe --tags --dirty  --always)
 GOFILES = $(shell find . -name '*.go')
 

--- a/build-tools/firebase-deploy
+++ b/build-tools/firebase-deploy
@@ -20,14 +20,16 @@ main() {
 	if [[ "${channel}" == "live" ]]; then
 		local domain
 		domain=$(get_domain "${environ}")
-		go run ./build-tools/site-gen --cache-bust --domain="${domain}" frontend out/firebase/public
+		go run ./build-tools/site-gen --cache-bust --domain="${domain}" frontend out/firebase/public/apex
+		go run ./build-tools/site-gen --cache-bust --domain="${domain}" --sub-domain=learn frontend/learn out/firebase/public/learn
 		# `firebase deploy` must be used with live channel
 		firebase --config out/firebase/firebase.json --project "${environ}" deploy --only hosting
 		on_ci && make_env_urls "${environ}" >>"$GITHUB_ENV"
 		exit 0
 	fi
 
-	go run ./build-tools/site-gen frontend out/firebase/public
+	go run ./build-tools/site-gen frontend out/firebase/public/apex
+	go run ./build-tools/site-gen --sub-domain=learn frontend/learn out/firebase/public/learn
 	# `firebase hosting:channel:deploy` must be used with preview/non-live channels
 	result=$(firebase --json --config out/firebase/firebase.json --project "${environ}" hosting:channel:deploy "${channel}")
 	check_deploy_error "${result}"

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -6,7 +6,7 @@
   "hosting": [
     {
       "target": "apex",
-      "public": "public",
+      "public": "public/apex",
       "headers": [
         {
           "source": "**/*.*.@(js|css|woff2|svg)",
@@ -39,19 +39,19 @@
     },
     {
       "target": "ai",
-      "public": "public/ai"
+      "public": "public/apex/ai"
     },
     {
       "target": "discord",
-      "public": "public/discord"
+      "public": "public/apex/discord"
     },
     {
       "target": "docs",
-      "public": "public/docs"
+      "public": "public/apex/docs"
     },
     {
       "target": "lab",
-      "public": "public/lab"
+      "public": "public/apex/lab"
     },
     {
       "target": "learn",
@@ -59,7 +59,7 @@
     },
     {
       "target": "play",
-      "public": "public/play",
+      "public": "public/apex/play",
       "rewrites": [
         {
           "source": "/version",


### PR DESCRIPTION
Use special root path re-write for learn subdomain where we replace
`/lear/PATH` with `/PATH`. This allows for absolute paths without domain used
as links, in particular in sidebar links.