### PR TITLE
labsite: Tweak UX

### DIFF
--- a/frontend/lab/index.html
+++ b/frontend/lab/index.html
@@ -76,17 +76,18 @@
     <div class="max-width-wrapper">
       <main class="main view-notes">
         <div class="notes" id="notes">
-          <h1>👋 Welcome!</h1>
-          <p>Programming is for everyone!</p>
+          <h1>👋 Welcome</h1>
           <p>
-            Check out the program on the right 👉.<br />
-            Hit <strong>Run</strong> to see the result!
+            Programming is for everyone – no special skills required, just curiosity and a
+            willingness to learn.
           </p>
-          <p>Can you change the program to print <strong>your name</strong>?</p>
-          <p>
-            Check out the docs for more info on the
-            <a href="/docs/builtins.html#print" target="_blank"><code>print</code> command</a>.
-          </p>
+          <p>Let's dive in! Hit <strong>Run</strong> on the right 👉.</p>
+          <p>That's what we'll build up to in this first lab—a bit of a whirlwind tour.</p>
+          <h2>🚀 Let's get started!</h2>
+          <p>There is also a step-by-step walk through video guide 🎬:</p>
+          <a href="https://youtu.be/FBqyiU4iZNY" target="_blank" class="youtube">
+            <img src="samples/intro/img/youtube.jpeg" alt="Screenshot of YouTube walk through" />
+          </a>
         </div>
         <div class="editor-wrap noscrollbar">
           <div class="editor language-evy" style="padding-left: calc(2ch + 1.5rem)">

--- a/frontend/lab/index.html
+++ b/frontend/lab/index.html
@@ -40,10 +40,8 @@
   <body>
     <header class="topnav">
       <div class="left">
-        <button id="hamburger">
-          <div class="mobile logo-small"></div>
-          <div class="desktop icon-hamburger"></div>
-        </button>
+        <button id="hamburger" class="icon-hamburger"></button>
+        <button id="show-notes" class="mobile icon-back hidden"></button>
         <a href="/" class="desktop">
           <img alt="Evy logo" class="logo" />
         </a>
@@ -65,11 +63,11 @@
         </button>
       </div>
       <div class="right">
-        <button class="mobile icon-back hidden" id="show-notes"></button>
         <button class="desktop share" id="share">
           <div class="icon-share"></div>
           <span>Share</span>
         </button>
+        <a href="/" class="mobile logo-small"></a>
       </div>
     </header>
 

--- a/frontend/play/css/index.css
+++ b/frontend/play/css/index.css
@@ -81,16 +81,13 @@ button.arrow {
   height: 28px;
   width: 28px;
 }
-button.arrow:hover {
+button.arrow:not(:disabled):hover {
   background: var(--primary-button-color);
   color: var(--color-accent-hover);
 }
-button.arrow.hidden {
-  display: block;
-  color: transparent;
-  background: transparent;
-  border-color: transparent;
-  pointer-events: none;
+button.arrow:disabled {
+  color: var(--border-color);
+  cursor: default;
 }
 button.arrow svg {
   margin-left: auto;

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -1141,14 +1141,14 @@ function updateSampleTitle() {
   titleDiv.textContent = sample?.title || sampleData.defaultTitle
   if (!sample || sample.unlisted) {
     indexDiv.classList.add("hidden")
-    prevButton.classList.add("hidden")
-    nextButton.classList.add("hidden")
+    prevButton.disabled = true
+    nextButton.disabled = true
     return
   }
   indexDiv.textContent = `${sample.sectionIndex}/${sample.sectionTotal}`
   indexDiv.classList.remove("hidden")
-  sample.previous ? prevButton.classList.remove("hidden") : prevButton.classList.add("hidden")
-  sample.next ? nextButton.classList.remove("hidden") : nextButton.classList.add("hidden")
+  prevButton.disabled = !sample.previous
+  nextButton.disabled = !sample.next
 }
 
 // --- UI: sidebar --------------------------------------------

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -240,17 +240,16 @@ async function handlePrimaryClick() {
     return
   }
   const view = getView()
-  const showNotesBtn = !notesHidden && document.querySelector("#show-notes")
   if (view == "view-notes" && !editorHidden) {
     await slide("view-code")
-    if (showNotesBtn) showNotesBtn.classList.remove("hidden")
+    toggleNotesButtonVisiblity(true)
     return
   }
   if (view === "view-notes" || view === "view-code") {
     // we need to wait for the slide transition to finish otherwise
     // el.focus() in jsRead() messes up the layout
     await slide("view-output")
-    if (showNotesBtn) showNotesBtn.classList.remove("hidden")
+    toggleNotesButtonVisiblity(true)
     start()
     return
   }
@@ -276,8 +275,20 @@ function showNotes() {
   if (notesHidden) return
   if (!stopped) stop()
   slide("view-notes")
+  toggleNotesButtonVisiblity(false)
+}
+
+function toggleNotesButtonVisiblity(show) {
   const showNotesBtn = document.querySelector("#show-notes")
-  if (showNotesBtn) showNotesBtn.classList.add("hidden")
+  if (!showNotesBtn) return
+  const hamburgerBtn = document.querySelector("#hamburger")
+  if (!notesHidden && show) {
+    showNotesBtn.classList.remove("hidden")
+    hamburgerBtn.classList.add("hidden")
+    return
+  }
+  showNotesBtn.classList.add("hidden")
+  hamburgerBtn.classList.remove("hidden")
 }
 
 // start calls evy wasm/go main(). It parses, formats and evaluates evy
@@ -483,8 +494,7 @@ function loadSession() {
 async function resetView() {
   const mainClassList = document.querySelector("main.main").classList
   mainClassList.add("no-translate-transition")
-  const showNotesBtn = document.querySelector("#show-notes")
-  if (showNotesBtn) showNotesBtn.classList.add("hidden")
+  toggleNotesButtonVisiblity(false)
   if (!notesHidden) {
     setView("view-notes")
   } else if (!editorHidden) {

--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -439,9 +439,16 @@ async function fetchSamples() {
 }
 
 function ctrlEnterListener(e) {
-  if ((e.metaKey || e.ctrlKey) && event.key === "Enter") {
+  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
     document.querySelector(".editor textarea").blur()
     handleRun()
+  }
+}
+
+function escListener(e) {
+  if (e.key === "Escape") {
+    hideModal()
+    hideSidebar()
   }
 }
 
@@ -1104,6 +1111,7 @@ function initModal() {
 function hideModal() {
   const el = document.querySelector("#modal")
   el.classList.add("hidden")
+  document.removeEventListener("keydown", escListener)
 }
 
 function showSamples() {
@@ -1113,6 +1121,7 @@ function showSamples() {
   modal.classList.remove("hidden")
   samples.querySelectorAll("a").forEach((a) => a.classList.remove("highlight"))
   samples.querySelector(`a[href$="#${currentSample}"]`)?.classList.add("highlight")
+  document.addEventListener("keydown", escListener)
 }
 
 function showPreviousSample() {
@@ -1162,11 +1171,13 @@ function showSidebar() {
   document.querySelector(".editor textarea").style.pointerEvents = "none"
   document.querySelector("#sidebar").classList.remove("hidden")
   document.addEventListener("click", handleOutsideSidebarClick)
+  document.addEventListener("keydown", escListener)
 }
 function hideSidebar() {
   document.querySelector(".editor textarea").style.pointerEvents = ""
   document.querySelector("#sidebar").classList.add("hidden")
   document.removeEventListener("click", handleOutsideSidebarClick)
+  document.removeEventListener("keydown", escListener)
 }
 function handleOutsideSidebarClick(e) {
   const sidebar = document.querySelector("#sidebar")


### PR DESCRIPTION
Tweak UX for labsite, no major changes

- Use same placeholder content in index.html as in samples/intro/welcome.md
- Always show next/previous sample selection arrows, only disable them
  (Jason's suggestion for more stable UI)
- Move back-to-notes button to the left (Jason's suggestion for more obvious UI)
- Make `esc` close sidebar or sample selection modal if open