### PR TITLE
bytecode: Implement local variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -474,6 +474,8 @@ func (c *compileCmd) Run() error {
 		return err
 	}
 	bc := comp.Bytecode()
+	fmt.Println("Num globals:", bc.GlobalCount)
+	fmt.Println("Num locals:", bc.LocalCount)
 	fmt.Println("Constants:")
 	for i, c := range bc.Constants {
 		fmt.Printf("%d: %v\n", i, c)

--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -10,11 +10,11 @@ const (
 	// OpConstant defines a constant that will be referred to by index
 	// in the bytecode.
 	OpConstant Opcode = iota
-	// OpGetGlobal retrieves a symbol from the symbol table at the
+	// OpGetGlobal retrieves a symbol from the global symbol table at the
 	// specified index.
 	OpGetGlobal
-	// OpSetGlobal adds a symbol to the specified index in the symbol
-	// table.
+	// OpSetGlobal adds a symbol to the specified index in the global
+	// symbol table.
 	OpSetGlobal
 	// OpDrop pops and discards the top N elements of the stack.
 	OpDrop

--- a/pkg/bytecode/code.go
+++ b/pkg/bytecode/code.go
@@ -18,6 +18,14 @@ const (
 	OpSetGlobal
 	// OpDrop pops and discards the top N elements of the stack.
 	OpDrop
+	// OpGetLocal retrieves a symbol from the current local-scoped
+	// symbol table at the specified index. This index also corresponds
+	// to its location on the VM stack.
+	OpGetLocal
+	// OpSetLocal adds a symbol to the specified index in the current
+	// local-scoped symbol table. This index also corresponds to its
+	// location on the VM stack.
+	OpSetLocal
 	// OpAdd instructs the virtual machine to perform an addition.
 	OpAdd
 	// OpSubtract instructs the virtual machine to perform a subtraction.
@@ -137,6 +145,8 @@ var definitions = map[Opcode]*OpDefinition{
 	OpGetGlobal: {"OpGetGlobal", []int{2}},
 	OpSetGlobal: {"OpSetGlobal", []int{2}},
 	OpDrop:      {"OpDrop", []int{2}},
+	OpGetLocal:  {"OpGetLocal", []int{2}},
+	OpSetLocal:  {"OpSetLocal", []int{2}},
 	// Operations like OpAdd have no operand width because the virtual
 	// machine is expected to pop the values from the stack when reading
 	// this instruction.

--- a/pkg/bytecode/symbol.go
+++ b/pkg/bytecode/symbol.go
@@ -6,6 +6,9 @@ type SymbolScope string
 const (
 	// GlobalScope is the top level scope of an evy program.
 	GlobalScope SymbolScope = "GLOBAL"
+	// LocalScope is any local scope in an evy program, it is distinct
+	// from the GlobalScope.
+	LocalScope SymbolScope = "LOCAL"
 )
 
 // Symbol is a variable inside an evy program.
@@ -15,9 +18,41 @@ type Symbol struct {
 	Index int
 }
 
-// SymbolTable is a mapping of string identifiers to symbols.
+// SymbolTable translates the variables of an Evy program to memory locations.
+// It maps variable names (or symbols) encountered during compilation to their
+// corresponding index-addressed memory locations, which are used at run time.
+// This enables efficient access and manipulation of variables by the Evy
+// virtual machine.
+//
+// Global variables, which are declared at the top level of a program and
+// outside of any blocks, are stored in a dedicated global memory space. All
+// other variables are considered local variables and are stored on the program
+// stack.
+//
+// Index mapping for symbols involves tracking variable counts within each
+// scope of the Evy program. As new variables are defined within a scope, the
+// corresponding index is incremented (see [SymbolTable.Define] method). Upon
+// entering a new block scope, a dedicated SymbolTable is created and pushed
+// onto a stack ([SymbolTable.Push] method) to manage variables within that
+// block. When exiting the block scope, the SymbolTable is popped off the stack
+// ([SymbolTable.Pop] method), and the maximum index value is propagated back
+// to the parent scope. This allows the maximum number of symbols in scope at
+// the same time to be known so we do not over-allocate space for them at run
+// time.
 type SymbolTable struct {
 	store map[string]Symbol
+	// index keeps track of the number of locals inside this scope,
+	// an enclosed SymbolTable will inherit a starting index from
+	// its outer table.
+	index int
+	// nestedMaxIndex is the maximum index of any inner symbol
+	// tables. It propagates up the SymbolTable chain as SymbolTables
+	// are Popped so know how much space to allocate for variables.
+	nestedMaxIndex int
+	// outer is a SymbolTable that encloses this one, Resolve will
+	// travel up the stack of tables looking for a symbol. If outer
+	// is nil, this SymbolTable is the global symbol table.
+	outer *SymbolTable
 }
 
 // NewSymbolTable returns a new SymbolTable.
@@ -27,20 +62,60 @@ func NewSymbolTable() *SymbolTable {
 	}
 }
 
+// Push nests a new symbol table under s. The index for the nested table starts
+// at the index of the outer symbol table if the outer symbol table is not the
+// global symbol table. Otherwise the index starts at zero.
+func (s *SymbolTable) Push() *SymbolTable {
+	index := s.index
+	// If our outer symbol table is the global symbol table, we do
+	// not count its index as globals are stored in a separate space.
+	if s.outer == nil {
+		index = 0
+	}
+	return &SymbolTable{
+		store: make(map[string]Symbol),
+		outer: s,
+		index: index,
+	}
+}
+
+// Pop returns the outer symbol table of s and updates the outer symbol table's
+// nested max index. This accumulates the maximum index of all nested scopes
+// into the parent scope so we know how much storage is needed for all the
+// variables of a scope and its children.
+func (s *SymbolTable) Pop() *SymbolTable {
+	if s.outer == nil {
+		return s
+	}
+	s.outer.nestedMaxIndex = max(s.outer.nestedMaxIndex, s.nestedMaxIndex+s.index)
+	return s.outer
+}
+
 // Define adds a symbol definition to the table or returns an
 // already defined symbol with the same name.
 func (s *SymbolTable) Define(name string) Symbol {
 	if existing, found := s.store[name]; found {
 		return existing
 	}
-	symbol := Symbol{Name: name, Index: len(s.store), Scope: GlobalScope}
+	symbol := Symbol{Name: name, Index: s.index}
+	s.index++
+	if s.outer == nil {
+		symbol.Scope = GlobalScope
+	} else {
+		symbol.Scope = LocalScope
+	}
 	s.store[name] = symbol
 	return symbol
 }
 
-// Resolve returns the Symbol with the specified name,
-// or false if there is no such Symbol.
+// Resolve returns the Symbol with the specified name and true, or if there is
+// no matching symbol, it recurses to the outer symbol table. If there is no
+// outer symbol table, false is returned.
 func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 	obj, ok := s.store[name]
-	return obj, ok
+	if ok || s.outer == nil {
+		// Found symbol or we cannot recurse any more.
+		return obj, ok
+	}
+	return s.outer.Resolve(name)
 }

--- a/pkg/bytecode/symbol_test.go
+++ b/pkg/bytecode/symbol_test.go
@@ -19,6 +19,26 @@ func TestDefine(t *testing.T) {
 	}
 }
 
+func TestIndex(t *testing.T) {
+	t.Run("enclosed index", func(t *testing.T) {
+		global := NewSymbolTable()
+		global.Define("a")
+		global.Define("b")
+		nested := global.Push()
+		symbol := nested.Define("c")
+		assert.Equal(t, 0, symbol.Index)
+		nested2 := nested.Push()
+		s2 := nested2.Define("d")
+		assert.Equal(t, 1, s2.Index)
+	})
+	t.Run("empty outer", func(t *testing.T) {
+		global := NewSymbolTable()
+		local := global.Push()
+		symbol := local.Define("c")
+		assert.Equal(t, 0, symbol.Index)
+	})
+}
+
 func TestResolveGlobal(t *testing.T) {
 	expected := []Symbol{
 		{Name: "a", Scope: GlobalScope, Index: 0},


### PR DESCRIPTION
Add scopes to the compiler so that it can differentiate whether a
variable is global or local. A local variable is one that is not defined
at the top-level of the program - i.e. it is either in a block at the
top-level of the program or in a function (although functions are not
yet implemented in the compiler).

Space is allocated at the top of the stack for the locals needed, with
the stack pointer initialised to start after that. The space allocated
for locals is reused where it can be, for example, when two blocks at
the same level have a local variable, they can share the same space as
they both cannot be in scope at the same time.

