### PR TITLE
play: Fix dash reset issues

### DIFF
--- a/frontend/play/index.js
+++ b/frontend/play/index.js
@@ -870,7 +870,7 @@ function fill(ptr, len) {
 // dash is exported to evy go/wasm.
 function dash(ptr, len) {
   const s = memToString(ptr, len)
-  const nums = s.split(" ").map(Number).map(transformX)
+  const nums = s === "" ? [] : s.split(" ").map(Number).map(transformX)
   canvas.ctx.setLineDash(nums)
 }
 


### PR DESCRIPTION
Fix dash reset issues with an explicit check for `dash`. Previously it resulted
in the incorrect:

	canvas.ctx.setLineDash([0])

Now it results in the correct:

	canvas.ctx.setLineDash([])

---

See https://evy-lang-stage-play--466-09qkylmw.web.app/#source=https://gist.githubusercontent.com/juliaogris/628d08c39d2710b04ce2fe0b17e7827f/raw/newton.evy