### PR TITLE
evy: Improve version information

### DIFF
--- a/main-full.go
+++ b/main-full.go
@@ -36,4 +36,5 @@ var fullContent embed.FS
 func init() {
 	content = fullContent
 	contentDir = "out/embed"
+	fullBuild = true
 }


### PR DESCRIPTION
Improve version information to use debug.BuildInfo if version string is
not explicitly set by compiler flags. This should provide Version
information when installed via

	go install evylang.dev/evy@latest