### PR TITLE
parser: Implement for niladic function calls without parens

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -696,7 +696,7 @@ func randFunc(_ *scope, args []value) (value, error) {
 }
 
 var rand1Decl = &parser.FuncDefStmt{
-	Name:       "rand",
+	Name:       "rand1",
 	Params:     []*parser.Var{},
 	ReturnType: parser.NUM_TYPE,
 }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -142,6 +142,10 @@ func (f *FuncDefStmt) Type() *Type {
 	return f.ReturnType
 }
 
+func (f *FuncDefStmt) isNiladic() bool {
+	return len(f.Params) == 0 && f.VariadicParam == nil
+}
+
 // EventHandlerStmt is an AST node that represents an event handler
 // definition. It includes the handler body, such as:
 //

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -73,6 +73,10 @@ func TestParseTopLevelExpression(t *testing.T) {
 		`print s[1]`:                  "print(any((s[1])))",
 		"print map2[s]":               "print(any((map2[s])))",
 
+		// niladic
+		`print rand1`:       "print(any(rand1()))",
+		`print rand1 rand1`: "print(any(rand1()), any(rand1()))",
+
 		// // Index expression
 		"arr[1]":        "(arr[1])",
 		"arr2[1][2]":    "((arr2[1])[2])",
@@ -298,5 +302,77 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		assertParseError(t, parser, input)
 		got := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, got.Error(), "input: %s\nerrors:\n%s", input, parser.errors)
+	}
+}
+
+func TestParseNiladic(t *testing.T) {
+	inputs := map[string]string{
+		"rand1":       "print rand1",
+		"rand1-twice": "print rand1 rand1",
+		"rand1-expr":  "print rand1+10",
+		"rand1-toplevelexpr": `
+n := rand1+0.5
+print n
+`,
+		"rand1-toplevelexpr-space": `
+if rand1 > 0.5
+	print "big"
+end
+`,
+		"custom1": `
+func answer:string
+	return "42"
+end
+
+print answer`,
+	}
+
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			parser := newParser(input, testBuiltins())
+			_ = parser.parse()
+			assertNoParseError(t, parser, input)
+		})
+	}
+}
+
+func TestParseNiladicErr(t *testing.T) {
+	type inputWithError struct {
+		input      string
+		wantErrMsg string
+	}
+	inputs := map[string]inputWithError{
+		"rand1-group": {
+			input:      "print (rand1 100)",
+			wantErrMsg: `line 1 column 14: expected ")", got ""`,
+		},
+		"custom1": {
+			input: `
+func answer
+	print "42"
+end
+
+len answer`,
+			wantErrMsg: `line 6 column 5: "len" takes 1st argument of type any, found none`,
+		},
+		"custom1-variadic": {
+			input: `
+func answer
+	print "42"
+end
+
+print answer`,
+			wantErrMsg: `line 6 column 7: "print" takes variadic arguments of type any, found none`,
+		},
+	}
+
+	for name, tc := range inputs {
+		t.Run(name, func(t *testing.T) {
+			parser := newParser(tc.input, testBuiltins())
+			_ = parser.parse()
+			assertParseError(t, parser, tc.input)
+			gotErr := parser.errors.Truncate(1)
+			assert.Equal(t, tc.wantErrMsg, gotErr.Error())
+		})
 	}
 }

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -353,7 +353,7 @@ func answer
 end
 
 len answer`,
-			wantErrMsg: `line 6 column 5: "len" takes 1st argument of type any, found none`,
+			wantErrMsg: `line 6 column 5: cannot use "answer" as 1st argument, it has no return value`,
 		},
 		"custom1-variadic": {
 			input: `
@@ -362,7 +362,7 @@ func answer
 end
 
 print answer`,
-			wantErrMsg: `line 6 column 7: "print" takes variadic arguments of type any, found none`,
+			wantErrMsg: `line 6 column 7: cannot use "answer" as argument, it has no return value`,
 		},
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -564,7 +564,7 @@ func (p *parser) isFuncCall(tok *lexer.Token) bool {
 }
 
 func (p *parser) parseFunCallStatement() Node {
-	fc := p.parseFuncCall().(*FuncCall)
+	fc := p.parseFuncCall(true).(*FuncCall) // top-level funcCall
 	p.assertEOL()
 	fcs := &FuncCallStmt{token: fc.token, FuncCall: fc}
 	p.recordComment(fcs)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -581,6 +581,9 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 			argType := arg.Type()
 			if !paramType.accepts(argType) {
 				msg := fmt.Sprintf("%q takes variadic arguments of type %s, found %s", funcName, paramType, argType)
+				if fc, ok := arg.(*FuncCall); ok && argType == NONE_TYPE {
+					msg = fmt.Sprintf("cannot use %q as argument, it has no return value", fc.FuncDef.Name)
+				}
 				p.appendErrorForToken(msg, arg.Token())
 			} else {
 				args[i] = wrapAny(arg, paramType)
@@ -602,6 +605,9 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 		argType := arg.Type()
 		if !paramType.accepts(argType) {
 			msg := fmt.Sprintf("%q takes %s argument of type %s, found %s", funcName, ordinalize(i+1), paramType, argType)
+			if fc, ok := arg.(*FuncCall); ok && argType == NONE_TYPE {
+				msg = fmt.Sprintf("cannot use %q as %s argument, it has no return value", fc.FuncDef.Name, ordinalize(i+1))
+			}
 			p.appendErrorForToken(msg, arg.Token())
 		} else {
 			args[i] = wrapAny(arg, paramType)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1785,6 +1785,11 @@ func testBuiltins() Builtins {
 			},
 			ReturnType: STRING_TYPE,
 		},
+		"rand1": {
+			Name:       "rand1",
+			Params:     []*Var{},
+			ReturnType: NUM_TYPE,
+		},
 	}
 	eventHandlers := map[string]*EventHandlerStmt{
 		"down": {


### PR DESCRIPTION
Implement niladic function calls without parens, so that the following Evy
code is now valid:

   if rand1 > 0.5
    print "Heads"
end

   print read

    print rand1 rand1+10

which reads better than `if (rand1) > 0.5` etc.

Along the way fix typo in name of builtin `"rand1"` (name is used in error
messages only). Improve error message where a function is called and expected
to have a return value.