### PR TITLE
firebase: Fix config for gallery prod deployment

### DIFF
--- a/firebase/.firebaserc
+++ b/firebase/.firebaserc
@@ -68,7 +68,7 @@
           "evy-lang-docs"
         ],
         "gallery": [
-          "evy-lang-stage-gallery"
+          "evy-lang-gallery"
         ],
         "lab": [
           "evy-lang-lab"


### PR DESCRIPTION
Fix config for gallery prod deployment which accidentally attempted to
deploy to stage - a copy-paste error in .firebaserc.