### PR TITLE
e2e: Reduce dialog snapshot test flakiness

### DIFF
--- a/e2e/docs/test.js
+++ b/e2e/docs/test.js
@@ -23,6 +23,7 @@ for (const baseURL of baseURLs) {
       }
 
       await page.getByRole("button", { name: "About" }).click()
+      await new Promise((resolve) => setTimeout(resolve, 1000)) // unflakes snapshot test :(
       await expect(page).toHaveScreenshot("dialog.png")
 
       await page.getByRole("button", { name: "Done" }).click()
@@ -32,6 +33,7 @@ for (const baseURL of baseURLs) {
       await expect(page).toHaveScreenshot("start-theme.png")
 
       await page.getByRole("button", { name: "About" }).click()
+      await new Promise((resolve) => setTimeout(resolve, 1000)) // unflakes snapshot test :(
       await expect(page).toHaveScreenshot("dialog-theme.png")
     })
 


### PR DESCRIPTION
Reduce dialog snapshot test flakiness, or at least attempt it. We just
add a 1 sec wait before we take the dialog snapshot which seems to have
removed any local flakiness. I'm really unsure what the right way to
fix this would be, but snapshot tests have been useful (and painful) in
the past and found real issues so we'll stick with them for now.