### PR TITLE
builtins: Fix `rand` and `sleep` functions

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -433,6 +433,9 @@ with `del` while iterating with a `for … range` loop.
 `sleep` can be used to create delays in Evy programs. For example, you
 could use sleep to create a countdown timer.
 
+In the [browser runtime](spec.md#runtimes) `sleep` pauses a minimum of 1
+millisecond.
+
 #### Example
 
 ```evy

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -969,6 +969,10 @@ print map
           <code>sleep</code> can be used to create delays in Evy programs. For example, you could
           use sleep to create a countdown timer.
         </p>
+        <p>
+          In the <a href="spec.html#runtimes">browser runtime</a> <code>sleep</code> pauses a
+          minimum of 1 millisecond.
+        </p>
         <h4>Example</h4>
         <pre><code class="language-evy">print &quot;2&quot;
 sleep 1

--- a/frontend/docs/builtins.htmlf
+++ b/frontend/docs/builtins.htmlf
@@ -397,6 +397,10 @@ print map
   <code>sleep</code> can be used to create delays in Evy programs. For example, you could use sleep
   to create a countdown timer.
 </p>
+<p>
+  In the <a href="spec.html#runtimes">browser runtime</a> <code>sleep</code> pauses a minimum of 1
+  millisecond.
+</p>
 <h4>Example</h4>
 <pre><code class="language-evy">print &quot;2&quot;
 sleep 1

--- a/pkg/cli/svg/runtime.go
+++ b/pkg/cli/svg/runtime.go
@@ -24,7 +24,7 @@ var (
 		Stroke:          "black",
 		StrokeWidth:     &defaultStrokeWidth,
 		StrokeLinecap:   "round",
-		StorkeDashArray: "",
+		StrokeDashArray: "",
 	}
 )
 
@@ -105,8 +105,8 @@ func (rt *GraphicsRuntime) nonDefaultAttr() Attr {
 	if rt.attr.StrokeLinecap == defaultAttr.StrokeLinecap {
 		attr.StrokeLinecap = ""
 	}
-	if rt.attr.StorkeDashArray == defaultAttr.StorkeDashArray {
-		attr.StorkeDashArray = ""
+	if rt.attr.StrokeDashArray == defaultAttr.StrokeDashArray {
+		attr.StrokeDashArray = ""
 	}
 	return attr
 }
@@ -327,7 +327,7 @@ func (rt *GraphicsRuntime) Dash(segments []float64) {
 	for i, segment := range segments {
 		segmentStrings[i] = ftoa(rt.scale(segment))
 	}
-	rt.attr.StorkeDashArray = strings.Join(segmentStrings, " ")
+	rt.attr.StrokeDashArray = strings.Join(segmentStrings, " ")
 }
 
 // Linecap sets the stroke linecap style.

--- a/pkg/cli/svg/svg.go
+++ b/pkg/cli/svg/svg.go
@@ -30,7 +30,7 @@ type Attr struct {
 	Stroke          string   `xml:"stroke,attr,omitempty"`
 	StrokeWidth     *float64 `xml:"stroke-width,attr,omitempty"`
 	StrokeLinecap   string   `xml:"stroke-linecap,attr,omitempty"`
-	StorkeDashArray string   `xml:"stroke-dasharray,attr,omitempty"`
+	StrokeDashArray string   `xml:"stroke-dasharray,attr,omitempty"`
 }
 
 // TextAttr represents the attributes of text or group SVG elements and

--- a/pkg/cli/svg/svg_test.go
+++ b/pkg/cli/svg/svg_test.go
@@ -34,7 +34,7 @@ func TestGolden(t *testing.T) {
 					Stroke:          "red",
 					StrokeWidth:     &testStrokeWidth,
 					StrokeLinecap:   "butt",
-					StorkeDashArray: "3 5",
+					StrokeDashArray: "3 5",
 				},
 			}},
 		},

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -668,8 +668,8 @@ var randsource = rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 
 func randFunc(_ *scope, args []value) (value, error) {
 	upper := args[0].(*numVal).V
-	if upper <= 0 || upper > 2147483647 { // [1, 2^31-1]
-		return nil, fmt.Errorf(`%w: "rand %0.f" not in range 1 to 2147483647`, ErrBadArguments, upper)
+	if upper < 1 || upper > 2147483647 { // [1, 2^31-1]
+		return nil, fmt.Errorf(`%w: "rand %v" not in range 1 to 2147483647`, ErrBadArguments, upper)
 	}
 	return &numVal{V: float64(randsource.Int31n(int32(upper)))}, nil
 }

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -26,11 +26,16 @@ func newJSRuntime() *jsRuntime {
 	return &jsRuntime{yielder: newSleepingYielder()}
 }
 
-func (rt *jsRuntime) Yielder() evaluator.Yielder       { return rt.yielder }
-func (rt *jsRuntime) Print(s string)                   { jsPrint(s) }
-func (rt *jsRuntime) Cls()                             { jsCls() }
-func (rt *jsRuntime) Read() string                     { return rt.yielder.Read() }
-func (rt *jsRuntime) Sleep(dur time.Duration)          { rt.yielder.Sleep(dur) }
+func (rt *jsRuntime) Yielder() evaluator.Yielder { return rt.yielder }
+func (rt *jsRuntime) Print(s string)             { jsPrint(s) }
+func (rt *jsRuntime) Cls()                       { jsCls() }
+func (rt *jsRuntime) Read() string               { return rt.yielder.Read() }
+
+func (rt *jsRuntime) Sleep(dur time.Duration) {
+	// Enforce a lower bound to stop browser tabs from freezing.
+	rt.yielder.Sleep(max(minSleepDur, dur))
+}
+
 func (rt *jsRuntime) Move(x, y float64)                { move(x, y) }
 func (rt *jsRuntime) Line(x, y float64)                { line(x, y) }
 func (rt *jsRuntime) Rect(x, y float64)                { rect(x, y) }


### PR DESCRIPTION
Fix `rand` and `sleep` functions to not crash when used with bad arguments: In
the case of rand we ensure the argument is `>= 1`, and in the case of sleep we
ensure we sleep a minimum of 1 millisecond.

Add a minor unrelated typo fix.

This PR has cherry-picked from two other PRs created from forked repo, which
cannot run CI.

Related-pull-request: https://github.com/evylang/evy/pull/412
Related-pull-request: https://github.com/evylang/evy/pull/413

---

@phy1um - I've manually tested it after the fix with `max`, just like you described in
your PR :pray: . 
Code sample 
- ✅ on [PR](https://evy-lang-stage-play--417-0bon79wf.web.app/#content=H4sIAAAAAAAAA0vLL1LIVLCyVShKzEtPVTA0AAEuBQUFheScYjBdUJSZV6KQCWYX56SmFigY6BlAgSFXal4KFwDlzDyURAAAAA==) 
- :boom: on [main](https://play.evy.dev/#content=H4sIAAAAAAAAA0vLL1LIVLCyVShKzEtPVTA0AAEuBQUFheScYjBdUJSZV6KQCWYX56SmFigY6BlAgSFXal4KFwDlzDyURAAAAA==) (crashes tab!)  

Docs update:
https://evy-lang-stage-docs--417-lffgt2s0.web.app/builtins.html#sleep