### PR TITLE
fmt: Create temp file in same dir as source file

### DIFF
--- a/main.go
+++ b/main.go
@@ -300,7 +300,7 @@ func (c *fmtCmd) fmtTxtarFile(filename string) error {
 }
 
 func writeAtomically(b []byte, filename string) error {
-	tempFile, err := os.CreateTemp("", "evy")
+	tempFile, err := os.CreateTemp(filepath.Dir(filename), "evy")
 	if err != nil {
 		return fmt.Errorf("%s: %w", filename, err)
 	}


### PR DESCRIPTION
Create the temporary file for formatting evy source in the same
directory as the source file so that we can rename it over the original
source file if necessary. A rename cannot be across filesystems so the
only valid place for the temp file is in the same directory as the file
that will be overwritten by the rename. Without that, you may get an
error like:

    evy: error: hsl.evy: rename /tmp/evy3084141908 hsl.evy: invalid cross-device link