### PR TITLE
learn-site: Add SPA links, loading only page fragments

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -9,6 +9,12 @@
       "options": {
         "parser": "html"
       }
+    },
+    {
+      "files": "*.htmlf",
+      "options": {
+        "parser": "html"
+      }
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ docs:
 
 ## Generate static HTML for learn.evy.dev in frontend/learn from MarkDown in learn/content
 learn: install
-	levy export html --no-self-contained --skip-questions --root-dir="/learn/" learn/content $(LEARN_TARGET_DIR)
+	levy export html --no-self-contained --root-dir="/learn/" learn/content $(LEARN_TARGET_DIR)
 	npx --prefix $(NODEPREFIX) -y prettier --write $(LEARN_TARGET_DIR)
 
 FIND_GENERATED_CMD = fd --exclude '*.css' --exclude '*.js' --type file --full-path

--- a/frontend/learn/courses.html
+++ b/frontend/learn/courses.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/courses.html
+++ b/frontend/learn/courses.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Courses</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="./img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="./css/resets.css" type="text/css" />
     <link rel="stylesheet" href="./css/root.css" type="text/css" />
     <link rel="stylesheet" href="./css/elements.css" type="text/css" />

--- a/frontend/learn/courses.htmlf
+++ b/frontend/learn/courses.htmlf
@@ -1,0 +1,4 @@
+<h1>Courses</h1>
+<ul>
+  <li><a href="foundation/index.html">Foundation</a></li>
+</ul>

--- a/frontend/learn/css/index.css
+++ b/frontend/learn/css/index.css
@@ -231,9 +231,13 @@ textarea {
   background: var(--background-code);
   font-family: var(--font-family-code);
 }
+label {
+  display: flex;
+  align-items: stretch;
+}
 input[type="radio"],
 input[type="checkbox"] {
-  margin-top: 0.4rem;
+  margin-left: 8px;
 }
 
 /* --- Alert notes ------------------------------------------------------- */

--- a/frontend/learn/css/index.css
+++ b/frontend/learn/css/index.css
@@ -34,7 +34,7 @@ main {
    If we applied the same rules to main, the scrollbar would show up offset from the
    right edge, at `margin-right:auto` distance. */
 main .max-width-wrapper {
-  max-width: 60rem;
+  max-width: 50rem;
   width: 100%;
   margin-left: auto;
   margin-right: auto;

--- a/frontend/learn/foundation/index.html
+++ b/frontend/learn/foundation/index.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/foundation/index.html
+++ b/frontend/learn/foundation/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>🌱 Foundation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="../img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="../css/resets.css" type="text/css" />
     <link rel="stylesheet" href="../css/root.css" type="text/css" />
     <link rel="stylesheet" href="../css/elements.css" type="text/css" />

--- a/frontend/learn/foundation/index.htmlf
+++ b/frontend/learn/foundation/index.htmlf
@@ -1,0 +1,20 @@
+<h1>🌱 Foundation</h1>
+<p>
+  Programming is for everyone! You don't have to have a specific background or education. You just
+  need curiosity and the willingness to try.
+</p>
+<p>
+  In this course, you'll learn how to make the computer follow your instructions one by one,
+  creating your first graphics! You'll work with different types of data like numbers and text, and
+  even teach your programs to make choices and repeat actions.
+</p>
+<p>Let's get started! 🚀</p>
+<h3>Units</h3>
+<ul>
+  <li><a href="sequence/index.html">Unit 1: Sequential Execution</a></li>
+</ul>
+<div class="badges">
+  <h2>Sequential Execution</h2>
+  <a href="sequence/print/index.html">🔲</a>
+  <a href="sequence/multiple-print/index.html">🔲</a>
+</div>

--- a/frontend/learn/foundation/sequence/evy.html
+++ b/frontend/learn/foundation/sequence/evy.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Evy</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="../../img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="../../css/resets.css" type="text/css" />
     <link rel="stylesheet" href="../../css/root.css" type="text/css" />
     <link rel="stylesheet" href="../../css/elements.css" type="text/css" />

--- a/frontend/learn/foundation/sequence/evy.html
+++ b/frontend/learn/foundation/sequence/evy.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/foundation/sequence/evy.htmlf
+++ b/frontend/learn/foundation/sequence/evy.htmlf
@@ -1,0 +1,21 @@
+<h1>Evy</h1>
+<p>
+  Evy is a programming language that helps you learn how to code. It's made for people who are just
+  starting out, and it has simple rules that make it easy to understand.
+</p>
+<h2>Evy website</h2>
+<p>
+  You can try it out on the Evy web <a href="https://play.evy.dev">playground</a>, where you can
+  choose from a variety of examples to get you started. If you have some programming experience, you
+  may also find the <a href="https://docs.evy.dev/syntax_by_example.html">Syntax by Example</a> or
+  the <a href="https://docs.evy.dev/spec.html">Language Specification</a> helpful.
+</p>
+<p>
+  Write your code on the left. Click <code>Run</code> to see the output on the right, including any
+  text or drawings that your code generates.
+</p>
+<p><img src="img/playground-screenshot.png" alt="Screenshot of the Evy web playground" /></p>
+<h2>Hello world in Evy</h2>
+<p>Here's an Evy program that writes <code>Hello world</code> to the screen</p>
+<pre><code class="language-evy">print &quot;Hello world&quot;
+</code></pre>

--- a/frontend/learn/foundation/sequence/index.html
+++ b/frontend/learn/foundation/sequence/index.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/foundation/sequence/index.html
+++ b/frontend/learn/foundation/sequence/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Sequential Execution</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="../../img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="../../css/resets.css" type="text/css" />
     <link rel="stylesheet" href="../../css/root.css" type="text/css" />
     <link rel="stylesheet" href="../../css/elements.css" type="text/css" />

--- a/frontend/learn/foundation/sequence/index.htmlf
+++ b/frontend/learn/foundation/sequence/index.htmlf
@@ -1,0 +1,23 @@
+<h1>Sequential Execution</h1>
+<div class="badges">
+  <a href="print/index.html">🔲</a>
+  <a href="multiple-print/index.html">🔲</a>
+</div>
+<p>
+  In this unit, we'll learn about sequential execution, which means telling the computer to do
+  things step-by-step, just like following a recipe. We'll see how this simple idea is the backbone
+  of every program you'll ever create.
+</p>
+<h2><code>print</code> sequentially</h2>
+<ul>
+  <li><a href="evy.html">📖 Evy web interface</a></li>
+  <li>
+    <a href="print/print.html">📖 The <code>print</code> command</a>
+  </li>
+  <li>
+    <a href="print/index.html">👉 <code>print</code> command</a>
+  </li>
+  <li>
+    <a href="multiple-print/index.html">👉 Sequential <code>print</code></a>
+  </li>
+</ul>

--- a/frontend/learn/foundation/sequence/multiple-print/index.html
+++ b/frontend/learn/foundation/sequence/multiple-print/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Sequential print</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="../../../img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="../../../css/resets.css" type="text/css" />
     <link rel="stylesheet" href="../../../css/root.css" type="text/css" />
     <link rel="stylesheet" href="../../../css/elements.css" type="text/css" />
@@ -118,28 +118,24 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "1" "2"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "2" "1"
 </code></pre>
             </div>
@@ -154,28 +150,24 @@ print "1"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "1" "2"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "2" "1"
 </code></pre>
             </div>
@@ -189,28 +181,24 @@ print "1"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "1" "2"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "2" "1"
 </code></pre>
             </div>
@@ -224,28 +212,24 @@ print "1"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "1" "2"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "2" "1"
 </code></pre>
             </div>
@@ -260,28 +244,24 @@ print "2"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>1
 2
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>2
 1
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>1 2
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>2 1
 </code></pre>
             </div>
@@ -296,28 +276,24 @@ print "1"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>1
 2
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>2
 1
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>1 2
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>2 1
 </code></pre>
             </div>
@@ -331,28 +307,24 @@ print "1"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>1
 2
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>2
 1
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>1 2
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>2 1
 </code></pre>
             </div>
@@ -366,28 +338,24 @@ print "1"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>1
 2
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>2
 1
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>1 2
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>2 1
 </code></pre>
             </div>
@@ -403,30 +371,26 @@ print "1"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱"
 print "🌦️"
 print "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷"
 print "🌦️"
 print "🌱"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
 </code></pre>
             </div>
@@ -442,30 +406,26 @@ print "🌱"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱"
 print "🌦️"
 print "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷"
 print "🌦️"
 print "🌱"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
 </code></pre>
             </div>
@@ -479,30 +439,26 @@ print "🌱"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱"
 print "🌦️"
 print "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷"
 print "🌦️"
 print "🌱"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
 </code></pre>
             </div>
@@ -516,30 +472,26 @@ print "🌱"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱"
 print "🌦️"
 print "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷"
 print "🌦️"
 print "🌱"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
 </code></pre>
             </div>
@@ -555,30 +507,26 @@ print "🌷"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🌱
 🌦️
 🌷
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🌷
 🌦️
 🌱
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🌱 🌦️ 🌷
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🌷 🌦️ 🌱
 </code></pre>
             </div>
@@ -594,30 +542,26 @@ print "🌱"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🌱
 🌦️
 🌷
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🌷
 🌦️
 🌱
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🌱 🌦️ 🌷
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🌷 🌦️ 🌱
 </code></pre>
             </div>
@@ -631,30 +575,26 @@ print "🌱"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🌱
 🌦️
 🌷
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🌷
 🌦️
 🌱
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🌱 🌦️ 🌷
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🌷 🌦️ 🌱
 </code></pre>
             </div>
@@ -668,30 +608,26 @@ print "🌱"
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🌱
 🌦️
 🌷
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🌷
 🌦️
 🌱
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🌱 🌦️ 🌷
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🌷 🌦️ 🌱
 </code></pre>
             </div>

--- a/frontend/learn/foundation/sequence/multiple-print/index.html
+++ b/frontend/learn/foundation/sequence/multiple-print/index.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/foundation/sequence/multiple-print/index.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/index.htmlf
@@ -1,0 +1,744 @@
+<h1>Sequential <code>print</code></h1>
+<h3>Question Composition</h3>
+<table>
+  <tr>
+    <td>easy 🌶️</td>
+    <td>2</td>
+  </tr>
+  <tr>
+    <td>medium 🌶️🌶️</td>
+    <td>2</td>
+  </tr>
+</table>
+<form id="q-countdown-inverted-8" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>1
+2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-inverted-d" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>2
+1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-inverted-a" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>1 2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-inverted-3" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>2 1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-5" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-f" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-4" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "1" "2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-1" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "2" "1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-inverted-e3" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-inverted-96" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-inverted-8b" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌱 🌦️ 🌷
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-inverted-93" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌷 🌦️ 🌱
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-0" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-a" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-5" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-plants-1" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-rhyme-inverted-61" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Bugs like hugs.
+👾🐛🥰
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+print "👾🐛🥰"
+</textarea
+  >
+</form>
+<form id="q-rhyme-inverted-f8" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Colors clash
+with a splash.
+💻🌈⛲️
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+print "Colors clash"
+
+print "💻🌈⛲️"
+</textarea
+  >
+</form>
+<form id="q-rhyme-inverted-a3" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>The early bird
+finds the bug.
+🐥🪳🐛
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+print "The early bird"
+
+print "🐥🪳🐛"
+</textarea
+  >
+</form>
+<form id="q-rhyme-inverted-02" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>🦊👗🐞
+Fox in dress
+finds bugs for less.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+print "🦊👗🐞"
+
+print "finds bugs for less."
+</textarea
+  >
+</form>
+<form id="q-rhyme-inverted-ad" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Foxes build boxes.
+🎁
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+print "🎁"
+</textarea
+  >
+</form>
+<form id="q-rhyme-inverted-6d" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Smart cookies
+code together.
+🍪💻
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+
+
+print "🍪💻"
+</textarea
+  >
+</form>
+<form id="q-rhyme-c" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Bugs like hugs."
+print "👾🐛🥰"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+👾🐛🥰
+</textarea
+  >
+</form>
+<form id="q-rhyme-1" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Colors clash"
+print "with a splash."
+print "💻🌈⛲️"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+Colors clash
+
+💻🌈⛲️
+</textarea
+  >
+</form>
+<form id="q-rhyme-6" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "The early bird"
+print "finds the bug."
+print "🐥🪳🐛"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+The early bird
+
+🐥🪳🐛
+</textarea
+  >
+</form>
+<form id="q-rhyme-f" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "🦊👗🐞"
+print "Fox in dress"
+print "finds bugs for less."
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+🦊👗🐞
+
+finds bugs for less.
+</textarea
+  >
+</form>
+<form id="q-rhyme-8" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Foxes build boxes."
+print "🎁"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+🎁
+</textarea
+  >
+</form>
+<form id="q-rhyme-9" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Smart cookies"
+print "code together."
+print "🍪💻"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+
+
+🍪💻
+</textarea
+  >
+</form>
+<form id="q-rhyme2-0" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Clever code,
+problems explode.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>
+<form id="q-rhyme2-1" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Every hour:
+pixel power.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>
+<form id="q-rhyme2-5" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Madam Program, never calm, 
+uses code as soothing balm.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>
+<form id="q-rhyme2-c" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Cookies remember
+things about you.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-1.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-1.htmlf
@@ -1,0 +1,31 @@
+<form id="q-countdown-1" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "2" "1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-4.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-4.htmlf
@@ -1,0 +1,31 @@
+<form id="q-countdown-4" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "1" "2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-5.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-5.htmlf
@@ -1,0 +1,32 @@
+<form id="q-countdown-5" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-f.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-f.htmlf
@@ -1,0 +1,32 @@
+<form id="q-countdown-f" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>1
+2
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>2
+1
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>1 2
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>2 1
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-3.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-3.htmlf
@@ -1,0 +1,31 @@
+<form id="q-countdown-inverted-3" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>2 1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-8.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-8.htmlf
@@ -1,0 +1,32 @@
+<form id="q-countdown-inverted-8" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>1
+2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-a.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-a.htmlf
@@ -1,0 +1,31 @@
+<form id="q-countdown-inverted-a" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>1 2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-d.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-countdown-inverted-d.htmlf
@@ -1,0 +1,32 @@
+<form id="q-countdown-inverted-d" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>2
+1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "1"
+print "2"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "2"
+print "1"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "1" "2"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "2" "1"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-0.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-0.htmlf
@@ -1,0 +1,35 @@
+<form id="q-plants-0" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-1.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-1.htmlf
@@ -1,0 +1,33 @@
+<form id="q-plants-1" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-5.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-5.htmlf
@@ -1,0 +1,33 @@
+<form id="q-plants-5" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-a.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-a.htmlf
@@ -1,0 +1,35 @@
+<form id="q-plants-a" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>What does this program output?</p>
+  <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🌱 🌦️ 🌷
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🌷 🌦️ 🌱
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-8b.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-8b.htmlf
@@ -1,0 +1,33 @@
+<form id="q-plants-inverted-8b" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌱 🌦️ 🌷
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-93.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-93.htmlf
@@ -1,0 +1,33 @@
+<form id="q-plants-inverted-93" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌷 🌦️ 🌱
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-96.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-96.htmlf
@@ -1,0 +1,35 @@
+<form id="q-plants-inverted-96" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌷
+🌦️
+🌱
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-e3.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-plants-inverted-e3.htmlf
@@ -1,0 +1,35 @@
+<form id="q-plants-inverted-e3" class="difficulty-easy">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌱
+🌦️
+🌷
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱"
+print "🌦️"
+print "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷"
+print "🌦️"
+print "🌱"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌱" "🌦️" "🌷"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🌷" "🌦️" "🌱"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-1.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-1.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-1" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Colors clash"
+print "with a splash."
+print "💻🌈⛲️"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+Colors clash
+
+💻🌈⛲️
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-6.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-6.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-6" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "The early bird"
+print "finds the bug."
+print "🐥🪳🐛"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+The early bird
+
+🐥🪳🐛
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-8.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-8.htmlf
@@ -1,0 +1,13 @@
+<form id="q-rhyme-8" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Foxes build boxes."
+print "🎁"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+🎁
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-9.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-9.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-9" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Smart cookies"
+print "code together."
+print "🍪💻"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+
+
+🍪💻
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-c.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-c.htmlf
@@ -1,0 +1,13 @@
+<form id="q-rhyme-c" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "Bugs like hugs."
+print "👾🐛🥰"
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+👾🐛🥰
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-f.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-f.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-f" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the output of this program:</p>
+  <pre><code class="language-evy">print "🦊👗🐞"
+print "Fox in dress"
+print "finds bugs for less."
+</code></pre>
+  <p>Output:</p>
+  <textarea name="answer" rows="4" cols="35">
+🦊👗🐞
+
+finds bugs for less.
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-02.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-02.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-inverted-02" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>🦊👗🐞
+Fox in dress
+finds bugs for less.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+print "🦊👗🐞"
+
+print "finds bugs for less."
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-61.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-61.htmlf
@@ -1,0 +1,13 @@
+<form id="q-rhyme-inverted-61" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Bugs like hugs.
+👾🐛🥰
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+print "👾🐛🥰"
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-6d.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-6d.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-inverted-6d" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Smart cookies
+code together.
+🍪💻
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+
+
+print "🍪💻"
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-a3.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-a3.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-inverted-a3" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>The early bird
+finds the bug.
+🐥🪳🐛
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+print "The early bird"
+
+print "🐥🪳🐛"
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-ad.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-ad.htmlf
@@ -1,0 +1,13 @@
+<form id="q-rhyme-inverted-ad" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Foxes build boxes.
+🎁
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="3" cols="35">
+
+print "🎁"
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-f8.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme-inverted-f8.htmlf
@@ -1,0 +1,15 @@
+<form id="q-rhyme-inverted-f8" class="difficulty-medium">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Complete the program that generates this output:</p>
+  <pre><code>Colors clash
+with a splash.
+💻🌈⛲️
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="4" cols="35">
+print "Colors clash"
+
+print "💻🌈⛲️"
+</textarea
+  >
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-0.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-0.htmlf
@@ -1,0 +1,9 @@
+<form id="q-rhyme2-0" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Clever code,
+problems explode.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-1.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-1.htmlf
@@ -1,0 +1,9 @@
+<form id="q-rhyme2-1" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Every hour:
+pixel power.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-5.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-5.htmlf
@@ -1,0 +1,9 @@
+<form id="q-rhyme2-5" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Madam Program, never calm, 
+uses code as soothing balm.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>

--- a/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-c.htmlf
+++ b/frontend/learn/foundation/sequence/multiple-print/q-rhyme2-c.htmlf
@@ -1,0 +1,9 @@
+<form id="q-rhyme2-c" class="difficulty-hard">
+  <h2>Sequential <code>print</code> command</h2>
+  <p>Write code that creates this output:</p>
+  <pre><code>Cookies remember
+things about you.
+</code></pre>
+  <p>Program:</p>
+  <textarea name="answer" rows="2" cols="35"> </textarea>
+</form>

--- a/frontend/learn/foundation/sequence/print/index.html
+++ b/frontend/learn/foundation/sequence/print/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>print command</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="../../../img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="../../../css/resets.css" type="text/css" />
     <link rel="stylesheet" href="../../../css/root.css" type="text/css" />
     <link rel="stylesheet" href="../../../css/elements.css" type="text/css" />
@@ -121,26 +121,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "banana 🍌"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "print 🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "print banana 🍌"
 </code></pre>
             </div>
@@ -154,26 +150,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "banana 🍌"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "print 🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "print banana 🍌"
 </code></pre>
             </div>
@@ -187,26 +179,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "banana 🍌"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "print 🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "print banana 🍌"
 </code></pre>
             </div>
@@ -220,26 +208,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "banana 🍌"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "print 🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "print banana 🍌"
 </code></pre>
             </div>
@@ -253,26 +237,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>banana 🍌
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>print 🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>print banana 🍌
 </code></pre>
             </div>
@@ -286,26 +266,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>banana 🍌
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>print 🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>print banana 🍌
 </code></pre>
             </div>
@@ -319,26 +295,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>banana 🍌
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>print 🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>print banana 🍌
 </code></pre>
             </div>
@@ -352,26 +324,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>banana 🍌
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>print 🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>print banana 🍌
 </code></pre>
             </div>
@@ -383,26 +351,22 @@
           <p>Select all correct answers:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="checkbox" value="a" name="answer" />
+              <label>a<input type="checkbox" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "banana 🍌"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="checkbox" value="b" name="answer" />
+              <label>b<input type="checkbox" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="checkbox" value="c" name="answer" />
+              <label>c<input type="checkbox" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "print 🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="checkbox" value="d" name="answer" />
+              <label>d<input type="checkbox" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "print banana 🍌"
 </code></pre>
             </div>
@@ -428,26 +392,22 @@
           <p>Select all correct answers:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="checkbox" value="a" name="answer" />
+              <label>a<input type="checkbox" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "banana 🍌"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="checkbox" value="b" name="answer" />
+              <label>b<input type="checkbox" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🍌 banana
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="checkbox" value="c" name="answer" />
+              <label>c<input type="checkbox" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "print 🍌 banana"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="checkbox" value="d" name="answer" />
+              <label>d<input type="checkbox" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "print banana 🍌"
 </code></pre>
             </div>
@@ -473,26 +433,22 @@
           <p>Select all correct answers:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="checkbox" value="a" name="answer" />
+              <label>a<input type="checkbox" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "bug 🪲"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="checkbox" value="b" name="answer" />
+              <label>b<input type="checkbox" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🪲 bug
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="checkbox" value="c" name="answer" />
+              <label>c<input type="checkbox" value="c" name="answer" /> </label>
               <pre><code class="language-evy">Print "print 🪲 bug"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="checkbox" value="d" name="answer" />
+              <label>d<input type="checkbox" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print print bug 🪲"
 </code></pre>
             </div>
@@ -518,26 +474,22 @@
           <p>Select all correct answers:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="checkbox" value="a" name="answer" />
+              <label>a<input type="checkbox" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "bug 🪲"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="checkbox" value="b" name="answer" />
+              <label>b<input type="checkbox" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🪲 bug
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="checkbox" value="c" name="answer" />
+              <label>c<input type="checkbox" value="c" name="answer" /> </label>
               <pre><code class="language-evy">Print "print 🪲 bug"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="checkbox" value="d" name="answer" />
+              <label>d<input type="checkbox" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print print bug 🪲"
 </code></pre>
             </div>
@@ -565,26 +517,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "3. .2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
 </code></pre>
             </div>
@@ -598,26 +546,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "3. .2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
 </code></pre>
             </div>
@@ -631,26 +575,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "3. .2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
 </code></pre>
             </div>
@@ -664,26 +604,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "3. .2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
 </code></pre>
             </div>
@@ -697,26 +633,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>3. .2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>3 . . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>3. . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>3 . .2 ...1 🚀
 </code></pre>
             </div>
@@ -730,26 +662,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>3. .2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>3 . . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>3. . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>3 . .2 ...1 🚀
 </code></pre>
             </div>
@@ -763,26 +691,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>3. .2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>3 . . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>3. . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>3 . .2 ...1 🚀
 </code></pre>
             </div>
@@ -796,26 +720,22 @@
           <p>Select the correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>3. .2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>3 . . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>3. . 2 ...1 🚀
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>3 . .2 ...1 🚀
 </code></pre>
             </div>
@@ -829,26 +749,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
 </code></pre>
             </div>
@@ -862,26 +778,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
 </code></pre>
             </div>
@@ -895,26 +807,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
 </code></pre>
             </div>
@@ -928,26 +836,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
 </code></pre>
             </div>
@@ -961,26 +865,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2:1
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 -  1 : 2
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2  :  1
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 1: 2
 </code></pre>
             </div>
@@ -994,26 +894,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2:1
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 -  1 : 2
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2  :  1
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 1: 2
 </code></pre>
             </div>
@@ -1027,26 +923,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2:1
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 -  1 : 2
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2  :  1
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 1: 2
 </code></pre>
             </div>
@@ -1060,26 +952,22 @@
           <p>Choose one correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="radio" value="a" name="answer" />
+              <label>a<input type="radio" value="a" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2:1
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="radio" value="b" name="answer" />
+              <label>b<input type="radio" value="b" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 -  1 : 2
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="radio" value="c" name="answer" />
+              <label>c<input type="radio" value="c" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 2  :  1
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="radio" value="d" name="answer" />
+              <label>d<input type="radio" value="d" name="answer" /> </label>
               <pre><code>🐒 vs 🤖 - 1: 2
 </code></pre>
             </div>
@@ -1093,26 +981,22 @@
           <p>Choose all correct answer:</p>
           <fieldset>
             <div>
-              <label for="a">a</label>
-              <input type="checkbox" value="a" name="answer" />
+              <label>a<input type="checkbox" value="a" name="answer" /> </label>
               <pre><code class="language-evy">print &quot;🌞 : 🌍 :&quot; &quot;🌛&quot;
 </code></pre>
             </div>
             <div>
-              <label for="b">b</label>
-              <input type="checkbox" value="b" name="answer" />
+              <label>b<input type="checkbox" value="b" name="answer" /> </label>
               <pre><code class="language-evy"> print &quot;🌞 :&quot; &quot;🌍 : 🌛&quot;
 </code></pre>
             </div>
             <div>
-              <label for="c">c</label>
-              <input type="checkbox" value="c" name="answer" />
+              <label>c<input type="checkbox" value="c" name="answer" /> </label>
               <pre><code class="language-evy"> print &quot;🌞  :  🌍 : 🌛&quot;
 </code></pre>
             </div>
             <div>
-              <label for="d">d</label>
-              <input type="checkbox" value="d" name="answer" />
+              <label>d<input type="checkbox" value="d" name="answer" /> </label>
               <pre><code class="language-evy"> print &quot;🌞 :&quot; &quot;🌍 :&quot; &quot;🌛&quot;
 </code></pre>
             </div>

--- a/frontend/learn/foundation/sequence/print/index.html
+++ b/frontend/learn/foundation/sequence/print/index.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/foundation/sequence/print/index.htmlf
+++ b/frontend/learn/foundation/sequence/print/index.htmlf
@@ -1,0 +1,905 @@
+<h1><code>print</code> command</h1>
+<h3>Question Composition</h3>
+<table>
+  <tr>
+    <td>easy 🌶️</td>
+    <td>3</td>
+  </tr>
+  <tr>
+    <td>medium 🌶️🌶️</td>
+    <td>3</td>
+  </tr>
+  <tr>
+    <td>easy 🌶️</td>
+    <td>1</td>
+  </tr>
+</table>
+<form id="q-banana-inverted-f" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>banana 🍌
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-banana-inverted-b" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>🍌 banana
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-banana-inverted-3" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>print 🍌 banana
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-banana-inverted-c" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>print banana 🍌
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-banana-0e" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-banana-7e" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-banana-27" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-banana-76" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-error-inverted" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program does <em>not</em> causes any parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+  <div class="alert alert-note">
+    <p class="alert-title">
+      <svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <path
+          d="M 0 8 a 8 8 0 1 1 16 0 A 8 8 0 0 1 0 8 Z m 8 -6.5 a 6.5 6.5 0 1 0 0 13 a 6.5 6.5 0 0 0 0 -13 Z M 6.5 7.75 A 0.75 0.75 0 0 1 7.25 7 h 1 a 0.75 0.75 0 0 1 0.75 0.75 v 2.75 h 0.25 a 0.75 0.75 0 0 1 0 1.5 h -2 a 0.75 0.75 0 0 1 0 -1.5 h 0.25 v -2 h -0.25 a 0.75 0.75 0 0 1 -0.75 -0.75 Z M 8 6 a 1 1 0 1 1 0 -2 a 1 1 0 0 1 0 2 Z"
+        ></path></svg
+      >Note
+    </p>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </div>
+</form>
+<form id="q-error" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program causes one or more parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+  <div class="alert alert-note">
+    <p class="alert-title">
+      <svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <path
+          d="M 0 8 a 8 8 0 1 1 16 0 A 8 8 0 0 1 0 8 Z m 8 -6.5 a 6.5 6.5 0 1 0 0 13 a 6.5 6.5 0 0 0 0 -13 Z M 6.5 7.75 A 0.75 0.75 0 0 1 7.25 7 h 1 a 0.75 0.75 0 0 1 0.75 0.75 v 2.75 h 0.25 a 0.75 0.75 0 0 1 0 1.5 h -2 a 0.75 0.75 0 0 1 0 -1.5 h 0.25 v -2 h -0.25 a 0.75 0.75 0 0 1 -0.75 -0.75 Z M 8 6 a 1 1 0 1 1 0 -2 a 1 1 0 0 1 0 2 Z"
+        ></path></svg
+      >Note
+    </p>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </div>
+</form>
+<form id="q-error2-inverted" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program does <em>not</em> causes any parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "bug 🪲"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🪲 bug
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">Print "print 🪲 bug"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print print bug 🪲"
+</code></pre>
+    </div>
+  </fieldset>
+  <div class="alert alert-note">
+    <p class="alert-title">
+      <svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <path
+          d="M 0 8 a 8 8 0 1 1 16 0 A 8 8 0 0 1 0 8 Z m 8 -6.5 a 6.5 6.5 0 1 0 0 13 a 6.5 6.5 0 0 0 0 -13 Z M 6.5 7.75 A 0.75 0.75 0 0 1 7.25 7 h 1 a 0.75 0.75 0 0 1 0.75 0.75 v 2.75 h 0.25 a 0.75 0.75 0 0 1 0 1.5 h -2 a 0.75 0.75 0 0 1 0 -1.5 h 0.25 v -2 h -0.25 a 0.75 0.75 0 0 1 -0.75 -0.75 Z M 8 6 a 1 1 0 1 1 0 -2 a 1 1 0 0 1 0 2 Z"
+        ></path></svg
+      >Note
+    </p>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </div>
+</form>
+<form id="q-error2" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program causes one or more parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "bug 🪲"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🪲 bug
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">Print "print 🪲 bug"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print print bug 🪲"
+</code></pre>
+    </div>
+  </fieldset>
+  <div class="alert alert-note">
+    <p class="alert-title">
+      <svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+        <path
+          d="M 0 8 a 8 8 0 1 1 16 0 A 8 8 0 0 1 0 8 Z m 8 -6.5 a 6.5 6.5 0 1 0 0 13 a 6.5 6.5 0 0 0 0 -13 Z M 6.5 7.75 A 0.75 0.75 0 0 1 7.25 7 h 1 a 0.75 0.75 0 0 1 0.75 0.75 v 2.75 h 0.25 a 0.75 0.75 0 0 1 0 1.5 h -2 a 0.75 0.75 0 0 1 0 -1.5 h 0.25 v -2 h -0.25 a 0.75 0.75 0 0 1 -0.75 -0.75 Z M 8 6 a 1 1 0 1 1 0 -2 a 1 1 0 0 1 0 2 Z"
+        ></path></svg
+      >Note
+    </p>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </div>
+</form>
+<form id="q-countdown-inverted-8" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3. .2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-inverted-d" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-inverted-a" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3. . 2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-inverted-3" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3 . .2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-5" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-f" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-4" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-countdown-1" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-inverted-f" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-inverted-b" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-inverted-e" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-inverted-3" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-25" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-2b" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-c5" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-game-a6" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>
+<form id="q-universe" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌞 : 🌍 : 🌛
+</code></pre>
+  <p>Choose all correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print &quot;🌞 : 🌍 :&quot; &quot;🌛&quot;
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy"> print &quot;🌞 :&quot; &quot;🌍 : 🌛&quot;
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy"> print &quot;🌞  :  🌍 : 🌛&quot;
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy"> print &quot;🌞 :&quot; &quot;🌍 :&quot; &quot;🌛&quot;
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/print.html
+++ b/frontend/learn/foundation/sequence/print/print.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>The print Command</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="../../../img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="../../../css/resets.css" type="text/css" />
     <link rel="stylesheet" href="../../../css/root.css" type="text/css" />
     <link rel="stylesheet" href="../../../css/elements.css" type="text/css" />

--- a/frontend/learn/foundation/sequence/print/print.html
+++ b/frontend/learn/foundation/sequence/print/print.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/foundation/sequence/print/print.htmlf
+++ b/frontend/learn/foundation/sequence/print/print.htmlf
@@ -1,0 +1,29 @@
+<h1>The <code>print</code> Command</h1>
+<p>
+  The <code>print</code> command tells the program to print something to the screen. The
+  <strong>argument</strong> is the thing that you want the program to print. The argument must be
+  surrounded by quotation or talking marks <code>&quot;</code>. For example, the following code will
+  print the word <code>Hello</code> to the screen:
+</p>
+<pre><code>✅ print &quot;Hello&quot;
+</code></pre>
+<p><code>&quot;Hello&quot;</code> is the argument to <code>print</code>.</p>
+<p>Without the quotation marks, this program will generate an error.</p>
+<pre><code>❌ print Hello
+</code></pre>
+<h2>More Arguments</h2>
+<p>
+  <code>print</code> takes any number of arguments: 0, 1, 2, …. Each argument is printed
+  <em>without</em> the quotation marks. Arguments are separated by a single space. After the last
+  argument has been printed a new line or return will be printed.
+</p>
+<p>The following program</p>
+<pre><code class="language-evy">print &quot;Bugs like hugs.&quot;
+print &quot;👾&quot; &quot;🐛&quot; &quot;🥰&quot;
+</code></pre>
+<p>creates the output</p>
+<pre><code>Bugs like hugs.
+👾 🐛 🥰
+</code></pre>
+<p><code>print</code> without any arguments prints an empty new line.</p>
+<p><a href="index.html">Exercise</a></p>

--- a/frontend/learn/foundation/sequence/print/q-banana-0e.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-0e.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-0e" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-banana-27.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-27.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-27" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-banana-76.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-76.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-76" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-banana-7e.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-7e.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-7e" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code show when it runs?</p>
+  <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>banana 🍌
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>print 🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>print banana 🍌
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-banana-inverted-3.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-inverted-3.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-inverted-3" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>print 🍌 banana
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-banana-inverted-b.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-inverted-b.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-inverted-b" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>🍌 banana
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-banana-inverted-c.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-inverted-c.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-inverted-c" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>print banana 🍌
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-banana-inverted-f.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-banana-inverted-f.htmlf
@@ -1,0 +1,29 @@
+<form id="q-banana-inverted-f" class="difficulty-easy">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output:</p>
+  <pre><code>banana 🍌
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-1.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-1.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-1" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-4.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-4.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-4" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-5.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-5.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-5" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-f.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-f.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-f" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this program output? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+  <p>Select the correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>3. .2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>3. . 2 ...1 🚀
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>3 . .2 ...1 🚀
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-inverted-3.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-inverted-3.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-inverted-3" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3 . .2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-inverted-8.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-inverted-8.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-inverted-8" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3. .2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-inverted-a.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-inverted-a.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-inverted-a" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3. . 2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-countdown-inverted-d.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-countdown-inverted-d.htmlf
@@ -1,0 +1,29 @@
+<form id="q-countdown-inverted-d" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>3 . . 2 ...1 🚀
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "3. .2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 . . 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "3." ". 2" "...1 🚀"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "3 ." ".2" "...1 🚀"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-error-inverted.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-error-inverted.htmlf
@@ -1,0 +1,34 @@
+<form id="q-error-inverted" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program does <em>not</em> causes any parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+  <blockquote>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </blockquote>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-error.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-error.htmlf
@@ -1,0 +1,34 @@
+<form id="q-error" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program causes one or more parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "banana 🍌"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🍌 banana
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "print 🍌 banana"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "print banana 🍌"
+</code></pre>
+    </div>
+  </fieldset>
+  <blockquote>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </blockquote>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-error2-inverted.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-error2-inverted.htmlf
@@ -1,0 +1,34 @@
+<form id="q-error2-inverted" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program does <em>not</em> causes any parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "bug 🪲"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🪲 bug
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">Print "print 🪲 bug"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print print bug 🪲"
+</code></pre>
+    </div>
+  </fieldset>
+  <blockquote>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </blockquote>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-error2.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-error2.htmlf
@@ -1,0 +1,34 @@
+<form id="q-error2" class="difficulty-easy">
+  <h2>Parse errors</h2>
+  <p>Which program causes one or more parse errors?</p>
+  <p>Select all correct answers:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "bug 🪲"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🪲 bug
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">Print "print 🪲 bug"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print print bug 🪲"
+</code></pre>
+    </div>
+  </fieldset>
+  <blockquote>
+    <p>
+      A <strong>parse error</strong>, also known as a syntax error or compilation error, happens
+      when your code doesn't follow Evy's language rules. A parse error prevents the computer from
+      understanding and executing your program.
+    </p>
+  </blockquote>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-25.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-25.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-25" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-2b.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-2b.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-2b" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-a6.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-a6.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-a6" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-c5.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-c5.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-c5" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>What will this code will output on the screen? Keep a close eye on the spaces.</p>
+  <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-inverted-3.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-inverted-3.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-inverted-3" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 - 1: 2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-inverted-b.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-inverted-b.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-inverted-b" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 -  1 : 2
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-inverted-e.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-inverted-e.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-inverted-e" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 - 2  :  1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-game-inverted-f.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-game-inverted-f.htmlf
@@ -1,0 +1,29 @@
+<form id="q-game-inverted-f" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which code creates this output? Keep a close eye on the spaces.</p>
+  <pre><code>🐒 vs 🤖 - 2:1
+</code></pre>
+  <p>Choose one correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="radio" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2:1"
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="radio" value="b" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 - " "1 : 2"
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="radio" value="c" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -" "2" " : " "1"
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="radio" value="d" name="answer" /> </label>
+      <pre><code class="language-evy">print "🐒 vs 🤖 -"  "1:" "2"
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/print/q-universe.htmlf
+++ b/frontend/learn/foundation/sequence/print/q-universe.htmlf
@@ -1,0 +1,29 @@
+<form id="q-universe" class="difficulty-medium">
+  <h2>The <code>print</code> command</h2>
+  <p>Which program generates the following output?</p>
+  <pre><code>🌞 : 🌍 : 🌛
+</code></pre>
+  <p>Choose all correct answer:</p>
+  <fieldset>
+    <div>
+      <label>a<input type="checkbox" value="a" name="answer" /> </label>
+      <pre><code class="language-evy">print &quot;🌞 : 🌍 :&quot; &quot;🌛&quot;
+</code></pre>
+    </div>
+    <div>
+      <label>b<input type="checkbox" value="b" name="answer" /> </label>
+      <pre><code class="language-evy"> print &quot;🌞 :&quot; &quot;🌍 : 🌛&quot;
+</code></pre>
+    </div>
+    <div>
+      <label>c<input type="checkbox" value="c" name="answer" /> </label>
+      <pre><code class="language-evy"> print &quot;🌞  :  🌍 : 🌛&quot;
+</code></pre>
+    </div>
+    <div>
+      <label>d<input type="checkbox" value="d" name="answer" /> </label>
+      <pre><code class="language-evy"> print &quot;🌞 :&quot; &quot;🌍 :&quot; &quot;🌛&quot;
+</code></pre>
+    </div>
+  </fieldset>
+</form>

--- a/frontend/learn/foundation/sequence/sequence.html
+++ b/frontend/learn/foundation/sequence/sequence.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Sequential Execution Explained</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="../../img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="../../css/resets.css" type="text/css" />
     <link rel="stylesheet" href="../../css/root.css" type="text/css" />
     <link rel="stylesheet" href="../../css/elements.css" type="text/css" />

--- a/frontend/learn/foundation/sequence/sequence.html
+++ b/frontend/learn/foundation/sequence/sequence.html
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }

--- a/frontend/learn/foundation/sequence/sequence.htmlf
+++ b/frontend/learn/foundation/sequence/sequence.htmlf
@@ -1,0 +1,26 @@
+<h1>Sequential Execution Explained</h1>
+<p><em>Doing things step-by-step.</em></p>
+<p>
+  A computer program executes commands sequentially, that is to say it follows instructions one at a
+  time. It can't skip steps or go back and forth. If it does, it'll get confused and won't work.
+</p>
+<p>
+  This is like following a recipe. You can't just start cooking at the end. You have to start at the
+  beginning and follow the steps in order. If you skip steps or go back and forth, you might not end
+  up with what you wanted.
+</p>
+<p>Here is an evy program that prints two lines of text to the screen:</p>
+<pre><code>print &quot;Hello world! 👋🌏&quot;
+print &quot;How are you today?&quot;
+</code></pre>
+<p>
+  First, the program prints <code>Hello world! 👋🌏</code>, after that it prints
+  <code>How are you today?</code>. The order always stays the same:
+</p>
+<pre><code>Hello world!  👋🌏
+How are you today?
+</code></pre>
+<p>
+  <a href="print/print.html">📖 The <code>print</code> command</a> |
+  <a href="print/index.html">Skip to exercise</a>
+</p>

--- a/frontend/learn/index.js
+++ b/frontend/learn/index.js
@@ -1,10 +1,19 @@
 import hightlightEvy from "./module/highlight.js"
 import initThemeToggle from "./module/theme.js"
+import { querySPALinks, wireSPALinks } from "./module/spa.js"
 
 // --- ThemeToggle ----------------------------------------------------
 initThemeToggle("#dark-theme", "theme")
 
-// --- Syntax coloring -----------------------------------------------
+// --- Spa light: load HTML fragments on course link clicks ------------
+const courseHref = document.querySelector("#sidebar h1 a").getAttribute("href")
+const courseDir = courseHref.substring(0, courseHref.lastIndexOf("/") + 1)
+const courseLinks = querySPALinks(courseDir)
+const target = document.querySelector("main div.max-width-wrapper")
+const scrollTop = document.querySelector("body>main")
+wireSPALinks(courseLinks, target, scrollTop)
+
+// --- Syntax coloring ------------------------------------------------
 document.querySelectorAll(".language-evy").forEach((el) => {
   el.innerHTML = hightlightEvy(el.textContent)
 })
@@ -14,6 +23,17 @@ const loginDialog = document.querySelector("#dialog-login")
 const showLoginDialog = document.querySelector("#show-dialog-login")
 showLoginDialog.addEventListener("click", () => {
   loginDialog.showModal()
+})
+
+// -- Tick radio/checkbox on outer div click -------------------------
+const checkables = [
+  // radio and checkbox inputs
+  ...document.querySelectorAll("div label input[type=checkbox],div label input[type=radio]"),
+]
+checkables.forEach((n) => {
+  // For any click on surrounding div, update checkbox or radio button
+  const div = n.parentElement.parentElement
+  div.addEventListener("click", () => (n.checked = !n.checked))
 })
 
 // --- Sidebar -------------------------------------------------------
@@ -27,10 +47,20 @@ window.addEventListener("hashchange", hideSidebar)
 const expanders = [...document.querySelectorAll("#sidebar .expander")]
 expanders.map((el) => (el.onclick = expanderClick))
 
+const sidebarLinks = [...document.querySelectorAll("#sidebar a")]
+sidebarLinks.map((el) => el.addEventListener("click", (e) => highlightItem(el)))
+
 // Highlight current page (sub-)heading in sidebar.
 highlightCurrent()
 
-// Utilities
+// --- Utility functions ---------------------------------------------
+function expanderClick(e) {
+  const expander = e.target
+  const siblingUL = expander.nextElementSibling
+  expander.classList.toggle("show")
+  siblingUL.classList.toggle("show")
+}
+
 function showSidebar() {
   sidebar.classList.add("show")
   document.addEventListener("click", handleOutsideSidebarClick)
@@ -45,61 +75,56 @@ function handleOutsideSidebarClick(e) {
   }
 }
 
-function expanderClick(e) {
-  e.target.nextElementSibling.classList.toggle("show")
-  e.target.classList.toggle("show")
-}
-
 function highlightCurrent() {
-  const highlighted = document.querySelectorAll("#sidebar .highlight")
-  highlighted.forEach((el) => el.classList.remove("highlight"))
-
   const item = getCurrentItem()
-  if (!item) {
-    return
-  }
-  item.classList.add("highlight")
-  const els = getShowing(item)
-  els.forEach((el) => el.classList.add("show"))
-  const last = els.pop()
-  last && last.previousElementSibling.classList.add("highlight-within")
+  item && highlightItem(item)
 }
 
 function getCurrentItem() {
-  const href = normalizedHref()
-  const last = href.split("/").pop()
+  // href is the page URL, replace trailing slash with /index.html
+  const href = window.location.href.replace(/\/$/, "/index.html")
+  const last = href.split("/").pop() // filename only
+  // [href=...] could be relative, so find all matching links with same base
+  // filename and then compare fully qualified n.href (as opposed to the
+  // original n.getAttribute("href")) against the page href.
   const nodes = document.querySelectorAll(`#sidebar a[href$="${last}"]`)
   return [...nodes].find((n) => n.href === href)
 }
 
-function normalizedHref() {
-  let href = window.location.href
-  let hash = window.location.hash
-  if (hash) {
-    href = href.replace(hash, "")
-  }
-  if (href.endsWith("/")) {
-    href = href + "index.html"
-  }
-  return href + hash
+function highlightItem(item) {
+  // clear previous highlight
+  const highlighted = document.querySelectorAll("#sidebar .highlight")
+  highlighted.forEach((el) => el.classList.remove("highlight"))
+  // add new highlight
+  item.classList.add("highlight")
+  // expand sidebar hierarchy to show highlighted item
+  const els = findElementsToExpand(item)
+  els.forEach((el) => el.classList.add("show")) // expand
+  const last = els.pop()
+  // highlight top level element
+  last && last.previousElementSibling.classList.add("highlight-within")
 }
 
-function getShowing(item) {
+// findElementsToExpand finds and returns an array of all <ul> and <div
+// class="expander"> elements that need to be showed and expanded up the
+// sidebar hierarchy tree for item to be visible. The <ul> adjecent to item
+// is also included as clicking on an item expands its child <ul>.
+function findElementsToExpand(item) {
   const parents = []
-  let n = item
-  if (n.nextElementSibling) {
-    n = n.nextElementSibling.nextElementSibling // sibling UL
+  if (item.nextElementSibling) {
+    const siblingUL = item.nextElementSibling.nextElementSibling // expand next level down
+    parents.push(siblingUL)
   }
-  while (n) {
-    if (n.tagName === "UL") {
-      const expander = n.previousElementSibling // div with ".expander" class
+  while (item) {
+    if (item.tagName === "UL") {
+      const expander = item.previousElementSibling // div with ".expander" class
       if (!expander.classList.contains("expander")) {
         break
       }
-      parents.push(n)
+      parents.push(item)
       parents.push(expander)
     }
-    n = n.parentElement
+    item = item.parentElement // move upwards in the sidebar hierarchy
   }
   return parents
 }

--- a/frontend/learn/module/spa.js
+++ b/frontend/learn/module/spa.js
@@ -1,0 +1,1 @@
+../../module/spa.js

--- a/frontend/module/spa.js
+++ b/frontend/module/spa.js
@@ -1,0 +1,75 @@
+// querySPALinks returns all relative links, and links within rootDir. Links
+// containing `:`, e.g. https://..., http://..., mailto:.... are excluded.
+export function querySPALinks(rootDir) {
+  const internalLinks = document.querySelectorAll('a:not([href*=":"])')
+  return [...internalLinks].filter((link) => {
+    // use literal href="..." contents, not derived, absolute link.href
+    const href = link.getAttribute("href")
+    // relative link or course root
+    return !href.startsWith("/") || href.startsWith(rootDir)
+  })
+}
+
+// Load only a site fragment, set inner HTML of target element and update
+// browser history and address bar  with a new URL.
+//
+// wireSPALinks intercepts clicks on links, fetches the links href with an "f"
+// suffix, e.g. print/index.htmlf, and replace the innerHTML of the target to
+// the fragment provided in the response.
+//
+// If a scrollTop element is provided, wireSPALinks will scroll to the top of
+// the element after replacement.
+export async function wireSPALinks(links, target, scrollTop, afterNavigate) {
+  links.forEach((link) => {
+    link.addEventListener("click", async (e) => {
+      e.preventDefault()
+      await onNavigate(link.href, target, scrollTop)
+      afterNavigate && afterNavigate()
+    })
+  })
+  window.addEventListener("popstate", async (e) => {
+    const href = e.state && e.state.fragment
+    if (href) {
+      await replaceFragment(href, target, scrollTop)
+      afterNavigate && afterNavigate()
+    }
+  })
+  const normalizedHref = window.location.href.replace(/\/(#|$)/, "/index.html$1")
+  window.history.replaceState({ fragment: normalizedHref }, "", window.location.href)
+}
+
+async function onNavigate(href, target, scrollTop) {
+  const normalizedHref = window.location.href.replace(/\/(#|$)/, "/index.html$1")
+  if (href === normalizedHref) {
+    return
+  }
+  window.history.pushState({ fragment: href }, "", href)
+  if (href.split("#").shift() !== normalizedHref.split("#").shift()) {
+    await replaceFragment(href, target, scrollTop)
+  } else {
+    scrollToHeading(href, scrollTop)
+  }
+}
+
+async function replaceFragment(href, target, scrollTop) {
+  const fragmentHref = href.split("#").shift() + "f"
+  const response = await fetch(fragmentHref)
+  target.innerHTML = await response.text()
+  scrollToHeading(href, scrollTop)
+}
+
+async function scrollToHeading(href, scrollTop) {
+  // this should be default browser behavior for onhashchange,
+  // but in combination with these CSS rules it does not seem to work.
+  //
+  //    display: grid | flex;
+  //    height: 100% | inherit;
+  //    overflow: auto;
+  const hash = href.split("#").pop()
+  if (hash && hash !== href) {
+    const scrollTarget = document.querySelector("#" + hash)
+    scrollTarget && scrollTarget.scrollIntoView(true)
+    return
+  }
+  scrollTop && scrollTop.scrollTo(0, 0)
+}

--- a/learn/cmd/levy/main.go
+++ b/learn/cmd/levy/main.go
@@ -70,7 +70,6 @@ type exportCmd struct {
 	PrivateKey        string `short:"k" help:"Secret private key to decrypt sealed answers." env:"EVY_LEARN_PRIVATE_KEY"`
 	WithAnswersMarked bool   `short:"m" help:"Include marked answers in HTML output. Cannot be used with export target answerkey."`
 	SelfContained     bool   `short:"c" help:"Ensure .html files are self-contained (embed CSS, JS, Favicon)." negatable:""`
-	SkipQuestions     bool   `short:"q" help:"Skip exporting individual questions, export full exercise only."`
 	RootDir           string `short:"r" default:"/" help:"Root directory for HTML links, e.g. /learn/."`
 }
 
@@ -103,7 +102,6 @@ func (c *exportCmd) Run() error {
 		WriteCatalog:      c.ExportType == "catalog" || c.ExportType == "all",
 		WithAnswersMarked: c.WithAnswersMarked,
 		SelfContained:     c.SelfContained,
-		SkipQuestions:     c.SkipQuestions,
 		RootDir:           c.RootDir,
 	}
 	modelOptions := getOptions(c.IgnoreSealed, c.PrivateKey)

--- a/learn/pkg/learn/question.go
+++ b/learn/pkg/learn/question.go
@@ -205,8 +205,9 @@ func (m *QuestionModel) printAnswerChoicesHTML(list *markdown.List, buf *bytes.B
 		}
 		letter := indexToLetter(i)
 		buf.WriteString("<div>\n")
-		buf.WriteString(`<label for="` + letter + `">` + letter + "</label>\n")
+		buf.WriteString(`<label>` + letter)
 		buf.WriteString(`<input type="` + inputType + `" value="` + letter + `" name="answer" ` + checked + "/>\n")
+		buf.WriteString("</label>\n")
 		for _, block := range item.(*markdown.Item).Blocks {
 			if embed, ok := m.embeds[block]; ok {
 				embed.RenderHTML(buf)
@@ -239,8 +240,9 @@ func (m *QuestionModel) printTxtarAnswerChoicesHTML(buf *bytes.Buffer, withAnswe
 		}
 		letter := indexToLetter(i)
 		buf.WriteString("<div>\n")
-		buf.WriteString(`<label for="` + letter + `">` + letter + "</label>\n")
+		buf.WriteString(`<label>` + letter)
 		buf.WriteString(`<input type="` + inputType + `" value="` + letter + `" name="answer" ` + checked + "/>\n")
+		buf.WriteString("</label>\n")
 		if m.isParserErrorQuestion() {
 			buf.WriteString(`<pre><code class="language-evy">`)
 			buf.Write(file.Data)

--- a/learn/pkg/learn/testdata/golden/exercise-with-marked/exercise1.html
+++ b/learn/pkg/learn/testdata/golden/exercise-with-marked/exercise1.html
@@ -13,26 +13,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>
@@ -46,26 +46,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" checked />
+<label>b<input type="checkbox" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" checked />
+<label>c<input type="checkbox" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>
@@ -79,26 +79,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>
@@ -112,20 +112,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>
@@ -137,26 +137,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>
@@ -172,32 +172,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>
@@ -215,32 +215,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -260,32 +260,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -304,32 +304,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10
@@ -347,32 +347,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/exercise/exercise1.html
+++ b/learn/pkg/learn/testdata/golden/exercise/exercise1.html
@@ -13,26 +13,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>
@@ -46,26 +46,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>
@@ -79,26 +79,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>
@@ -112,20 +112,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>
@@ -137,26 +137,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>
@@ -172,32 +172,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>
@@ -215,32 +215,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -260,32 +260,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -304,32 +304,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10
@@ -347,32 +347,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/index.html
@@ -100,8 +100,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -110,8 +110,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -119,8 +119,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -129,8 +129,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear
@@ -154,8 +154,8 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -164,8 +164,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -173,8 +173,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -183,8 +183,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear
@@ -206,8 +206,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -218,8 +218,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -230,8 +230,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -242,8 +242,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -267,8 +267,8 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -279,8 +279,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -291,8 +291,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -303,8 +303,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -329,20 +329,20 @@ print &quot;hi&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>
@@ -360,20 +360,20 @@ print &quot;hey&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <code>hey</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>ha</code></div>
 </fieldset>
 </form>
@@ -386,8 +386,8 @@ ho
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" checked />
+<label>a<input type="checkbox" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -395,8 +395,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" checked />
+<label>b<input type="checkbox" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -404,8 +404,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -415,8 +415,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;
@@ -432,8 +432,8 @@ print &quot;ho&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" checked />
+<label>a<input type="checkbox" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -442,8 +442,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -451,8 +451,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -462,8 +462,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" checked />
+<label>d<input type="checkbox" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls1.html
@@ -92,20 +92,20 @@ print &quot;hi&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls2.html
@@ -93,20 +93,20 @@ print &quot;hey&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <code>hey</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>ha</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls3.html
@@ -88,8 +88,8 @@ ho
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" checked />
+<label>a<input type="checkbox" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -97,8 +97,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" checked />
+<label>b<input type="checkbox" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -106,8 +106,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -117,8 +117,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-cls4.html
@@ -87,8 +87,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" checked />
+<label>a<input type="checkbox" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -97,8 +97,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -106,8 +106,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -117,8 +117,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" checked />
+<label>d<input type="checkbox" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw1.html
@@ -93,8 +93,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -103,8 +103,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -112,8 +112,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -122,8 +122,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw2.html
@@ -93,8 +93,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -103,8 +103,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -112,8 +112,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -122,8 +122,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw3.html
@@ -91,8 +91,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -103,8 +103,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -115,8 +115,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -127,8 +127,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/cls/q-draw4.html
@@ -91,8 +91,8 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -103,8 +103,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -115,8 +115,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -127,8 +127,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-parse-error/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-parse-error/index.html
@@ -91,23 +91,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" checked />
+<label>a<input type="checkbox" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" checked />
+<label>c<input type="checkbox" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" checked />
+<label>d<input type="checkbox" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>
@@ -120,23 +120,23 @@ also called syntax error or compilation error.</p>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-parse-error/q-no-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-parse-error/q-no-parse-error.html
@@ -85,23 +85,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" checked />
+<label>a<input type="checkbox" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" checked />
+<label>c<input type="checkbox" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" checked />
+<label>d<input type="checkbox" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-parse-error/q-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-parse-error/q-parse-error.html
@@ -85,23 +85,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/index.html
@@ -94,26 +94,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -127,26 +127,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -160,26 +160,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -193,26 +193,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -226,26 +226,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -259,26 +259,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -292,26 +292,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -325,26 +325,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -358,26 +358,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -391,26 +391,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -424,26 +424,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -457,26 +457,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -490,26 +490,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -523,26 +523,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -556,26 +556,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -589,26 +589,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -623,28 +623,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -659,28 +659,28 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -694,28 +694,28 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -729,28 +729,28 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -764,8 +764,8 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 *** txtar Content ERROR ***</div>
 </fieldset>
 </form>
@@ -779,32 +779,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -822,32 +822,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -865,32 +865,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -908,32 +908,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -951,32 +951,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10
@@ -994,32 +994,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10
@@ -1037,32 +1037,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10
@@ -1080,32 +1080,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-0e.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-0e.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-27.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-27.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-76.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-76.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-7e.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-7e.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-3.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-b.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-b.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-c.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-c.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-f.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-banana-inverted-f.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-5.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-5.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-8.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-8.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-d.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-d.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-f.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-f.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-5.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-5.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-7.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-7.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-a.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-a.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-d.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print-inverted-d.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-5.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-5.html
@@ -87,28 +87,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-9.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-9.html
@@ -88,28 +88,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-a.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-a.html
@@ -87,28 +87,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-f.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print2-f.html
@@ -88,28 +88,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-print3.html
@@ -87,8 +87,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 *** txtar Content ERROR ***</div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-1.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-4.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-9.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-9.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-c.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-c.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-a9.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-a9.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-d5.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-d5.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-db.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-db.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-ea.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise-txtar/q-shape-inverted-ea.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/index.html
@@ -94,26 +94,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>
@@ -127,26 +127,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" checked />
+<label>b<input type="checkbox" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" checked />
+<label>c<input type="checkbox" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>
@@ -160,26 +160,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>
@@ -193,20 +193,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>
@@ -218,26 +218,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>
@@ -253,32 +253,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>
@@ -296,32 +296,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -341,32 +341,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -385,32 +385,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10
@@ -428,32 +428,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-img1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-img1.html
@@ -89,32 +89,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-img2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-img2.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-img3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-img3.html
@@ -91,32 +91,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link1.html
@@ -90,32 +90,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link2.html
@@ -89,32 +89,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link3.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question-link4.html
@@ -87,26 +87,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" checked />
+<label>b<input type="checkbox" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" checked />
+<label>c<input type="checkbox" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question1-sealed.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question1-sealed.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question1.html
@@ -87,20 +87,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/exercise1/question2.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/index.html
@@ -98,29 +98,29 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>
@@ -136,8 +136,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -146,8 +146,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -156,8 +156,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -166,8 +166,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -186,8 +186,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -196,8 +196,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -206,8 +206,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -216,8 +216,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -239,29 +239,29 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>
@@ -280,8 +280,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -291,8 +291,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -302,8 +302,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -313,8 +313,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -337,8 +337,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -348,8 +348,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -359,8 +359,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -370,8 +370,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -395,8 +395,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -405,8 +405,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -415,8 +415,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -425,8 +425,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 
@@ -449,8 +449,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -459,8 +459,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -469,8 +469,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -479,8 +479,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles1.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -102,8 +102,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -112,8 +112,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -122,8 +122,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles2.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -102,8 +102,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -112,8 +112,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -122,8 +122,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles3.html
@@ -91,8 +91,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -102,8 +102,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -113,8 +113,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -124,8 +124,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-2circles4.html
@@ -91,8 +91,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -102,8 +102,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -113,8 +113,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -124,8 +124,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle1.html
@@ -91,29 +91,29 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle2.html
@@ -88,8 +88,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -98,8 +98,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -108,8 +108,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -118,8 +118,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle3.html
@@ -88,8 +88,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -98,8 +98,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -108,8 +108,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -118,8 +118,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/shape/q-circle4.html
@@ -91,29 +91,29 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/index.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/index.html
@@ -99,8 +99,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -108,8 +108,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -117,8 +117,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -126,8 +126,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20
@@ -149,8 +149,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -158,8 +158,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -167,8 +167,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -176,8 +176,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20
@@ -197,8 +197,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -208,8 +208,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -219,8 +219,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -230,8 +230,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -253,8 +253,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -264,8 +264,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -275,8 +275,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -286,8 +286,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -311,8 +311,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -320,8 +320,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -329,8 +329,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -338,8 +338,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -361,8 +361,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -370,8 +370,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -379,8 +379,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -388,8 +388,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -409,8 +409,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -420,8 +420,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -431,8 +431,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -442,8 +442,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -465,8 +465,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -476,8 +476,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -487,8 +487,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -498,8 +498,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored1.html
@@ -90,8 +90,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -112,8 +112,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -123,8 +123,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored2.html
@@ -90,8 +90,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -112,8 +112,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -123,8 +123,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored3.html
@@ -92,8 +92,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -101,8 +101,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -110,8 +110,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -119,8 +119,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-colored4.html
@@ -92,8 +92,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -101,8 +101,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -110,8 +110,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -119,8 +119,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain1.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain1.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -110,8 +110,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -119,8 +119,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain2.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain2.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -110,8 +110,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -119,8 +119,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain3.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain3.html
@@ -90,8 +90,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -101,8 +101,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -112,8 +112,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -123,8 +123,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain4.html
+++ b/learn/pkg/learn/testdata/golden/export/all/unit1/text/q-plain4.html
@@ -90,8 +90,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -101,8 +101,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -112,8 +112,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -123,8 +123,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/index.html
@@ -100,8 +100,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -110,8 +110,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -119,8 +119,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -129,8 +129,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear
@@ -154,8 +154,8 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -164,8 +164,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -173,8 +173,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -183,8 +183,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear
@@ -206,8 +206,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -218,8 +218,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -230,8 +230,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -242,8 +242,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -267,8 +267,8 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -279,8 +279,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -291,8 +291,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -303,8 +303,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -329,20 +329,20 @@ print &quot;hi&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>
@@ -360,20 +360,20 @@ print &quot;hey&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>hey</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>ha</code></div>
 </fieldset>
 </form>
@@ -386,8 +386,8 @@ ho
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -395,8 +395,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -404,8 +404,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -415,8 +415,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;
@@ -432,8 +432,8 @@ print &quot;ho&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -442,8 +442,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -451,8 +451,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -462,8 +462,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls1.html
@@ -92,20 +92,20 @@ print &quot;hi&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls2.html
@@ -93,20 +93,20 @@ print &quot;hey&quot;
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>hey</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>ha</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls3.html
@@ -88,8 +88,8 @@ ho
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -97,8 +97,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -106,8 +106,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -117,8 +117,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-cls4.html
@@ -87,8 +87,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;ho&quot;
 cls
 print &quot;hi&quot;
@@ -97,8 +97,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -106,8 +106,8 @@ print &quot;ho&quot;
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;hi&quot;
@@ -117,8 +117,8 @@ print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 cls
 print &quot;ho&quot;

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw1.html
@@ -93,8 +93,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -103,8 +103,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -112,8 +112,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -122,8 +122,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw2.html
@@ -93,8 +93,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 20
 clear
@@ -103,8 +103,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 circle 10
 clear
@@ -112,8 +112,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 clear
@@ -122,8 +122,8 @@ circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 circle 10
 clear

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw3.html
@@ -91,8 +91,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -103,8 +103,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -115,8 +115,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -127,8 +127,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/cls/q-draw4.html
@@ -91,8 +91,8 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -103,8 +103,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -115,8 +115,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -127,8 +127,8 @@ circle 20
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-parse-error/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-parse-error/index.html
@@ -91,23 +91,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>
@@ -120,23 +120,23 @@ also called syntax error or compilation error.</p>
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-parse-error/q-no-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-parse-error/q-no-parse-error.html
@@ -85,23 +85,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-parse-error/q-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-parse-error/q-parse-error.html
@@ -85,23 +85,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/index.html
@@ -94,26 +94,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -127,26 +127,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -160,26 +160,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -193,26 +193,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>
@@ -226,26 +226,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -259,26 +259,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -292,26 +292,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -325,26 +325,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>
@@ -358,26 +358,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -391,26 +391,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -424,26 +424,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -457,26 +457,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
@@ -490,26 +490,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -523,26 +523,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -556,26 +556,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -589,26 +589,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
@@ -623,28 +623,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -659,28 +659,28 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -694,28 +694,28 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -729,28 +729,28 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>
@@ -764,8 +764,8 @@ print "1"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 *** txtar Content ERROR ***</div>
 </fieldset>
 </form>
@@ -779,32 +779,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -822,32 +822,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -865,32 +865,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -908,32 +908,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>
@@ -951,32 +951,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10
@@ -994,32 +994,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10
@@ -1037,32 +1037,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10
@@ -1080,32 +1080,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-0e.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-0e.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-27.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-27.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-76.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-76.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-7e.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-7e.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-3.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-b.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-b.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-c.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-c.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-f.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-banana-inverted-f.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>banana
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>🍌
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print 🍌
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print banana
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-5.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-5.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-8.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-8.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-d.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-d.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-f.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-f.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-5.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-5.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-7.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-7.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-a.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-a.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-d.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print-inverted-d.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>hey
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hey
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-5.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-5.html
@@ -87,28 +87,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-9.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-9.html
@@ -88,28 +88,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-a.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-a.html
@@ -87,28 +87,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-f.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print2-f.html
@@ -88,28 +88,28 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "1"
 print "2"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "2"
 print "1"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "1" "2"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "2" "1"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-print3.html
@@ -87,8 +87,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 *** txtar Content ERROR ***</div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-1.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-4.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-9.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-9.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-c.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-c.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 40
 color "blue"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 60
 color "blue"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-a9.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-a9.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-d5.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-d5.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-db.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-db.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-ea.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise-txtar/q-shape-inverted-ea.html
@@ -89,32 +89,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="400" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="600" cy="600" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="blue" stroke="blue" cx="400" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/index.html
@@ -94,26 +94,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>
@@ -127,26 +127,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>
@@ -160,20 +160,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>
@@ -185,26 +185,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>
@@ -220,32 +220,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>
@@ -263,32 +263,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -308,32 +308,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10
@@ -352,32 +352,32 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10
@@ -395,32 +395,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-img1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-img1.html
@@ -89,32 +89,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-img2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-img2.html
@@ -89,32 +89,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-img3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-img3.html
@@ -91,32 +91,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link1.html
@@ -90,32 +90,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link2.html
@@ -89,32 +89,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link3.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question-link4.html
@@ -87,26 +87,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question1-sealed.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question1-sealed.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question1.html
@@ -87,20 +87,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/exercise1/question2.html
@@ -87,26 +87,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/index.html
@@ -98,29 +98,29 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>
@@ -136,8 +136,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -146,8 +146,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -156,8 +156,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -166,8 +166,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -186,8 +186,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -196,8 +196,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -206,8 +206,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -216,8 +216,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -239,29 +239,29 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>
@@ -280,8 +280,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -291,8 +291,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -302,8 +302,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -313,8 +313,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -337,8 +337,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -348,8 +348,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -359,8 +359,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -370,8 +370,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -395,8 +395,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -405,8 +405,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -415,8 +415,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -425,8 +425,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 
@@ -449,8 +449,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -459,8 +459,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -469,8 +469,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -479,8 +479,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles1.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -102,8 +102,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -112,8 +112,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -122,8 +122,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles2.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 5
 
@@ -102,8 +102,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 
@@ -112,8 +112,8 @@ circle 5
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 5
 
@@ -122,8 +122,8 @@ circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles3.html
@@ -91,8 +91,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -102,8 +102,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -113,8 +113,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -124,8 +124,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-2circles4.html
@@ -91,8 +91,8 @@ circle 5
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -102,8 +102,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -113,8 +113,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -124,8 +124,8 @@ circle 5
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle1.html
@@ -91,29 +91,29 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle2.html
@@ -88,8 +88,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -98,8 +98,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -108,8 +108,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -118,8 +118,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle3.html
@@ -88,8 +88,8 @@ circle 10
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -98,8 +98,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -108,8 +108,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -118,8 +118,8 @@ circle 10
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/shape/q-circle4.html
@@ -91,29 +91,29 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 80
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 20
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 80 80
 circle 10
 </code></pre>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/index.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/index.html
@@ -99,8 +99,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -108,8 +108,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -117,8 +117,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -126,8 +126,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20
@@ -149,8 +149,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -158,8 +158,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -167,8 +167,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -176,8 +176,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20
@@ -197,8 +197,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -208,8 +208,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -219,8 +219,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -230,8 +230,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -253,8 +253,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -264,8 +264,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -275,8 +275,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -286,8 +286,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -311,8 +311,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -320,8 +320,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -329,8 +329,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -338,8 +338,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -361,8 +361,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -370,8 +370,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -379,8 +379,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -388,8 +388,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -409,8 +409,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -420,8 +420,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -431,8 +431,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -442,8 +442,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -465,8 +465,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -476,8 +476,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -487,8 +487,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -498,8 +498,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored1.html
@@ -90,8 +90,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -112,8 +112,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -123,8 +123,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored2.html
@@ -90,8 +90,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "red"
@@ -112,8 +112,8 @@ text "Hello"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"
@@ -123,8 +123,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">font {size:25 family:"arial"} // set the letter size and style
 move 20 20
 color "blue"

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored3.html
@@ -92,8 +92,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -101,8 +101,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -110,8 +110,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -119,8 +119,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-colored4.html
@@ -92,8 +92,8 @@ text "Hello"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -101,8 +101,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="red" stroke="red" font-size="250" font-family="arial" x="200" y="800">World</text>
@@ -110,8 +110,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">Hello</text>
@@ -119,8 +119,8 @@ text "Hello"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <text fill="blue" stroke="blue" font-size="250" font-family="arial" x="200" y="800">World</text>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain1.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain1.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -110,8 +110,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -119,8 +119,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain2.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain2.html
@@ -92,8 +92,8 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 20 60
@@ -101,8 +101,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 60
 text "Hello"
 move 20 20
@@ -110,8 +110,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 20 20
 text "Hello"
 move 60 20
@@ -119,8 +119,8 @@ text "World"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 20
 text "Hello"
 move 20 20

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain3.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain3.html
@@ -90,8 +90,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -101,8 +101,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -112,8 +112,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -123,8 +123,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain4.html
+++ b/learn/pkg/learn/testdata/golden/export/html-no-private-key/unit1/text/q-plain4.html
@@ -90,8 +90,8 @@ text "World"
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -101,8 +101,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -112,8 +112,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
@@ -123,8 +123,8 @@ text "World"
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <g>
     <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>

--- a/learn/pkg/learn/testdata/golden/question-parse-error-with-marked/q-no-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/question-parse-error-with-marked/q-no-parse-error.html
@@ -4,23 +4,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" checked />
+<label>a<input type="checkbox" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" checked />
+<label>c<input type="checkbox" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" checked />
+<label>d<input type="checkbox" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/question-parse-error-with-marked/q-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/question-parse-error-with-marked/q-parse-error.html
@@ -4,23 +4,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/question-parse-error/q-no-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/question-parse-error/q-no-parse-error.html
@@ -4,23 +4,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/question-parse-error/q-parse-error.html
+++ b/learn/pkg/learn/testdata/golden/question-parse-error/q-parse-error.html
@@ -4,23 +4,23 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "banana"
 </code></pre></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "🍌
 </code></pre></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print 🍌"
 </code></pre></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print banana"
 </code></pre></div>
 </fieldset>

--- a/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-0.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-0.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-1.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-1.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-2.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-2.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-3.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar-with-marked/sub-3.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-txtar/sub-0.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar/sub-0.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-txtar/sub-1.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar/sub-1.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-txtar/sub-2.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar/sub-2.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-txtar/sub-3.html
+++ b/learn/pkg/learn/testdata/golden/question-txtar/sub-3.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "hey"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hey"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question-img1.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question-img1.html
@@ -8,32 +8,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" checked />
+<label>b<input type="radio" value="b" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question-img2.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question-img2.html
@@ -8,32 +8,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question-link1.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question-link1.html
@@ -9,32 +9,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question-link2.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question-link2.html
@@ -8,32 +8,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question-link3.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question-link3.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" checked />
+<label>d<input type="radio" value="d" name="answer" checked />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question-link4.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question-link4.html
@@ -6,26 +6,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" checked />
+<label>b<input type="checkbox" value="b" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" checked />
+<label>c<input type="checkbox" value="c" name="answer" checked />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question1-sealed-unsealed-only.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question1-sealed-unsealed-only.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question1-sealed.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question1-sealed.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question1.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question1.html
@@ -6,20 +6,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" checked />
+<label>c<input type="radio" value="c" name="answer" checked />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/question-with-marked/question2.html
+++ b/learn/pkg/learn/testdata/golden/question-with-marked/question2.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" checked />
+<label>a<input type="radio" value="a" name="answer" checked />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question/question-img1.html
+++ b/learn/pkg/learn/testdata/golden/question/question-img1.html
@@ -8,32 +8,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/question/question-img2.html
+++ b/learn/pkg/learn/testdata/golden/question/question-img2.html
@@ -8,32 +8,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color &quot;red&quot;
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color &quot;red&quot;
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color &quot;red&quot;
 circle 10

--- a/learn/pkg/learn/testdata/golden/question/question-link1.html
+++ b/learn/pkg/learn/testdata/golden/question/question-link1.html
@@ -9,32 +9,32 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 10
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">move 50 50
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">move 40 40
 color "red"
 circle 20
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">move 60 60
 color "red"
 circle 10

--- a/learn/pkg/learn/testdata/golden/question/question-link2.html
+++ b/learn/pkg/learn/testdata/golden/question/question-link2.html
@@ -8,32 +8,32 @@ circle 20
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="100"></circle>
 </svg>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="500" cy="500" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="400" cy="600" r="200"></circle>
 </svg>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <svg stroke="black" stroke-linecap="round" font-size="60" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
   <rect fill="white" stroke="white" x="0" y="0" width="100%" height="100%"></rect>
   <circle fill="red" stroke="red" cx="600" cy="400" r="100"></circle>

--- a/learn/pkg/learn/testdata/golden/question/question-link3.html
+++ b/learn/pkg/learn/testdata/golden/question/question-link3.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>print hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>hi print hi
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question/question-link4.html
+++ b/learn/pkg/learn/testdata/golden/question/question-link4.html
@@ -6,26 +6,26 @@
 <p>Choose two correct answers:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="checkbox" value="a" name="answer" />
+<label>a<input type="checkbox" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi"
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="checkbox" value="b" name="answer" />
+<label>b<input type="checkbox" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print "print hi"
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="checkbox" value="c" name="answer" />
+<label>c<input type="checkbox" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">print "print" "hi"
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="checkbox" value="d" name="answer" />
+<label>d<input type="checkbox" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">print "hi print hi"
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question/question1-sealed.html
+++ b/learn/pkg/learn/testdata/golden/question/question1-sealed.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code>&quot;hey&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code>ho
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code>hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code>&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/testdata/golden/question/question1.html
+++ b/learn/pkg/learn/testdata/golden/question/question1.html
@@ -6,20 +6,20 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <code>&quot;hey&quot;</code></div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <code>ho</code></div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <code>hi</code></div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <code>&quot;hi&quot;</code></div>
 </fieldset>
 </form>

--- a/learn/pkg/learn/testdata/golden/question/question2.html
+++ b/learn/pkg/learn/testdata/golden/question/question2.html
@@ -6,26 +6,26 @@
 <p>Choose one correct answer:</p>
 <fieldset>
 <div>
-<label for="a">a</label>
-<input type="radio" value="a" name="answer" />
+<label>a<input type="radio" value="a" name="answer" />
+</label>
 <pre><code class="language-evy">print &quot;hi&quot;
 </code></pre>
 </div>
 <div>
-<label for="b">b</label>
-<input type="radio" value="b" name="answer" />
+<label>b<input type="radio" value="b" name="answer" />
+</label>
 <pre><code class="language-evy">print hi
 </code></pre>
 </div>
 <div>
-<label for="c">c</label>
-<input type="radio" value="c" name="answer" />
+<label>c<input type="radio" value="c" name="answer" />
+</label>
 <pre><code class="language-evy">hi
 </code></pre>
 </div>
 <div>
-<label for="d">d</label>
-<input type="radio" value="d" name="answer" />
+<label>d<input type="radio" value="d" name="answer" />
+</label>
 <pre><code class="language-evy">&quot;hi&quot;
 </code></pre>
 </div>

--- a/learn/pkg/learn/tmpl/learn.html.tmpl
+++ b/learn/pkg/learn/tmpl/learn.html.tmpl
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>{{.Title}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="{{.Root}}/img/favicon.png" />
+    <link rel="icon" href="/learn/img/favicon.png" />
     <link rel="stylesheet" href="{{.Root}}/css/resets.css" type="text/css" />
     <link rel="stylesheet" href="{{.Root}}/css/root.css" type="text/css" />
     <link rel="stylesheet" href="{{.Root}}/css/elements.css" type="text/css" />

--- a/learn/pkg/learn/tmpl/learn.html.tmpl
+++ b/learn/pkg/learn/tmpl/learn.html.tmpl
@@ -21,6 +21,7 @@
       {
         "imports": {
           "./module/highlight.js": "./module/highlight.js",
+          "./module/spa.js": "./module/spa.js",
           "./module/theme.js": "./module/theme.js"
         }
       }


### PR DESCRIPTION
Capture `onclick` event of course link: links starting with the same
courseRoot directory derived from the sidebar heading and all other relative
links.

Instead of default link navigation load fragment of href (href + "f") and
replace inner HTML (`...`) of

    <main>
      <div class="max-width-wrapper">
        ...
      </div>
    </main>

Fiddle with HS History API so that the browser back and forwards buttons
still work as expected. Fun.

In preparatory commit generate HTML Fragments with .htmlf ending - the same
files as the regular .html files without doctype, html, head, body, and other
tags that are not needed when we only want to replace the main content of the
page:

    <!doctype html>
    <html lang="en">
      <head>...</head>
      <body>
        <header>...</header>
        <nav>...</nav>
        <main>
           <div class="max-width-wrapper">
                <!-- 👉 KEEP this bit as FRAGMENT 👈 -->
           </div>
        </main>
      </body>
    </html>

Sneak in a mini style change making the content narrower.