### PR TITLE
lint: Ignore unwrapped errors in main package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,15 @@ issues:
     - "^G304: Potential file inclusion via variable"
     - "^G306: Expect WriteFile permissions to be 0600 or less"
     - "^G301: Expect directory permissions to be 0750 or less"
+  exclude-rules:
+    # Dynamic errors are OK in main packages. Packages should use sentinels.
+    - path: "^([^/]*|build-tools/.*)$"
+      linters:
+        - err113
+    # Used with `cd learn; golangci-lint run`
+    - path: "^cmd/.*$"
+      linters:
+        - err113
 
 linters:
   enable-all: true

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,12 @@ build-full: embed | $(O)
 ## Build evy binaries without web content embedded
 build-go: $(O)
 	go build -o $(O) -ldflags='$(GO_LDFLAGS)' $(CMDS)
-	cd learn; go build -o ../$(O) -ldflags='$(GO_LDFLAGS)' $(LEARN_CMDS)
+	go build -C learn -o ../$(O) -ldflags='$(GO_LDFLAGS)' $(LEARN_CMDS)
 
 ## Build and install binaries in $GOBIN
 install-full: embed
 	go install -tags full -ldflags='$(GO_LDFLAGS)' $(CMDS)
-	cd learn; go install -ldflags='$(GO_LDFLAGS)' $(LEARN_CMDS)
+	go -C learn install -ldflags='$(GO_LDFLAGS)' $(LEARN_CMDS)
 
 ## Build and install binaries without embedded frontend in $GOBIN
 install:
@@ -94,7 +94,7 @@ EXPORTDIR = $(O)/export-test
 ## Run non-tinygo tests and generate a coverage file
 test-go: | $(O)
 	go test -coverprofile=$(COVERFILE) ./...
-	cd learn; go test -coverprofile=../$(LEARNCOVERFILE) ./...
+	go test -C learn -coverprofile=../$(LEARNCOVERFILE) ./...
 
 ## Test evy CLI
 test-cli: build-full

--- a/build-tools/site-gen/main.go
+++ b/build-tools/site-gen/main.go
@@ -106,7 +106,6 @@ func (a *app) copyTree() error {
 		case 0: // normal file
 			return a.handleFile(filename)
 		default:
-			//nolint:goerr113 // dynamic errors in package main is ok
 			return fmt.Errorf("unknown file type: %s: %s", mode, srcfile)
 		}
 	})
@@ -125,11 +124,9 @@ func checkSymlink(srcfile string) error {
 	}
 	mode := fi.Mode() & fs.ModeType
 	if mode == fs.ModeDir {
-		//nolint:goerr113 // dynamic errors in package main is ok
 		return fmt.Errorf("symlink dirs not allowed: %s", srcfile)
 	}
 	if mode != 0 {
-		//nolint:goerr113 // dynamic errors in package main is ok
 		return fmt.Errorf("symlink to unknown file type: %s: %s", mode, srcfile)
 	}
 	return nil
@@ -157,7 +154,6 @@ func (a *app) handleFile(filename string) error {
 		basename := strings.TrimSuffix(filepath.Base(filename), ext)
 		target := basename + "." + shortSha + ext
 		if _, ok := a.renamedFiles[filename]; ok {
-			//nolint:goerr113 // dynamic errors in package main is ok
 			return fmt.Errorf("duplicate filename: %s", srcfile)
 		}
 		a.renamedFiles[filename] = target

--- a/docs/development/upgrade.md
+++ b/docs/development/upgrade.md
@@ -52,8 +52,8 @@ Upgrade all Go package dependencies with
 
 and the same again for the `evy/learn` sub-module
 
-    go -C learn get -u ./...
-    go -C learn mod tidy
+    go get -C learn -u ./...
+    go mod -C learn tidy
 
 Verify that the Go version specified in the `go.mod` files matches the Go
 version that Hermit installs, which has potentially been upgraded in the prior

--- a/frontend/docs/development/upgrade.html
+++ b/frontend/docs/development/upgrade.html
@@ -100,8 +100,8 @@
 go mod tidy
 </code></pre>
         <p>and the same again for the <code>evy/learn</code> sub-module</p>
-        <pre><code>go -C learn get -u ./...
-go -C learn mod tidy
+        <pre><code>go get -C learn -u ./...
+go mod -C learn tidy
 </code></pre>
         <p>
           Verify that the Go version specified in the <code>go.mod</code> files matches the Go

--- a/frontend/docs/development/upgrade.htmlf
+++ b/frontend/docs/development/upgrade.htmlf
@@ -47,8 +47,8 @@
 go mod tidy
 </code></pre>
 <p>and the same again for the <code>evy/learn</code> sub-module</p>
-<pre><code>go -C learn get -u ./...
-go -C learn mod tidy
+<pre><code>go get -C learn -u ./...
+go mod -C learn tidy
 </code></pre>
 <p>
   Verify that the Go version specified in the <code>go.mod</code> files matches the Go version that

--- a/learn/cmd/levy/main.go
+++ b/learn/cmd/levy/main.go
@@ -94,7 +94,7 @@ type unsealCmd struct {
 
 func (c *exportCmd) Run() error {
 	if c.WithAnswersMarked && c.ExportType != "all" && c.ExportType != "html" {
-		return errors.New(`--with-marked can only be used with all "all" and "html" export targets`) //nolint:err113 // dynamic errors in main are fine.
+		return errors.New(`--with-marked can only be used with all "all" and "html" export targets`)
 	}
 	exportOptions := learn.ExportOptions{
 		WriteHTML:         c.ExportType == "html" || c.ExportType == "all",

--- a/learn/pkg/learn/learn.go
+++ b/learn/pkg/learn/learn.go
@@ -126,7 +126,7 @@ func newModelWithFrontmatter(mdFile, frontmatterString, mdString string, opts []
 	case "course":
 		return NewCourseModel(mdFile, opts...)
 	}
-	return nil, fmt.Errorf("unsupported frontmatter type %q", string(fm.Type)) //nolint:err113 // dynamic errors in main are fine.
+	return nil, fmt.Errorf("%w: unsupported frontmatter type %q", ErrInvalidFrontmatter, string(fm.Type))
 }
 
 type baseFrontmatter struct {

--- a/main.go
+++ b/main.go
@@ -167,7 +167,6 @@ func (c *runCmd) Run() error {
 
 func (c *runCmd) fileBytes() ([]byte, error) {
 	if c.Txtar != "" && filepath.Ext(c.Source) != ".txtar" {
-		//nolint:goerr113 // dynamic errors in package main is ok
 		return nil, errors.New("txtar member specified but source file is not a txtar archive")
 	}
 	b, err := fileBytes(c.Source)
@@ -181,7 +180,6 @@ func (c *runCmd) fileBytes() ([]byte, error) {
 				return file.Data, nil
 			}
 		}
-		//nolint:goerr113 // dynamic errors in package main is ok
 		return nil, fmt.Errorf("file %q not found in txtar archive", c.Txtar)
 	}
 	return b, nil
@@ -391,7 +389,6 @@ func validateExportDir(force bool, name string) error {
 		if force {
 			return nil
 		}
-		//nolint:goerr113 // dynamic errors in package main is ok
 		return fmt.Errorf("%q is not empty, use --force", name)
 	}
 	return err


### PR DESCRIPTION
Ignore unwrapped errors in Go `main` packages. We only use Sentinel
errors when provided by packages. Disable err113 linter for main
packages and remove inline `//nolint:` directives.

As I fixed this up I revisited building the go sub-module in `learn/`
and made it consistent in docs and Makefile.