### PR TITLE
make: Rework make targets for parallelism

### DIFF
--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -12,19 +12,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: ./bin/make build-go test
+      - run: ./bin/make -j $(nproc) build-go test
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: ./bin/make lint
+      - run: ./bin/make -j $(nproc) lint
 
   check-uptodate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: ./bin/make ci-check-uptodate
+      - run: ./bin/make -j $(nproc) ci-check-uptodate
         env:
           TERM: vt100
 
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: ./bin/make deploy ENV=stage CHANNEL= # empty channel becomes PR-NUM or "live"
+      - run: ./bin/make -j $(nproc) deploy ENV=stage CHANNEL= # empty channel becomes PR-NUM or "live"
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -12,15 +12,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: ./bin/make check-uptodate build-go test
-        env:
-          TERM: vt100
+      - run: ./bin/make build-go test
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: ./bin/make lint
+
+  check-uptodate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./bin/make ci-check-uptodate
+        env:
+          TERM: vt100
 
   deploy:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -151,22 +151,22 @@ conform: install
 # --- Docs ---------------------------------------------------------------------
 doc: doctest godoc toc usage
 
-DOCTEST_CMD = ./build-tools/doctest.awk $(md) > $(O)/out.md && mv $(O)/out.md $(md)
+DOCTEST_CMD = ./build-tools/doctest.awk $(md) > $(O)/doctest-out.md && mv $(O)/doctest-out.md $(md)
 DOCTESTS = docs/builtins.md docs/spec.md docs/syntax-by-example.md
 doctest: install
 	$(foreach md,$(DOCTESTS),$(DOCTEST_CMD)$(nl))
 
-TOC_CMD = ./build-tools/toc.awk $(md) > $(O)/out.md && mv $(O)/out.md $(md)
+TOC_CMD = ./build-tools/toc.awk $(md) > $(O)/toc-out.md && mv $(O)/toc-out.md $(md)
 TOCFILES = docs/builtins.md docs/spec.md
-toc:
+toc: | $(O)
 	$(foreach md,$(TOCFILES),$(TOC_CMD)$(nl))
 
-USAGE_CMD = ./build-tools/gencmd.awk $(md) > $(O)/out.md && mv $(O)/out.md $(md)
+USAGE_CMD = ./build-tools/gencmd.awk $(md) > $(O)/usage-out.md && mv $(O)/usage-out.md $(md)
 USAGEFILES = docs/usage.md
 usage: install
 	$(foreach md,$(USAGEFILES),$(USAGE_CMD)$(nl))
 
-GODOC_CMD = ./build-tools/gengodoc.awk $(filename) > $(O)/out.go && mv $(O)/out.go $(filename)
+GODOC_CMD = ./build-tools/gengodoc.awk $(filename) > $(O)/godoc-out.go && mv $(O)/godoc-out.go $(filename)
 GODOCFILES = main.go learn/cmd/levy/main.go
 godoc: install
 	$(foreach filename,$(GODOCFILES),$(GODOC_CMD)$(nl))
@@ -292,7 +292,8 @@ snaps: run-playwright
 $(NODELIB):
 	@mkdir -p $@
 
-.PHONY: check-prettier e2e prettier serve
+.PHONY: check-prettier check-style e2e e2e-diff install-playwright run-playwright prettier serve snaps style
+.NOTPARALLEL: check-prettier check-style prettier style
 
 # --- deploy -----------------------------------------------------------------
 CHANNEL = live

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ test: test-go test-tiny test-cli check-coverage
 lint: lint-go lint-sh check-prettier check-style check-fmt-evy conform
 
 ## Full clean build and up-to-date checks as run on CI
-ci: clean check-uptodate all
+ci: ci-check-uptodate .WAIT all
+
+ci-check-uptodate: clean .WAIT check-uptodate
 
 check-uptodate: tidy fmt doc docs learn lab
 	test -z "$$(git status --porcelain)" || { git status; false; }
@@ -28,7 +30,7 @@ check-uptodate: tidy fmt doc docs learn lab
 clean::
 	-rm -rf $(O)
 
-.PHONY: all check-uptodate ci test lint clean
+.PHONY: all check-uptodate ci ci-check-uptodate test lint clean
 
 # --- Build --------------------------------------------------------------------
 GO_LDFLAGS = -X main.version=$(VERSION)


### PR DESCRIPTION
Rework make targets for parallelism, so that we can run

    make ci -j $(nproc)

to speed up the CI builds locally and on GitHub Actions. This required a
little of renaming of files used for markdown generation. It also seems
that the node tool prettier and stylelint cannot be installed / run via npx
in parallel.

In a preparatory step add check-uptodate to CI in a fully separate job and
remove it from the test job, to speed up the test CI job. Parallelizing make
does not help with this as `check-uptodate` interferes with testing and needs
to be run sequentially - or on different instances in parallel.

FWIW, hyperfine tells my that my local builds sped up around 2.4 times:

    Summary
      'make ci -j 16' ran
        2.41 ± 0.04 times faster than 'make ci'
