### PR TITLE
labsite: Change book-icon to back-icon for mobile

### DIFF
--- a/frontend/css/icons.css
+++ b/frontend/css/icons.css
@@ -3,8 +3,8 @@
   SVG source files are located at /img/icon/*.svg.
   Encoding tool: https://yoksel.github.io/url-encoder/
 */
-.icon-book {
-  mask: url("data:image/svg+xml,%3Csvg fill='currentColor' stroke='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath d='M0 3.75A.75.75 0 0 1 .75 3h7.497c1.566 0 2.945.8 3.751 2.014A4.495 4.495 0 0 1 15.75 3h7.5a.75.75 0 0 1 .75.75v15.063a.752.752 0 0 1-.755.75l-7.682-.052a3 3 0 0 0-2.142.878l-.89.891a.75.75 0 0 1-1.061 0l-.902-.901a2.996 2.996 0 0 0-2.121-.879H.75a.75.75 0 0 1-.75-.75Zm12.75 15.232a4.503 4.503 0 0 1 2.823-.971l6.927.047V4.5h-6.75a3 3 0 0 0-3 3ZM11.247 7.497a3 3 0 0 0-3-2.997H1.5V18h6.947c1.018 0 2.006.346 2.803.98Z'%3E%3C/path%3E%3C/svg%3E");
+.icon-back {
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M10.78 19.03a.75.75 0 0 1-1.06 0l-6.25-6.25a.75.75 0 0 1 0-1.06l6.25-6.25a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L5.81 11.5h14.44a.75.75 0 0 1 0 1.5H5.81l4.97 4.97a.75.75 0 0 1 0 1.06Z'%3E%3C/path%3E%3C/svg%3E");
 }
 
 .icon-close {
@@ -47,7 +47,7 @@
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 142.5 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke-linecap='round' stroke-width='25' fill='none'%3E%3Cpath d='M12.5,12.5 h0' stroke='hsl(49deg 100%25 50%25) ' /%3E%3Cpath d='M50,12.5 h80' stroke='hsl(336deg 78%25 64%25)' /%3E%3Cpath d='M12.5,50 h0' stroke='hsl(7deg 66%25 56%25)' /%3E%3Cpath d='M50,50 h42.5' stroke='hsl(201deg 100%25 63%25)' /%3E%3Cpath d='M12.5,87.5 h0' stroke='hsl(150deg 50%25 47%25) ' /%3E%3Cpath d='M50,87.5 h72.5' stroke='hsl(234deg 48%25 51%25)' /%3E%3C/g%3E%3C/svg%3E");
 }
 
-.icon-book,
+.icon-back,
 .icon-chevron,
 .icon-close,
 .icon-copy,

--- a/frontend/lab/css/overrides.css
+++ b/frontend/lab/css/overrides.css
@@ -207,11 +207,6 @@ a.youtube {
   height: 1.5rem;
   color: var(--color);
 }
-
-#show-notes[disabled] {
-  cursor: none;
-  color: var(--color-dimmed);
-}
 /* --- Notes responsive tweaks ---------------------------------- */
 @media (hover: hover) {
   .notes summary,

--- a/frontend/lab/index.html
+++ b/frontend/lab/index.html
@@ -65,7 +65,7 @@
         </button>
       </div>
       <div class="right">
-        <button class="mobile icon-book" id="show-notes" disabled></button>
+        <button class="mobile icon-back hidden" id="show-notes"></button>
         <button class="desktop share" id="share">
           <div class="icon-share"></div>
           <span>Share</span>

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -240,17 +240,17 @@ async function handlePrimaryClick() {
     return
   }
   const view = getView()
-  const showNotesBtn = document.querySelector("#show-notes")
+  const showNotesBtn = !notesHidden && document.querySelector("#show-notes")
   if (view == "view-notes" && !editorHidden) {
     await slide("view-code")
-    if (showNotesBtn) showNotesBtn.disabled = false
+    if (showNotesBtn) showNotesBtn.classList.remove("hidden")
     return
   }
   if (view === "view-notes" || view === "view-code") {
     // we need to wait for the slide transition to finish otherwise
     // el.focus() in jsRead() messes up the layout
     await slide("view-output")
-    if (showNotesBtn) showNotesBtn.disabled = false
+    if (showNotesBtn) showNotesBtn.classList.remove("hidden")
     start()
     return
   }
@@ -277,7 +277,7 @@ function showNotes() {
   if (!stopped) stop()
   slide("view-notes")
   const showNotesBtn = document.querySelector("#show-notes")
-  if (showNotesBtn) showNotesBtn.disabled = true
+  if (showNotesBtn) showNotesBtn.classList.add("hidden")
 }
 
 // start calls evy wasm/go main(). It parses, formats and evaluates evy
@@ -482,7 +482,7 @@ function loadSession() {
 // Otherwise, defaults to the output view
 function resetView() {
   const showNotesBtn = document.querySelector("#show-notes")
-  if (showNotesBtn) showNotesBtn.disabled = true
+  if (showNotesBtn) showNotesBtn.classList.add("hidden")
   if (!notesHidden) {
     setView("view-notes")
   } else if (!editorHidden) {


### PR DESCRIPTION
Change book-icon to back-icon for mobile: When on mobile only one of
these three screens is showed at a time: Notes, Code, Output. Clicking
the primary button lets you move from Notes -> Code <-> Output. To get
back to the Notes we had a book icon in the top right corner which
caused confusion. The back button is hopefully more logical and also
aligns with the whole screen swipe to to left.