### PR TITLE
labsite: Fix regression

### DIFF
--- a/frontend/lab/index.html
+++ b/frontend/lab/index.html
@@ -194,7 +194,7 @@
             <input type="text" id="share-url" />
             <button type="button" class="icon-copy"></button>
           </div>
-          <button class="primary">Done</button>
+          <button class="primary" id="copy">Copy</button>
         </main>
       </form>
     </dialog>


### PR DESCRIPTION
Fix regression introduced with the updated share-dialog. I forgot to update the
 lab/index.html which did _not_ have a copy button with ID, which caused the
 index.js file to throw an exception and abort mid way through initialization.
 Not great. I could add e2e tests for the labsite, but this site is so much in
 flux at the moment, I'll wait a little longer. Alternatively I could try and
 make the JS a little more robust against initialization exceptions, but maybe
 erroring early is the right way here.

 Fixed for now, labsite e2e on the horizon.

---

btw, this error shows for instance by going to:

https://lab.evy.dev/#hsl

it is kinda weird that it doesn't show with other lab samples, but I can't be
bothered to understand more deeply right now.