### PR TITLE
docsite: Fix broken PDF links

### DIFF
--- a/frontend/module/spa.js
+++ b/frontend/module/spa.js
@@ -1,12 +1,18 @@
-// querySPALinks returns all relative links, and links within rootDir. Links
-// containing `:`, e.g. https://..., http://..., mailto:.... are excluded.
+// querySPALinks returns all relative links, and links within rootDir to .html
+// files, including to anchor tags within .html files, e.g.
+// sibling.html#middle.
+//
+// Links to file with other extensions and links containing `:`, e.g.
+// https://..., http://..., mailto:.... are excluded.
 export function querySPALinks(rootDir) {
   const internalLinks = document.querySelectorAll('a:not([href*=":"])')
   return [...internalLinks].filter((link) => {
     // use literal href="..." contents, not derived, absolute link.href
     const href = link.getAttribute("href")
-    // relative link or course root
-    return !href.startsWith("/") || href.startsWith(rootDir)
+    // relative link or root directory links to .html files only
+    const isRelativeLink = !href.startsWith("/") || href.startsWith(rootDir)
+    const isHTMLFile = href.split("#").shift().endsWith(".html")
+    return isRelativeLink && isHTMLFile
   })
 }
 


### PR DESCRIPTION
Fix broken PDF links which showed some really strange results on
initial click to Cheat Sheet or Evy Paper. This was caused by link
re-writing in the SPA module. All relative links are re-written on the
docs page to load the .htmlf fragment and display inside the `<main>`
area of the docs. This happens indiscriminately of file type, so the
bug was that we tried to load evy-cheat-sheet.pdff (not the double "f"
at the end). Patch it by using an additional filter condition that only
re-writes relative links that end in `.html`.

Admittedly, this is a bit of a foot-gun, I guess this can happen when
you write all your own tooling. Hopefully the more careful `.html`
file only filtering is the end of this.