### PR TITLE
make: Add govulncheck to lint-go target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,8 @@ EVY_FILES = $(shell fd --type file --extension evy)
 lint-go:
 	golangci-lint run
 	cd learn; golangci-lint run
+	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	go run golang.org/x/vuln/cmd/govulncheck@latest -C learn ./...
 
 lint-node: install-npm-deps .WAIT check-prettier check-style
 


### PR DESCRIPTION
Add govulncheck to lint-go target, provided by the Go core team. I just
did the Go developer survey and they asked about whether I know about
it and use it. I did not really know about it, but it seems knowing
about vulnerabilities early is what we want. The current result when
running the check is:

	No vulnerabilities found.

	Your code is affected by 0 vulnerabilities.
	This scan also found 0 vulnerabilities in packages you import and 3
	vulnerabilities in modules you require, but your code doesn't appear to call
	these vulnerabilities.

	Vulnerability #1: GO-2024-3107
	    Stack exhaustion in Parse in go/build/constraint
	  More info: https://pkg.go.dev/vuln/GO-2024-3107
	  Standard library
	    Found in: stdlib@go1.23
	    Fixed in: stdlib@go1.23.1

	Vulnerability #2: GO-2024-3106
	    Stack exhaustion in Decoder.Decode in encoding/gob
	  More info: https://pkg.go.dev/vuln/GO-2024-3106
	  Standard library
	    Found in: stdlib@go1.23
	    Fixed in: stdlib@go1.23.1

	Vulnerability #3: GO-2024-3105
	    Stack exhaustion in all Parse functions in go/parser
	  More info: https://pkg.go.dev/vuln/GO-2024-3105
	  Standard library
	    Found in: stdlib@go1.23
	    Fixed in: stdlib@go1.23.1