### PR TITLE
labsite: Tweak UI after session with school

### DIFF
--- a/frontend/lab/css/overrides.css
+++ b/frontend/lab/css/overrides.css
@@ -28,7 +28,7 @@ html {
   scroll-behavior: smooth;
   position: relative;
 }
-.notes:after {
+.notes:not(.notes:has(+ .editor-wrap.hidden)):after {
   content: "";
   display: block;
   height: 80%;

--- a/frontend/lab/css/overrides.css
+++ b/frontend/lab/css/overrides.css
@@ -122,7 +122,7 @@ html {
     padding: 0;
     background: none;
     margin-bottom: 24px;
-    pointer-events: none;
+    user-select: none;
   }
 }
 

--- a/frontend/lab/index.html
+++ b/frontend/lab/index.html
@@ -192,7 +192,6 @@
           <div class="copy">
             <label for="share-url">Sharable URL</label>
             <input type="text" id="share-url" />
-            <button type="button" class="icon-copy"></button>
           </div>
           <button class="primary" id="copy">Copy</button>
         </main>

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -478,7 +478,8 @@ function handleNotesNextClick(e) {
     if (el.querySelector(".next-btn")) break
     el = el.nextElementSibling
   }
-  document.querySelector("#notes").scrollTo({ top: btn.offsetTop + 38, behavior: "smooth" })
+  const top = btn.offsetTop + btn.offsetHeight
+  document.querySelector("#notes").scrollTo({ top, behavior: "smooth" })
 }
 
 function updateEditor(content, opts) {


### PR DESCRIPTION
- Make Hint content un-copyable
- Remove copy icon
- Remove extra notes space without editor. There won't be Next buttons (overview only)
- Tweak smooth scrolling offset