### PR TITLE
labsite: Fix link and mobile layout issues

### DIFF
--- a/frontend/lab/css/overrides.css
+++ b/frontend/lab/css/overrides.css
@@ -254,7 +254,7 @@ a.youtube {
     }
   }
   /* 1 column layout */
-  .main:has(.notes.hidden, .editorWrap.hidden) {
+  .main:has(> .notes.hidden):has(> .editor-wrap.hidden) {
     &.view-output {
       translate: 0;
     }

--- a/frontend/lab/index.html
+++ b/frontend/lab/index.html
@@ -140,7 +140,7 @@
       </header>
       <ul>
         <li><button id="sidebar-about">About Evy</button></li>
-        <li><a href="/playground" target="_blank">Playground</a></li>
+        <li><a href="/play" target="_blank">Playground</a></li>
         <li><a href="/docs" target="_blank">Docs</a></li>
         <li><a href="/discord" target="_blank">Discord</a></li>
         <li><a href="/gallery" target="_blank">Gallery</a></li>


### PR DESCRIPTION
Fix link and mobile layout issues and lab.evy.dev. The link to the playground
was incorrect in the sidebar (/playground rather than /play), now fixed.

Additionally shared links on mobile didn't work, the output display didn't show.
CSS tweaked for this too.

---

Test link:
https://lab.evy.dev/#content=H4sIAAAAAAAAAysoyswrUVDySM3JyddRcCpNV1T4MH9i94f5Pf1KXAAmQO5JHQAAAA==
vs
https://lab.evytest.dev/#content=H4sIAAAAAAAAAysoyswrUVDySM3JyddRcCpNV1T4MH9i94f5Pf1KXAAmQO5JHQAAAA==