### PR TITLE
all: Rename "runtime" to "platform"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Use [Homebrew] to install `evy`.
 The Evy interpreter is written in [Go] and built using the Go and
 [TinyGo] compilers. TinyGo targets [WebAssembly], which allows Evy
 source code to be parsed and run in a web browser. The browser
-runtime is written in plain JavaScript without the use of frameworks.
+platform is written in plain JavaScript without the use of frameworks.
 
 To build the Evy source code, [clone] this repository and
 [activate Hermit] in your terminal. Then, build the sources with

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -433,7 +433,7 @@ with `del` while iterating with a `for … range` loop.
 `sleep` can be used to create delays in Evy programs. For example, you
 could use sleep to create a countdown timer.
 
-In the [browser runtime](spec.md#runtimes) `sleep` pauses a minimum of 1
+In the [browser platform](spec.md#platforms) `sleep` pauses a minimum of 1
 millisecond.
 
 #### Example

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -48,7 +48,7 @@ To get an intuitive understanding of Evy, you can either look at its
     [Assignability of variable values](#assignability-of-variable-values), [Assignability of constant values](#assignability-of-constant-values), [Assignability of empty composite literals](#assignability-of-empty-composite-literals)
 24. [**Run-time Panics and Recoverable Errors**](#run-time-panics-and-recoverable-errors)
 25. [**Execution Model and Event Handlers**](#execution-model-and-event-handlers)
-26. [**Runtimes**](#runtimes)
+26. [**Platforms**](#platforms)
 
 <!-- genend:toc -->
 
@@ -1490,15 +1490,16 @@ only some parameters are needed, use the anonymous `_` parameter.
 For more information on individual event handlers, see the
 [built-in documentation](builtins.md#event-handlers).
 
-## Runtimes
+## Platforms
 
-Evy has two runtimes: the **terminal runtime** and the **browser runtime**.
+Evy has two platforms: the **terminal platform** and the **browser
+platform**.
 
-The browser runtime can be tried at [play.evy.dev]. It fully
+The browser platform can be tried at [play.evy.dev]. It fully
 supports all built-in functions and event handlers as described in the
 [built-in documentation](builtin.md).
 
-To use the terminal runtime, first install Evy and then run
+To use the terminal platform, first install Evy and then run
 
     evy run FILE.evy
 
@@ -1509,6 +1510,6 @@ with
     evy fmt FILE.evy
 
 For more details, run `evy run --help` or `evy fmt --help`. The terminal
-runtime does not support event handlers or graphics functions.
+platform does not support event handlers or graphics functions.
 
 [play.evy.dev]: https://play.evy.dev

--- a/frontend/docs/builtins.html
+++ b/frontend/docs/builtins.html
@@ -513,7 +513,7 @@
                   >Execution Model and Event Handlers</a
                 >
               </li>
-              <li><a href="spec.html#runtimes">Runtimes</a></li>
+              <li><a href="spec.html#platforms">Platforms</a></li>
             </ul>
           </li>
           <li>
@@ -974,7 +974,7 @@ print map
           use sleep to create a countdown timer.
         </p>
         <p>
-          In the <a href="spec.html#runtimes">browser runtime</a> <code>sleep</code> pauses a
+          In the <a href="spec.html#platforms">browser platform</a> <code>sleep</code> pauses a
           minimum of 1 millisecond.
         </p>
         <h4>Example</h4>

--- a/frontend/docs/builtins.htmlf
+++ b/frontend/docs/builtins.htmlf
@@ -398,7 +398,7 @@ print map
   to create a countdown timer.
 </p>
 <p>
-  In the <a href="spec.html#runtimes">browser runtime</a> <code>sleep</code> pauses a minimum of 1
+  In the <a href="spec.html#platforms">browser platform</a> <code>sleep</code> pauses a minimum of 1
   millisecond.
 </p>
 <h4>Example</h4>

--- a/frontend/docs/index.html
+++ b/frontend/docs/index.html
@@ -513,7 +513,7 @@
                   >Execution Model and Event Handlers</a
                 >
               </li>
-              <li><a href="spec.html#runtimes">Runtimes</a></li>
+              <li><a href="spec.html#platforms">Platforms</a></li>
             </ul>
           </li>
           <li>

--- a/frontend/docs/spec.html
+++ b/frontend/docs/spec.html
@@ -513,7 +513,7 @@
                   >Execution Model and Event Handlers</a
                 >
               </li>
-              <li><a href="spec.html#runtimes">Runtimes</a></li>
+              <li><a href="spec.html#platforms">Platforms</a></li>
             </ul>
           </li>
           <li>
@@ -2138,17 +2138,17 @@ num
           For more information on individual event handlers, see the
           <a href="builtins.html#event-handlers">built-in documentation</a>.
         </p>
-        <h2><a id="runtimes" href="#runtimes" class="anchor">#</a>Runtimes</h2>
+        <h2><a id="platforms" href="#platforms" class="anchor">#</a>Platforms</h2>
         <p>
-          Evy has two runtimes: the <strong>terminal runtime</strong> and the
-          <strong>browser runtime</strong>.
+          Evy has two platforms: the <strong>terminal platform</strong> and the
+          <strong>browser platform</strong>.
         </p>
         <p>
-          The browser runtime can be tried at <a href="/play">play.evy.dev</a>. It fully supports
+          The browser platform can be tried at <a href="/play">play.evy.dev</a>. It fully supports
           all built-in functions and event handlers as described in the
           <a href="builtin.html">built-in documentation</a>.
         </p>
-        <p>To use the terminal runtime, first install Evy and then run</p>
+        <p>To use the terminal platform, first install Evy and then run</p>
         <pre><code>evy run FILE.evy
 </code></pre>
         <p>
@@ -2159,7 +2159,7 @@ num
 </code></pre>
         <p>
           For more details, run <code>evy run --help</code> or <code>evy fmt --help</code>. The
-          terminal runtime does not support event handlers or graphics functions.
+          terminal platform does not support event handlers or graphics functions.
         </p>
       </div>
     </main>

--- a/frontend/docs/spec.htmlf
+++ b/frontend/docs/spec.htmlf
@@ -1490,17 +1490,17 @@ num
   For more information on individual event handlers, see the
   <a href="builtins.html#event-handlers">built-in documentation</a>.
 </p>
-<h2><a id="runtimes" href="#runtimes" class="anchor">#</a>Runtimes</h2>
+<h2><a id="platforms" href="#platforms" class="anchor">#</a>Platforms</h2>
 <p>
-  Evy has two runtimes: the <strong>terminal runtime</strong> and the
-  <strong>browser runtime</strong>.
+  Evy has two platforms: the <strong>terminal platform</strong> and the
+  <strong>browser platform</strong>.
 </p>
 <p>
-  The browser runtime can be tried at <a href="/play">play.evy.dev</a>. It fully supports all
+  The browser platform can be tried at <a href="/play">play.evy.dev</a>. It fully supports all
   built-in functions and event handlers as described in the
   <a href="builtin.html">built-in documentation</a>.
 </p>
-<p>To use the terminal runtime, first install Evy and then run</p>
+<p>To use the terminal platform, first install Evy and then run</p>
 <pre><code>evy run FILE.evy
 </code></pre>
 <p>
@@ -1511,5 +1511,5 @@ num
 </code></pre>
 <p>
   For more details, run <code>evy run --help</code> or <code>evy fmt --help</code>. The terminal
-  runtime does not support event handlers or graphics functions.
+  platform does not support event handlers or graphics functions.
 </p>

--- a/frontend/docs/syntax-by-example.html
+++ b/frontend/docs/syntax-by-example.html
@@ -513,7 +513,7 @@
                   >Execution Model and Event Handlers</a
                 >
               </li>
-              <li><a href="spec.html#runtimes">Runtimes</a></li>
+              <li><a href="spec.html#platforms">Platforms</a></li>
             </ul>
           </li>
           <li>

--- a/frontend/docs/talks-and-papers.html
+++ b/frontend/docs/talks-and-papers.html
@@ -513,7 +513,7 @@
                   >Execution Model and Event Handlers</a
                 >
               </li>
-              <li><a href="spec.html#runtimes">Runtimes</a></li>
+              <li><a href="spec.html#platforms">Platforms</a></li>
             </ul>
           </li>
           <li>

--- a/frontend/docs/usage.html
+++ b/frontend/docs/usage.html
@@ -513,7 +513,7 @@
                   >Execution Model and Event Handlers</a
                 >
               </li>
-              <li><a href="spec.html#runtimes">Runtimes</a></li>
+              <li><a href="spec.html#platforms">Platforms</a></li>
             </ul>
           </li>
           <li>

--- a/learn/pkg/learn/markdown.go
+++ b/learn/pkg/learn/markdown.go
@@ -152,7 +152,7 @@ func printAlert(quote *markdown.Quote, buf *bytes.Buffer, alertType string) {
 	buf.WriteString(`<svg viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="`)
 	buf.WriteString(alertIconPath[alertType])
 	buf.WriteString(`"></path></svg>`)
-	buf.WriteString(strings.Title(alertType)) //nolint: staticcheck // we can savely use it here as we know all strings we want to use and have no punctuation.
+	buf.WriteString(strings.Title(alertType)) //nolint:staticcheck // we can safely use it here as we know all strings we want to use and have no punctuation.
 	buf.WriteString(`</p>`)
 	for _, block := range quote.Blocks {
 		buf.WriteString(markdown.ToHTML(block))

--- a/learn/pkg/learn/renderer.go
+++ b/learn/pkg/learn/renderer.go
@@ -348,7 +348,7 @@ func runEvy(source string, t ResultType) string {
 		cli.WithCls(textWriter.Reset),
 		cli.WithSVG("", "", "" /* root style, width, height */),
 	}
-	rt := cli.NewRuntime(opts...)
+	rt := cli.NewPlatform(opts...)
 	eval := evaluator.NewEvaluator(rt)
 	err := eval.Run(source)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -185,7 +185,7 @@ func (c *runCmd) Run() error {
 	if err != nil {
 		return err
 	}
-	rt := cli.NewRuntime(c.runtimeOptions()...)
+	rt := cli.NewPlatform(c.platformOptions()...)
 	if c.RandSeed != 0 {
 		evaluator.RandSource = rand.New(rand.NewSource(c.RandSeed)) //nolint:gosec // not for security
 	}
@@ -221,7 +221,7 @@ func (c *runCmd) fileBytes() ([]byte, error) {
 	return b, nil
 }
 
-func (c *runCmd) runtimeOptions() []cli.Option {
+func (c *runCmd) platformOptions() []cli.Option {
 	opts := []cli.Option{cli.WithSkipSleep(c.SkipSleep)}
 	if c.SVGOut != "" {
 		opts = append(opts, cli.WithSVG(c.SVGStyle, c.SVGWidth, c.SVGHeight))
@@ -229,7 +229,7 @@ func (c *runCmd) runtimeOptions() []cli.Option {
 	return opts
 }
 
-func (c *runCmd) writeSVG(rt *cli.Runtime) error {
+func (c *runCmd) writeSVG(rt *cli.Platform) error {
 	if c.SVGOut == "" {
 		return nil
 	}

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -1,6 +1,6 @@
 //go:build !tinygo
 
-// Package cli provides an Evy runtime to for Evy CLI execution in terminal.
+// Package cli provides an Evy platform to for Evy CLI execution in terminal.
 package cli
 
 import (
@@ -16,58 +16,58 @@ import (
 	"evylang.dev/evy/pkg/evaluator"
 )
 
-// Runtime implements evaluator.Runtime.
-type Runtime struct {
-	evaluator.GraphicsRuntime
+// Platform implements evaluator.Platform.
+type Platform struct {
+	evaluator.GraphicsPlatform
 	reader    *bufio.Reader
 	writer    io.Writer
 	clsFn     func()
 	SkipSleep bool
 }
 
-// Option is used on Runtime creation to set optional parameters.
-type Option func(*Runtime)
+// Option is used on Platform creation to set optional parameters.
+type Option func(*Platform)
 
-// WithSkipSleep sets the SkipSleep field Runtime and is intended to be used
-// with NewRuntime.
+// WithSkipSleep sets the SkipSleep field Platform and is intended to be used
+// with NewPlatform.
 func WithSkipSleep(skipSleep bool) Option {
-	return func(rt *Runtime) {
+	return func(rt *Platform) {
 		rt.SkipSleep = skipSleep
 	}
 }
 
-// WithSVG sets up an SVG graphics runtime and writes its output to the
+// WithSVG sets up an SVG graphics platform and writes its output to the
 // given writer.
 func WithSVG(svgStyle string, svgWidth string, svgHeight string) Option {
-	return func(rt *Runtime) {
-		svgRT := svg.NewGraphicsRuntime()
+	return func(rt *Platform) {
+		svgRT := svg.NewGraphicsPlatform()
 		svgRT.SVG.Style = svgStyle
 		svgRT.SVG.Width = svgWidth
 		svgRT.SVG.Height = svgHeight
-		rt.GraphicsRuntime = svgRT
+		rt.GraphicsPlatform = svgRT
 	}
 }
 
 // WithOutputWriter sets the text output writer, which defaults to os.Stdout.
 func WithOutputWriter(w io.Writer) Option {
-	return func(rt *Runtime) {
+	return func(rt *Platform) {
 		rt.writer = w
 	}
 }
 
 // WithCls sets the action to be done for `cls` command.
 func WithCls(clsFn func()) Option {
-	return func(rt *Runtime) {
+	return func(rt *Platform) {
 		rt.clsFn = clsFn
 	}
 }
 
-// NewRuntime returns an initialized cli runtime.
-func NewRuntime(options ...Option) *Runtime {
-	rt := &Runtime{
-		reader:          bufio.NewReader(os.Stdin),
-		writer:          os.Stdout,
-		GraphicsRuntime: &evaluator.UnimplementedRuntime{},
+// NewPlatform returns an initialized cli platform.
+func NewPlatform(options ...Option) *Platform {
+	rt := &Platform{
+		reader:           bufio.NewReader(os.Stdin),
+		writer:           os.Stdout,
+		GraphicsPlatform: &evaluator.UnimplementedPlatform{},
 	}
 	for _, opt := range options {
 		opt(rt)
@@ -76,12 +76,12 @@ func NewRuntime(options ...Option) *Runtime {
 }
 
 // Print prints s to stdout.
-func (rt *Runtime) Print(s string) {
+func (rt *Platform) Print(s string) {
 	fmt.Fprint(rt.writer, s) //nolint:errcheck // no need to check for stdout
 }
 
 // Cls clears the screen.
-func (rt *Runtime) Cls() {
+func (rt *Platform) Cls() {
 	if rt.clsFn != nil {
 		rt.clsFn()
 		return
@@ -97,7 +97,7 @@ func (rt *Runtime) Cls() {
 }
 
 // Read reads a line of input from stdin and strips trailing newline.
-func (rt *Runtime) Read() string {
+func (rt *Platform) Read() string {
 	s, err := rt.reader.ReadString('\n')
 	if err != nil {
 		panic(err)
@@ -106,7 +106,7 @@ func (rt *Runtime) Read() string {
 }
 
 // Sleep sleeps for dur. If the --skip-sleep flag is used, it does nothing.
-func (rt *Runtime) Sleep(dur time.Duration) {
+func (rt *Platform) Sleep(dur time.Duration) {
 	if !rt.SkipSleep {
 		time.Sleep(dur)
 	}
@@ -115,11 +115,11 @@ func (rt *Runtime) Sleep(dur time.Duration) {
 // Yielder returns a no-op yielder for CLI evy as it is not needed. By
 // contrast, browser Evy needs to explicitly hand over control to JS
 // host with Yielder.
-func (*Runtime) Yielder() evaluator.Yielder { return nil }
+func (*Platform) Yielder() evaluator.Yielder { return nil }
 
 // WriteSVG writes the graphics output in SVG format to the writer set with
 // option WithSVGWriter.
-func (rt *Runtime) WriteSVG(w io.Writer) error {
-	graphicsRT := rt.GraphicsRuntime.(*svg.GraphicsRuntime)
+func (rt *Platform) WriteSVG(w io.Writer) error {
+	graphicsRT := rt.GraphicsPlatform.(*svg.GraphicsPlatform)
 	return graphicsRT.WriteSVG(w)
 }

--- a/pkg/cli/runtime_test.go
+++ b/pkg/cli/runtime_test.go
@@ -22,7 +22,7 @@ func TestGraphics(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			style := "border: 1px solid red; width: 400px; height: 400px"
 			svgWriter := &bytes.Buffer{}
-			rt := NewRuntime(WithSVG(style, "", ""), WithSkipSleep(true))
+			rt := NewPlatform(WithSVG(style, "", ""), WithSkipSleep(true))
 
 			eval := evaluator.NewEvaluator(rt)
 			evyFilename := strings.TrimSuffix(file, filepath.Ext(file)) + ".evy"
@@ -45,10 +45,10 @@ func TestGraphics(t *testing.T) {
 func TestPrintRead(t *testing.T) {
 	readBuffer := &bytes.Buffer{}
 	writeBuffer := &bytes.Buffer{}
-	rt := &Runtime{
-		reader:          bufio.NewReader(readBuffer),
-		writer:          writeBuffer,
-		GraphicsRuntime: &evaluator.UnimplementedRuntime{},
+	rt := &Platform{
+		reader:           bufio.NewReader(readBuffer),
+		writer:           writeBuffer,
+		GraphicsPlatform: &evaluator.UnimplementedPlatform{},
 	}
 	readBuffer.WriteString("Hello world\n")
 	s := rt.Read()

--- a/pkg/cli/svg/runtime.go
+++ b/pkg/cli/svg/runtime.go
@@ -42,8 +42,8 @@ var (
 	}
 )
 
-// GraphicsRuntime implements evaluator.GraphcisRuntime for SVG output.
-type GraphicsRuntime struct {
+// GraphicsPlatform implements evaluator.GraphicsPlatform for SVG output.
+type GraphicsPlatform struct {
 	x float64 // current cursor position
 	y float64 // current cursor position
 
@@ -53,11 +53,11 @@ type GraphicsRuntime struct {
 	elements []any
 }
 
-// NewGraphicsRuntime returns a new GraphicsRuntime with default attributes
+// NewGraphicsPlatform returns a new GraphicsPlatform with default attributes
 // set suitable for Evy drawing output.
-func NewGraphicsRuntime() *GraphicsRuntime {
+func NewGraphicsPlatform() *GraphicsPlatform {
 	viewBox := fmt.Sprintf("0 0 %d %d", evyWidth*scaleFactor, evyHeight*scaleFactor)
-	rt := &GraphicsRuntime{
+	rt := &GraphicsPlatform{
 		attr:     defaultAttr,
 		textAttr: defaultTextAttr,
 		SVG: SVG{
@@ -78,22 +78,22 @@ func NewGraphicsRuntime() *GraphicsRuntime {
 	return rt
 }
 
-func (rt *GraphicsRuntime) transformX(x float64) float64 {
+func (rt *GraphicsPlatform) transformX(x float64) float64 {
 	return rt.scale(x)
 }
 
 // transformY flips the y axis. Evy operates in a Cartesian number plain,
 // SVG has an inverted y-axis like most computer graphics. We cannot
 // directly use SVG `transform` as it would turn all text upside down.
-func (rt *GraphicsRuntime) transformY(y float64) float64 {
+func (rt *GraphicsPlatform) transformY(y float64) float64 {
 	return rt.scale(evyHeight) - rt.scale(y)
 }
 
-func (rt *GraphicsRuntime) scale(s float64) float64 {
+func (rt *GraphicsPlatform) scale(s float64) float64 {
 	return scaleFactor * s
 }
 
-func (rt *GraphicsRuntime) nonDefaultAttr() Attr {
+func (rt *GraphicsPlatform) nonDefaultAttr() Attr {
 	attr := rt.attr
 	if rt.attr.Fill == defaultAttr.Fill {
 		attr.Fill = ""
@@ -113,7 +113,7 @@ func (rt *GraphicsRuntime) nonDefaultAttr() Attr {
 	return attr
 }
 
-func (rt *GraphicsRuntime) nonDefaultTextAttr() TextAttr {
+func (rt *GraphicsPlatform) nonDefaultTextAttr() TextAttr {
 	textAttr := rt.textAttr
 	if rt.textAttr.TextAnchor == defaultTextAttr.TextAnchor {
 		textAttr.TextAnchor = ""
@@ -146,7 +146,7 @@ func (rt *GraphicsRuntime) nonDefaultTextAttr() TextAttr {
 // If there are multiple collected elements, they are wrapped in a group and
 // the styles are applied to the group element. If there is only one element,
 // the styles are applied directly to that element.
-func (rt *GraphicsRuntime) Push() {
+func (rt *GraphicsPlatform) Push() {
 	if len(rt.elements) == 0 {
 		return
 	}
@@ -168,13 +168,13 @@ func (rt *GraphicsRuntime) Push() {
 }
 
 // Move sets the current cursor position.
-func (rt *GraphicsRuntime) Move(x, y float64) {
+func (rt *GraphicsPlatform) Move(x, y float64) {
 	rt.x = rt.transformX(x)
 	rt.y = rt.transformY(y)
 }
 
 // Line draws a line from the current cursor position to the given x, y.
-func (rt *GraphicsRuntime) Line(x, y float64) {
+func (rt *GraphicsPlatform) Line(x, y float64) {
 	x = rt.transformX(x)
 	y = rt.transformY(y)
 	line := Line{X1: rt.x, Y1: rt.y, X2: x, Y2: y}
@@ -185,7 +185,7 @@ func (rt *GraphicsRuntime) Line(x, y float64) {
 
 // Rect draws a rectangle from the current cursor position for given width and
 // height. Negative values are permitted.
-func (rt *GraphicsRuntime) Rect(width, height float64) {
+func (rt *GraphicsPlatform) Rect(width, height float64) {
 	x := rt.x
 	y := rt.y
 	width = rt.scale(width)
@@ -202,7 +202,7 @@ func (rt *GraphicsRuntime) Rect(width, height float64) {
 }
 
 // Circle draws a circle at the current cursor position with the given radius.
-func (rt *GraphicsRuntime) Circle(radius float64) {
+func (rt *GraphicsPlatform) Circle(radius float64) {
 	radius = rt.scale(radius)
 	circle := Circle{CX: rt.x, CY: rt.y, R: radius}
 	rt.elements = append(rt.elements, &circle)
@@ -211,7 +211,7 @@ func (rt *GraphicsRuntime) Circle(radius float64) {
 // Clear sets the background color of the SVG canvas. We cannot simply remove
 // all previous SVG elements as the background color could be
 // semi-transparent overlaying previous elements.
-func (rt *GraphicsRuntime) Clear(color string) {
+func (rt *GraphicsPlatform) Clear(color string) {
 	if color == "" {
 		color = "white"
 	}
@@ -229,7 +229,7 @@ func (rt *GraphicsRuntime) Clear(color string) {
 }
 
 // Poly draws a polygon or polyline with the given vertices.
-func (rt *GraphicsRuntime) Poly(vertices [][]float64) {
+func (rt *GraphicsPlatform) Poly(vertices [][]float64) {
 	points := make([]string, len(vertices))
 	for i, v := range vertices {
 		x := rt.transformX(v[0])
@@ -244,7 +244,7 @@ func (rt *GraphicsRuntime) Poly(vertices [][]float64) {
 
 // Ellipse draws an ellipse at the given x, y with the given radii.
 // Note: startAngle, endAngle are not implemented.
-func (rt *GraphicsRuntime) Ellipse(x, y, radiusX, radiusY, rotation, _, _ float64) {
+func (rt *GraphicsPlatform) Ellipse(x, y, radiusX, radiusY, rotation, _, _ float64) {
 	// TODO: implement the last two parameters: startAngle, endAngle.
 	x = rt.transformX(x)
 	y = rt.transformX(y)
@@ -263,7 +263,7 @@ func (rt *GraphicsRuntime) Ellipse(x, y, radiusX, radiusY, rotation, _, _ float6
 }
 
 // Text draws a text at the current cursor position.
-func (rt *GraphicsRuntime) Text(str string) {
+func (rt *GraphicsPlatform) Text(str string) {
 	text := Text{
 		X:     rt.x,
 		Y:     rt.y,
@@ -276,7 +276,7 @@ func (rt *GraphicsRuntime) Text(str string) {
 }
 
 // Gridn draws a grid with the given unit and color.
-func (rt *GraphicsRuntime) Gridn(unit float64, color string) {
+func (rt *GraphicsPlatform) Gridn(unit float64, color string) {
 	unit = rt.transformX(unit)
 	group := Group{Attr: Attr{Stroke: color}}
 	lineCnt := 0
@@ -297,33 +297,33 @@ func (rt *GraphicsRuntime) Gridn(unit float64, color string) {
 }
 
 // Width sets the stroke width.
-func (rt *GraphicsRuntime) Width(w float64) {
+func (rt *GraphicsPlatform) Width(w float64) {
 	rt.Push()
 	strokeWidth := rt.scale(w)
 	rt.attr.StrokeWidth = &strokeWidth
 }
 
 // Color sets the stroke and fill color.
-func (rt *GraphicsRuntime) Color(color string) {
+func (rt *GraphicsPlatform) Color(color string) {
 	rt.Push()
 	rt.attr.Stroke = color
 	rt.attr.Fill = color
 }
 
 // Stroke sets the stroke color only.
-func (rt *GraphicsRuntime) Stroke(str string) {
+func (rt *GraphicsPlatform) Stroke(str string) {
 	rt.Push()
 	rt.attr.Stroke = str
 }
 
 // Fill sets the fill color only.
-func (rt *GraphicsRuntime) Fill(str string) {
+func (rt *GraphicsPlatform) Fill(str string) {
 	rt.Push()
 	rt.attr.Fill = str
 }
 
 // Dash sets the stroke dash array.
-func (rt *GraphicsRuntime) Dash(segments []float64) {
+func (rt *GraphicsPlatform) Dash(segments []float64) {
 	rt.Push()
 	segmentStrings := make([]string, len(segments))
 	for i, segment := range segments {
@@ -333,7 +333,7 @@ func (rt *GraphicsRuntime) Dash(segments []float64) {
 }
 
 // Linecap sets the stroke linecap style.
-func (rt *GraphicsRuntime) Linecap(str string) {
+func (rt *GraphicsPlatform) Linecap(str string) {
 	rt.Push()
 	rt.attr.StrokeLinecap = str
 }
@@ -348,7 +348,7 @@ func (rt *GraphicsRuntime) Linecap(str string) {
 //	"baseline": "top", // | "middle" | "bottom" | "alphabetic"
 //	"align": "left", // | "center" | "right"
 //	"letterspacing": 1 // number, see size. extra inter-character space. negative allowed.
-func (rt *GraphicsRuntime) Font(props map[string]any) {
+func (rt *GraphicsPlatform) Font(props map[string]any) {
 	rt.Push()
 
 	if family, ok := props["family"].(string); ok {
@@ -393,7 +393,7 @@ func (rt *GraphicsRuntime) Font(props map[string]any) {
 }
 
 // WriteSVG writes the SVG output to the given writer.
-func (rt *GraphicsRuntime) WriteSVG(w io.Writer) error {
+func (rt *GraphicsPlatform) WriteSVG(w io.Writer) error {
 	rt.Push()
 	encoder := xml.NewEncoder(w)
 	encoder.Indent("", "  ")

--- a/pkg/cli/svg/runtime_test.go
+++ b/pkg/cli/svg/runtime_test.go
@@ -10,8 +10,8 @@ import (
 	"evylang.dev/evy/pkg/assert"
 )
 
-func TestRuntimeCircleRect(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformCircleRect(t *testing.T) {
+	rt := newTestPlatform()
 	rt.Move(20, 0)
 	rt.Rect(10, 30)
 	rt.Rect(20, 5)
@@ -22,22 +22,22 @@ func TestRuntimeCircleRect(t *testing.T) {
 	assertSVG(t, "testdata/circle-rect.svg", rt)
 }
 
-func TestRuntimeQuarterCircle(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformQuarterCircle(t *testing.T) {
+	rt := newTestPlatform()
 	rt.Circle(100) // should be centered at 0 0
 	assertSVG(t, "testdata/quarter-circle.svg", rt)
 }
 
-func TestRuntimeEllipse(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformEllipse(t *testing.T) {
+	rt := newTestPlatform()
 	rt.Ellipse(50, 85, 30, 10, 0, 0, 0)
 	rt.Ellipse(50, 55, 30, 10, 30, 0, 0)
 
 	assertSVG(t, "testdata/ellipse.svg", rt)
 }
 
-func TestRuntimeFill(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformFill(t *testing.T) {
+	rt := newTestPlatform()
 	rt.Width(2)
 	rt.Move(10, 65)
 	rt.Color("red")
@@ -85,8 +85,8 @@ func TestRuntimeFill(t *testing.T) {
 	assertSVG(t, "testdata/fill.svg", rt)
 }
 
-func TestRuntimeLines(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformLines(t *testing.T) {
+	rt := newTestPlatform()
 	for i := float64(0); i < 100; i += 3 {
 		rt.Move(i, 0)
 		rt.Line(100, i)
@@ -94,8 +94,8 @@ func TestRuntimeLines(t *testing.T) {
 	assertSVG(t, "testdata/lines.svg", rt)
 }
 
-func TestRuntimeLinestyle(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformLinestyle(t *testing.T) {
+	rt := newTestPlatform()
 
 	rt.Width(3)
 	rt.Linecap("round")
@@ -122,8 +122,8 @@ func TestRuntimeLinestyle(t *testing.T) {
 	assertSVG(t, "testdata/linestyle.svg", rt)
 }
 
-func TestRuntimePoly(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformPoly(t *testing.T) {
+	rt := newTestPlatform()
 	rt.Width(1)
 	rt.Color("red")
 	rt.Fill("none")
@@ -134,8 +134,8 @@ func TestRuntimePoly(t *testing.T) {
 	assertSVG(t, "testdata/poly.svg", rt)
 }
 
-func TestRuntimeText(t *testing.T) {
-	rt := newTestRuntime()
+func TestPlatformText(t *testing.T) {
+	rt := newTestPlatform()
 
 	rt.Move(10, 85)
 	rt.Text("“Time is an illusion.")
@@ -199,7 +199,7 @@ func TestRuntimeText(t *testing.T) {
 	assertSVG(t, "testdata/text.svg", rt)
 }
 
-func assertSVG(t *testing.T, wantFilename string, gotRT *GraphicsRuntime) {
+func assertSVG(t *testing.T, wantFilename string, gotRT *GraphicsPlatform) {
 	t.Helper()
 	b, err := os.ReadFile(wantFilename)
 	assert.NoError(t, err)
@@ -215,8 +215,8 @@ func assertSVG(t *testing.T, wantFilename string, gotRT *GraphicsRuntime) {
 
 const testStyle = "border: 1px solid red; width: 400px; height: 400px"
 
-func newTestRuntime() *GraphicsRuntime {
-	rt := NewGraphicsRuntime()
+func newTestPlatform() *GraphicsPlatform {
+	rt := NewGraphicsPlatform()
 	rt.SVG.Style = testStyle
 	return rt
 }

--- a/pkg/cli/svg/svg.go
+++ b/pkg/cli/svg/svg.go
@@ -1,6 +1,6 @@
 //go:build !tinygo
 
-// Package svg provides an Evy runtime to generate SVG output for evy programs
+// Package svg provides an Evy platform to generate SVG output for evy programs
 // that contain graphics function calls. The SVG elements modeled in this
 // package, such as <svg>, <circle> or <g>, and their attributes, "fill"
 // or "stroke-width", are a small subset of all SVG elements and attributes.

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -25,14 +25,14 @@ type builtins struct {
 	Funcs         map[string]builtin
 	EventHandlers map[string]*parser.EventHandlerStmt
 	Globals       map[string]global
-	Runtime       Runtime
+	Platform      Platform
 }
 
 // BuiltinDecls returns the signatures of all built-in functions and
 // event handlers, as well as predefined global variables, for use by
 // the [parser.Parse] function.
 func BuiltinDecls() parser.Builtins {
-	b := newBuiltins(&UnimplementedRuntime{})
+	b := newBuiltins(&UnimplementedPlatform{})
 	return builtinsDeclsFromBuiltins(b)
 }
 
@@ -54,7 +54,7 @@ func builtinsDeclsFromBuiltins(b builtins) parser.Builtins {
 
 type builtinFunc func(scope *scope, args []value) (value, error)
 
-func newBuiltins(rt Runtime) builtins {
+func newBuiltins(rt Platform) builtins {
 	funcs := map[string]builtin{
 		"read":   {Func: readFunc(rt.Read), Decl: readDecl},
 		"cls":    {Func: clsFunc(rt.Cls), Decl: emptyDecl("cls")},
@@ -165,7 +165,7 @@ func newBuiltins(rt Runtime) builtins {
 		EventHandlers: eventHandlers,
 		Funcs:         funcs,
 		Globals:       globals,
-		Runtime:       rt,
+		Platform:      rt,
 	}
 }
 

--- a/pkg/evaluator/doc.go
+++ b/pkg/evaluator/doc.go
@@ -10,14 +10,14 @@
 // compilation step. This is a straightforward way to implement an
 // interpreter, but it trades off execution performance for simplicity.
 //
-// The [Evaluator] uses different [Runtime] implementations to target
-// different environments. For example, there is a JS/[WASM] runtime for
+// The [Evaluator] uses different [Platform] implementations to target
+// different environments. For example, there is a JS/[WASM] platform for
 // the browser, which has full support for all graphics built-in
 // functions. There is also a command line environment, which does not
 // have graphics functions support.
 //
 // The [NewEvaluator] function creates a new [Evaluator] for a given
-// [Runtime]. The evaluator can then be used by either:
+// [Platform]. The evaluator can then be used by either:
 //   - Passing an Evy program directly to the [Evaluator.Run] function.
 //   - Passing the pre-generated AST to the [Evaluator.Eval] function.
 //

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -108,10 +108,10 @@ func (e TestErrors) Error() string {
 	return strings.Join(s, "\n")
 }
 
-// NewEvaluator creates a new Evaluator for a given [Runtime]. Runtimes
-// target different environments, such as the browser or the command
-// line.
-func NewEvaluator(rt Runtime) *Evaluator {
+// NewEvaluator creates a new Evaluator for a given [Platform].
+// Platforms target different environments, such as the browser or the
+// command line.
+func NewEvaluator(rt Platform) *Evaluator {
 	builtins := newBuiltins(rt)
 	scope := newScope()
 	for _, global := range builtins.Globals {
@@ -121,7 +121,7 @@ func NewEvaluator(rt Runtime) *Evaluator {
 		builtins: builtins,
 		scope:    scope,
 		global:   scope,
-		yielder:  builtins.Runtime.Yielder(),
+		yielder:  builtins.Platform.Yielder(),
 	}
 }
 
@@ -171,19 +171,19 @@ func (e *Evaluator) Run(input string) error {
 	return e.Eval(prog)
 }
 
-// Yielder is a runtime-implemented mechanism that causes the
-// evaluation process to periodically give up control to the runtime.
-// The Yield method of the Yielder interface is called at the
-// beginning of each evaluation step. This allows the runtime to
-// handle external tasks, such as processing events. For a sample
-// implementation, see the sleepingYielder of the browser environment
-// in the pkg/wasm directory.
+// Yielder is a platform-implemented mechanism that causes the
+// evaluation process to periodically give up control to the platform.
+// The Yield method of the Yielder interface is called at the beginning
+// of each evaluation step. This allows the platform to handle external
+// tasks, such as processing events. For a sample implementation, see
+// the sleepingYielder of the browser environment in the pkg/wasm
+// directory.
 type Yielder interface {
 	Yield()
 }
 
 // Eval evaluates a [parser.Program], which is the root node of the AST.
-// The program's statements are evaluated in order. If a runtime panic
+// The program's statements are evaluated in order. If a platform panic
 // occurs, a wrapped [ErrPanic] is returned. If an internal error
 // occurs, a wrapped [ErrInternal] is returned. Evaluation is also
 // stopped if the built-in exit function is called, which results in an
@@ -191,7 +191,7 @@ type Yielder interface {
 // true, evaluation is stopped and [ErrStopped] is returned.
 func (e *Evaluator) Eval(prog *parser.Program) error {
 	_, err := e.eval(prog)
-	e.TestInfo.Report(e.builtins.Runtime.Print)
+	e.TestInfo.Report(e.builtins.Platform.Print)
 	if err != nil {
 		return err
 	}

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type testRT struct {
-	UnimplementedRuntime
+	UnimplementedPlatform
 	b bytes.Buffer
 }
 
@@ -24,7 +24,7 @@ func (*testRT) Yielder() Yielder {
 
 func run(input string) string {
 	rt := &testRT{}
-	rt.UnimplementedRuntime.print = rt.Print
+	rt.UnimplementedPlatform.print = rt.Print
 	eval := NewEvaluator(rt)
 	err := eval.Run(input)
 	if err != nil {
@@ -145,7 +145,7 @@ end
 `
 
 	rt := &testRT{}
-	rt.UnimplementedRuntime.print = rt.Print
+	rt.UnimplementedPlatform.print = rt.Print
 	eval := NewEvaluator(&testRT{})
 	err := eval.Run(prog)
 	assert.Equal(t, true, errors.Is(err, ErrVarNotSet))
@@ -515,7 +515,7 @@ func TestIndexErr(t *testing.T) {
 
 func TestEvyTest(t *testing.T) {
 	rt := &testRT{}
-	rt.UnimplementedRuntime.print = rt.Print
+	rt.UnimplementedPlatform.print = rt.Print
 	eval := NewEvaluator(rt)
 	prog := `
 test true
@@ -546,7 +546,7 @@ test [[1] [2 3]] got`,
 	for _, prog := range progs {
 		t.Run(prog, func(t *testing.T) {
 			rt := &testRT{}
-			rt.UnimplementedRuntime.print = rt.Print
+			rt.UnimplementedPlatform.print = rt.Print
 			eval := NewEvaluator(rt)
 			err := eval.Run(prog)
 			assert.NoError(t, err)
@@ -569,7 +569,7 @@ func TestFailedEvyTest(t *testing.T) {
 	for prog, want := range progs {
 		t.Run(prog, func(t *testing.T) {
 			rt := &testRT{}
-			rt.UnimplementedRuntime.print = rt.Print
+			rt.UnimplementedPlatform.print = rt.Print
 			eval := NewEvaluator(rt)
 			err := eval.Run(prog)
 			assert.Error(t, ErrTest, err)
@@ -589,7 +589,7 @@ test 1 1
 test "abc" "123" "custom message"
 	`
 	rt := &testRT{}
-	rt.UnimplementedRuntime.print = rt.Print
+	rt.UnimplementedPlatform.print = rt.Print
 	eval := NewEvaluator(rt)
 	err := eval.Run(prog)
 	assert.Error(t, ErrTest, err)
@@ -627,7 +627,7 @@ test 1 1
 test "abc" "123" "custom message"
 	`
 	rt := &testRT{}
-	rt.UnimplementedRuntime.print = rt.Print
+	rt.UnimplementedPlatform.print = rt.Print
 	eval := NewEvaluator(rt)
 	eval.TestInfo.NoTestSummary = true
 	err := eval.Run(prog)
@@ -2182,7 +2182,7 @@ func TestNestedTypeof(t *testing.T) {
 			in += "\n print (typeof a)"
 			var got string
 			rt := &testRT{}
-			rt.UnimplementedRuntime.print = rt.Print
+			rt.UnimplementedPlatform.print = rt.Print
 			eval := NewEvaluator(rt)
 			err := eval.Run(in)
 			if err != nil {

--- a/pkg/evaluator/runtime.go
+++ b/pkg/evaluator/runtime.go
@@ -5,19 +5,19 @@ import (
 	"time"
 )
 
-// The Runtime interface must be implemented by an environment in order
-// to execute Evy source code and Evy builtins. To create a new runtime
-// implementation, you can embed [UnimplementedRuntime] and override
-// the methods that your runtime can provide. For example, there is a
-// jsRuntime implementation for the browser, which has full support for
+// The Platform interface must be implemented by an environment in order
+// to execute Evy source code and Evy builtins. To create a new platform
+// implementation, you can embed [UnimplementedPlatform] and override
+// the methods that your platform can provide. For example, there is a
+// jsPlatform implementation for the browser, which has full support for
 // all graphics built-in functions. There is also a command-line
 // environment implementation, which does not have graphics function
 // support. For more details on the built-in functions, see the
 // [built-ins documentation].
 //
 // [built-ins documentation]: https://github.com/evylang/evy/blob/main/docs/builtins.md
-type Runtime interface {
-	GraphicsRuntime
+type Platform interface {
+	GraphicsPlatform
 	Print(string)
 	Read() string
 	Cls()
@@ -25,12 +25,12 @@ type Runtime interface {
 	Yielder() Yielder
 }
 
-// The GraphicsRuntime interface contains all methods that are required
+// The GraphicsPlatform interface contains all methods that are required
 // by the graphics built-ins. For more details see the
 // [graphics built-ins] documentation.
 //
 // [graphics built-ins]: https://github.com/evylang/evy/blob/main/docs/builtins.md#graphics
-type GraphicsRuntime interface {
+type GraphicsPlatform interface {
 	Move(x, y float64)
 	Line(x, y float64)
 	Rect(dx, dy float64)
@@ -64,13 +64,13 @@ type GraphicsRuntime interface {
 	Gridn(unit float64, color string)
 }
 
-// UnimplementedRuntime implements Runtime with no-ops and prints a "<func> not implemented" message.
-type UnimplementedRuntime struct {
+// UnimplementedPlatform implements Platform with no-ops and prints a "<func> not implemented" message.
+type UnimplementedPlatform struct {
 	print func(string)
 }
 
 // Print prints to os.Stdout.
-func (rt *UnimplementedRuntime) Print(s string) {
+func (rt *UnimplementedPlatform) Print(s string) {
 	if rt.print != nil {
 		rt.print(s)
 	} else {
@@ -78,68 +78,68 @@ func (rt *UnimplementedRuntime) Print(s string) {
 	}
 }
 
-func (rt *UnimplementedRuntime) unimplemented(s string) {
+func (rt *UnimplementedPlatform) unimplemented(s string) {
 	rt.Print(fmt.Sprintf("%q not implemented\n", s))
 }
 
 // Cls is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Cls() { rt.unimplemented("cls") }
+func (rt *UnimplementedPlatform) Cls() { rt.unimplemented("cls") }
 
 // Read is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Read() string { rt.unimplemented("read"); return "" }
+func (rt *UnimplementedPlatform) Read() string { rt.unimplemented("read"); return "" }
 
 // Sleep is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Sleep(time.Duration) { rt.unimplemented("sleep") }
+func (rt *UnimplementedPlatform) Sleep(time.Duration) { rt.unimplemented("sleep") }
 
 // Yielder is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Yielder() Yielder { rt.unimplemented("yielder"); return nil }
+func (rt *UnimplementedPlatform) Yielder() Yielder { rt.unimplemented("yielder"); return nil }
 
 // Move is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Move(float64, float64) { rt.unimplemented("move") }
+func (rt *UnimplementedPlatform) Move(float64, float64) { rt.unimplemented("move") }
 
 // Line is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Line(float64, float64) { rt.unimplemented("line") }
+func (rt *UnimplementedPlatform) Line(float64, float64) { rt.unimplemented("line") }
 
 // Rect is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Rect(float64, float64) { rt.unimplemented("rect") }
+func (rt *UnimplementedPlatform) Rect(float64, float64) { rt.unimplemented("rect") }
 
 // Circle is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Circle(float64) { rt.unimplemented("circle") }
+func (rt *UnimplementedPlatform) Circle(float64) { rt.unimplemented("circle") }
 
 // Width is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Width(float64) { rt.unimplemented("width") }
+func (rt *UnimplementedPlatform) Width(float64) { rt.unimplemented("width") }
 
 // Color is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Color(string) { rt.unimplemented("color") }
+func (rt *UnimplementedPlatform) Color(string) { rt.unimplemented("color") }
 
 // Clear is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Clear(string) { rt.unimplemented("clear") }
+func (rt *UnimplementedPlatform) Clear(string) { rt.unimplemented("clear") }
 
 // Gridn is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Gridn(float64, string) { rt.unimplemented("gridn") }
+func (rt *UnimplementedPlatform) Gridn(float64, string) { rt.unimplemented("gridn") }
 
 // Poly is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Poly([][]float64) { rt.unimplemented("poly") }
+func (rt *UnimplementedPlatform) Poly([][]float64) { rt.unimplemented("poly") }
 
 // Stroke is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Stroke(string) { rt.unimplemented("stroke") }
+func (rt *UnimplementedPlatform) Stroke(string) { rt.unimplemented("stroke") }
 
 // Fill is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Fill(string) { rt.unimplemented("fill") }
+func (rt *UnimplementedPlatform) Fill(string) { rt.unimplemented("fill") }
 
 // Dash is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Dash([]float64) { rt.unimplemented("dash") }
+func (rt *UnimplementedPlatform) Dash([]float64) { rt.unimplemented("dash") }
 
 // Linecap is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Linecap(string) { rt.unimplemented("linecap") }
+func (rt *UnimplementedPlatform) Linecap(string) { rt.unimplemented("linecap") }
 
 // Text is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Text(string) { rt.unimplemented("text") }
+func (rt *UnimplementedPlatform) Text(string) { rt.unimplemented("text") }
 
 // Font is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Font(map[string]any) { rt.unimplemented("font") }
+func (rt *UnimplementedPlatform) Font(map[string]any) { rt.unimplemented("font") }
 
 // Ellipse is a no-op that prints an "unimplemented" message.
-func (rt *UnimplementedRuntime) Ellipse(float64, float64, float64, float64, float64, float64, float64) {
+func (rt *UnimplementedPlatform) Ellipse(float64, float64, float64, float64, float64, float64, float64) {
 	rt.unimplemented("ellipse")
 }

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -4,8 +4,8 @@ package main
 
 // This file contains JS functions imported into Go/WASM. Functions are
 // declared without body, the full definition can be found in the JS
-// implementation. The `jsRuntime` struct wraps these functions to
-// implement evaluator.Runtime.
+// implementation. The `jsPlatform` struct wraps these functions to
+// implement evaluator.Platform.
 
 import (
 	"fmt"
@@ -17,39 +17,39 @@ import (
 
 const minSleepDur = time.Millisecond
 
-// jsRuntime implements evaluator.Runtime.
-type jsRuntime struct {
+// jsPlatform implements evaluator.Platform.
+type jsPlatform struct {
 	yielder *sleepingYielder
 }
 
-func newJSRuntime() *jsRuntime {
-	return &jsRuntime{yielder: newSleepingYielder()}
+func newJSPlatform() *jsPlatform {
+	return &jsPlatform{yielder: newSleepingYielder()}
 }
 
-func (rt *jsRuntime) Yielder() evaluator.Yielder { return rt.yielder }
-func (rt *jsRuntime) Print(s string)             { jsPrint(s) }
-func (rt *jsRuntime) Cls()                       { jsCls() }
-func (rt *jsRuntime) Read() string               { return rt.yielder.Read() }
+func (rt *jsPlatform) Yielder() evaluator.Yielder { return rt.yielder }
+func (rt *jsPlatform) Print(s string)             { jsPrint(s) }
+func (rt *jsPlatform) Cls()                       { jsCls() }
+func (rt *jsPlatform) Read() string               { return rt.yielder.Read() }
 
-func (rt *jsRuntime) Sleep(dur time.Duration) {
+func (rt *jsPlatform) Sleep(dur time.Duration) {
 	// Enforce a lower bound to stop browser tabs from freezing.
 	rt.yielder.Sleep(max(minSleepDur, dur))
 }
 
-func (rt *jsRuntime) Move(x, y float64)                { move(x, y) }
-func (rt *jsRuntime) Line(x, y float64)                { line(x, y) }
-func (rt *jsRuntime) Rect(x, y float64)                { rect(x, y) }
-func (rt *jsRuntime) Circle(r float64)                 { circle(r) }
-func (rt *jsRuntime) Width(w float64)                  { width(w) }
-func (rt *jsRuntime) Color(s string)                   { color(s) }
-func (rt *jsRuntime) Clear(color string)               { clear(color) }
-func (rt *jsRuntime) Gridn(unit float64, color string) { gridn(unit, color) }
-func (rt *jsRuntime) Stroke(s string)                  { stroke(s) }
-func (rt *jsRuntime) Fill(s string)                    { fill(s) }
-func (rt *jsRuntime) Dash(segments []float64)          { dash(floatsToString(segments)) }
-func (rt *jsRuntime) Linecap(s string)                 { linecap(s) }
-func (rt *jsRuntime) Text(s string)                    { text(s) }
-func (rt *jsRuntime) Font(props map[string]any) {
+func (rt *jsPlatform) Move(x, y float64)                { move(x, y) }
+func (rt *jsPlatform) Line(x, y float64)                { line(x, y) }
+func (rt *jsPlatform) Rect(x, y float64)                { rect(x, y) }
+func (rt *jsPlatform) Circle(r float64)                 { circle(r) }
+func (rt *jsPlatform) Width(w float64)                  { width(w) }
+func (rt *jsPlatform) Color(s string)                   { color(s) }
+func (rt *jsPlatform) Clear(color string)               { clear(color) }
+func (rt *jsPlatform) Gridn(unit float64, color string) { gridn(unit, color) }
+func (rt *jsPlatform) Stroke(s string)                  { stroke(s) }
+func (rt *jsPlatform) Fill(s string)                    { fill(s) }
+func (rt *jsPlatform) Dash(segments []float64)          { dash(floatsToString(segments)) }
+func (rt *jsPlatform) Linecap(s string)                 { linecap(s) }
+func (rt *jsPlatform) Text(s string)                    { text(s) }
+func (rt *jsPlatform) Font(props map[string]any) {
 	// We don't use encoding/json here as it adds more than 100K to evy.wasm.
 	pairs := make([]string, 0, len(props))
 	for key, value := range props {
@@ -64,7 +64,7 @@ func (rt *jsRuntime) Font(props map[string]any) {
 	font(jsonProps)
 }
 
-func (rt *jsRuntime) Poly(vertices [][]float64) {
+func (rt *jsPlatform) Poly(vertices [][]float64) {
 	vStrings := make([]string, len(vertices))
 	for i, vertex := range vertices {
 		vStrings[i] = fmt.Sprintf("%f %f", vertex[0], vertex[1])
@@ -72,7 +72,7 @@ func (rt *jsRuntime) Poly(vertices [][]float64) {
 	poly(strings.Join(vStrings, " "))
 }
 
-func (rt *jsRuntime) Ellipse(x, y, rX, rY, rotation, startAngle, endAngle float64) {
+func (rt *jsPlatform) Ellipse(x, y, rX, rY, rotation, startAngle, endAngle float64) {
 	ellipse(x, y, rX, rY, rotation, startAngle, endAngle)
 }
 

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -41,7 +41,7 @@ func main() {
 		prepareUI(ast)
 	}
 	if actions["eval"] {
-		rt := newJSRuntime()
+		rt := newJSPlatform()
 		err := evaluate(ast, rt)
 		if err == nil || errors.Is(err, evaluator.ErrStopped) {
 			return
@@ -94,7 +94,7 @@ func prepareUI(prog *parser.Program) {
 	jsPrepareUI(strings.Join(names, ","))
 }
 
-func evaluate(prog *parser.Program, rt *jsRuntime) error {
+func evaluate(prog *parser.Program, rt *jsPlatform) error {
 	eval = evaluator.NewEvaluator(rt)
 	if err := eval.Eval(prog); err != nil {
 		return err


### PR DESCRIPTION
Rename uses of "runtime" where it refers to the CLI runtime and the browser
runtime to "platform". Runtime usually refers to the thing doing the
running, such as the evaluator or bytecode VM and has started to cause a
little confusion or cumbersome language now that the bytecode VM is being
developed. Initial talk of perhaps targeting micro-controllers as
"platforms" also suggests this should be called platform.

There are still a few uses of the word "runtime" left - these refer to 
things like "runtime errors" where the term still makes sense, as it does
not refer to the Evy abstraction for runtime/platform.

Fix a lint error in `learn/pkg/learn/markdown.go` since golangci-lint wants
to complain about this now.