### PR TITLE
wasm: Set lower bound for sleep function

### DIFF
--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -26,11 +26,19 @@ func newJSRuntime() *jsRuntime {
 	return &jsRuntime{yielder: newSleepingYielder()}
 }
 
-func (rt *jsRuntime) Yielder() evaluator.Yielder       { return rt.yielder }
-func (rt *jsRuntime) Print(s string)                   { jsPrint(s) }
-func (rt *jsRuntime) Cls()                             { jsCls() }
-func (rt *jsRuntime) Read() string                     { return rt.yielder.Read() }
-func (rt *jsRuntime) Sleep(dur time.Duration)          { rt.yielder.Sleep(dur) }
+func (rt *jsRuntime) Yielder() evaluator.Yielder { return rt.yielder }
+func (rt *jsRuntime) Print(s string)             { jsPrint(s) }
+func (rt *jsRuntime) Cls()                       { jsCls() }
+func (rt *jsRuntime) Read() string               { return rt.yielder.Read() }
+
+func (rt *jsRuntime) Sleep(dur time.Duration) {
+	// Enforce a lower bound to stop browser tabs from freezing.
+	if dur < minSleepDur {
+		dur = minSleepDur
+	}
+	rt.yielder.Sleep(dur)
+}
+
 func (rt *jsRuntime) Move(x, y float64)                { move(x, y) }
 func (rt *jsRuntime) Line(x, y float64)                { line(x, y) }
 func (rt *jsRuntime) Rect(x, y float64)                { rect(x, y) }


### PR DESCRIPTION
When calling `sleep` in the JS runtime, enforce a minimum allowed
interval of 1 millisecond.

This change is motivated by watching students use evy. I found they
experimented with very large and very small numbers. When writing a loop
with 10,000,000,000+ iterations containing `sleep 0`, their browser tabs
crash. For example, run this program against `main`:

```evy
i:num

clear "blue"
while i < 100000
    move i 50
    color "yellow"
    circle 5
    i = i + 0.1
    sleep 0
end
```

This is enough to freeze the browser tab on my PC for a few seconds, and
the evy UI is unresponsive even after the render finishes. In my branch,
it runs smoothly - and slowly - with the STOP button still functional.

I experimented with a few values and found a minimum sleep of 1
millisecond (0.001 seconds) is enough to ensure that the browser remains
responsive.

---

## Questions
- Is this the correct approach to this problem? Should we enforce this at all, or should the compiler (?) emit a warning (?) for cases where we see `sleep 0`.
- Does other hardware behave the same as my setup? Please run this locally and let me know!
- I have reused `minSleepDur`, should I define a second constant?
