### PR TITLE
e2e: Revert some recent e2e fixes

### DIFF
--- a/e2e/docs/test.js
+++ b/e2e/docs/test.js
@@ -64,6 +64,7 @@ for (const baseURL of baseURLs) {
       await link.hover()
       await expect(page).toHaveScreenshot("comment-hover.png", sreenshotOpts)
       await link.click()
+      await page.waitForLoadState("networkidle")
       await expect(page).toHaveScreenshot("comment-page.png", sreenshotOpts)
     })
 

--- a/e2e/play/test.js
+++ b/e2e/play/test.js
@@ -91,7 +91,7 @@ end
       }
       await page.locator('input[type="text"]').click()
       await page.locator('input[type="text"]').press("ArrowRight")
-      await expect(page).toHaveScreenshot("share-dialog.png")
+      await expect(page).toHaveScreenshot("share-dialog.png", { maxDiffPixelRatio: 0.01 })
       await page.locator("#dialog-share .icon-close").click()
       await expect(page).toHaveScreenshot("no-dialog.png")
       await page.locator("#hamburger").click()


### PR DESCRIPTION
Revert some recent e2e fixes around share dialog snapshot tests. Revert the
removed pixel difference threshhold in one test. However, the previously added
ios tests seem to be ok, so we will leave them in.

It is unclear how these tests passed on PR CI and but do not pass on main CI
despite 3 re-runs. I somewhat consistently could reproduce the issue locally
with:

	BASEURL='https://evy.dev' make e2e USE_DOCKER=1

Against localhost / without BASEURL the issue never shows up for me even when
run with docker. However, I had another unrelated issue show up quite
frequently too in the docs tests which seems to be addressed with an extra
wait for network idle. I will keep the docs tests fix in place.

I also suspected that once tests pass once it is harder to get them to fail
again, which would explain why we didn't see the issue on the PR before. I'm
not sure if this makes any sense at all.

Related-Pull-Request: https://github.com/evylang/evy/pull/420
Related-Commit: b8f0fdfb6f28213d1be655fb6645713b7f3abc4e